### PR TITLE
Fix for PHP Fatal error:  Function name must be a string in /var/www/…

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -3322,7 +3322,7 @@ function start_delivery_chain($channel, $item, $item_id, $parent) {
 		dbesc($title),
 		dbesc($body),
 		intval($item_wall),
-		$intval($item_origin),
+		intval($item_origin),
 		intval($item_id)
 	);
 


### PR DESCRIPTION
…hubzilla/include/items.php on line 3325

Please review if this is correct?