### PR TITLE
Updated Help pages to include Hubzilla on OpenShift

### DIFF
--- a/.openshift/README.md
+++ b/.openshift/README.md
@@ -9,7 +9,7 @@ rhc app-create your_app_name php-5.4 mysql-5.5 cron phpmyadmin --namespace your_
 
 Make a note of the database username and password OpenShift creates for your instance, and use these at https://your_app_name-your_domain.rhcloud.com/ to complete the setup.
 
-NOTE: PostgreSQL is NOT support yet.
+NOTE: PostgreSQL is NOT supported by the deploy script yet.
 
 Update
 To update, consider your own workflow first. I have forked Hubzilla code into my GitHub account to be able to try things out, this remote repo is called origin. Here is how I fetch new code from upstream, merge into my local repo, then push the updated code both into origin and the remote repo called openshift.
@@ -26,7 +26,7 @@ Symptoms of need for MySQL database administration are:
 
 ###How to fix crashed tables in MySQL
 Using MySQL and the MyISAM database engine can result in table indexes coming out of sync, and you have at least two options for fixing tables marked as crashed.
-- Use the database username and password OpenShift creates for your instance at #^https://your_app_name-your_domain.rhcloud.com/phpmyadmin/ to login via the web into your phpMyAdmin web interface, click your database in the left column, in the right column scroll down to the bottom of the list of tables and click the checkbox for marking all tables, then select Check tables from the drop down menu. This will check the tables for problems, and you can then checkmark only those tables with problems, and select Repair table from the same drop down menu at the bottom.
+- Use the database username and password OpenShift creates for your instance at https://your_app_name-your_domain.rhcloud.com/phpmyadmin/ to login via the web into your phpMyAdmin web interface, click your database in the left column, in the right column scroll down to the bottom of the list of tables and click the checkbox for marking all tables, then select Check tables from the drop down menu. This will check the tables for problems, and you can then checkmark only those tables with problems, and select Repair table from the same drop down menu at the bottom.
 - You can login to your instance with SSH - see OpenShift for details - then
 
 ```

--- a/.openshift/README.md
+++ b/.openshift/README.md
@@ -24,6 +24,14 @@ Symptoms of need for MySQL database administration are:
 - you can login, but your channel posts are not visible. This can mean your item table is marked as crashed.
 - you can login and you can see your channel posts, but apparently nobody is getting your posts, comments, likes and so on. This can mean your outq table is marked as crashed.
 
+You can check your OpenShift logs by doing
+
+```
+rhc tail -a your_app_name -n your_domain -l your@email.address -p your_account_password 
+```
+
+and you might be able to confirm the above suspicions about crashed tables, or other problems you need to fix. 
+
 ###How to fix crashed tables in MySQL
 Using MySQL and the MyISAM database engine can result in table indexes coming out of sync, and you have at least two options for fixing tables marked as crashed.
 - Use the database username and password OpenShift creates for your instance at https://your_app_name-your_domain.rhcloud.com/phpmyadmin/ to login via the web into your phpMyAdmin web interface, click your database in the left column, in the right column scroll down to the bottom of the list of tables and click the checkbox for marking all tables, then select Check tables from the drop down menu. This will check the tables for problems, and you can then checkmark only those tables with problems, and select Repair table from the same drop down menu at the bottom.

--- a/doc/Hubzilla_on_OpenShift.bb
+++ b/doc/Hubzilla_on_OpenShift.bb
@@ -8,7 +8,7 @@ Create an account on OpenShift, then use the registration e-mail and password to
 
 Make a note of the database username and password OpenShift creates for your instance, and use these at [url=https://your_app_name-your_domain.rhcloud.com/]https://your_app_name-your_domain.rhcloud.com/[/url] to complete the setup.
 
-NOTE: PostgreSQL is NOT support yet, see [zrl=https://zot-mor.rhcloud.com/display/3c7035f2a6febf87057d84ea0ae511223e9b38dc27913177bc0df053edecac7c@zot-mor.rhcloud.com?zid=haakon%40zot-mor.rhcloud.com]this thread[/zrl].
+NOTE: PostgreSQL is NOT supported yet, see [zrl=https://zot-mor.rhcloud.com/display/3c7035f2a6febf87057d84ea0ae511223e9b38dc27913177bc0df053edecac7c@zot-mor.rhcloud.com?zid=haakon%40zot-mor.rhcloud.com]this thread[/zrl].
 
 [b]Update[/b]
 To update, consider your own workflow first. I have forked Hubzilla code into my GitHub account to be able to try things out, this remote repo is called origin. Here is how I fetch new code from upstream, merge into my local repo, then push the updated code both into origin and the remote repo called openshift.

--- a/doc/Hubzilla_on_OpenShift.bb
+++ b/doc/Hubzilla_on_OpenShift.bb
@@ -1,12 +1,12 @@
 [b]Hubzilla on OpenShift[/b]
-You will notice a new .openshift folder when you fetch from upstream, i.e. from #^[url=https://github.com/redmatrix/hubzilla.git]https://github.com/redmatrix/hubzilla.git[/url] , which contains a deploy script to set up Hubzilla on OpenShift.
+You will notice a new .openshift folder when you fetch from upstream, i.e. from [url=https://github.com/redmatrix/hubzilla.git]https://github.com/redmatrix/hubzilla.git[/url] , which contains a deploy script to set up Hubzilla on OpenShift.
 
 Create an account on OpenShift, then use the registration e-mail and password to create your first Hubzilla instance. Install git and RedHat's command line tools - rhc - if you have not already done so.
 
 [code]rhc app-create your_app_name php-5.4 mysql-5.5 cron phpmyadmin --namespace your_domain --from-code https://github.com/redmatrix/hubzilla.git -l your@email.address -p your_account_password
 [/code]
 
-Make a note of the database username and password OpenShift creates for your instance, and use these at #^[url=https://your_app_name-your_domain.rhcloud.com/]https://your_app_name-your_domain.rhcloud.com/[/url] to complete the setup.
+Make a note of the database username and password OpenShift creates for your instance, and use these at [url=https://your_app_name-your_domain.rhcloud.com/]https://your_app_name-your_domain.rhcloud.com/[/url] to complete the setup.
 
 NOTE: PostgreSQL is NOT support yet, see [zrl=https://zot-mor.rhcloud.com/display/3c7035f2a6febf87057d84ea0ae511223e9b38dc27913177bc0df053edecac7c@zot-mor.rhcloud.com?zid=haakon%40zot-mor.rhcloud.com]this thread[/zrl].
 
@@ -27,7 +27,7 @@ Symptoms of need for MySQL database administration are:
 [b]How to fix crashed tables in MySQL[/b]
 Using MySQL and the MyISAM database engine can result in table indexes coming out of sync, and you have at least two options for fixing tables marked as crashed.
 [list]
-[*] Use the database username and password OpenShift creates for your instance at #^[url=https://your_app_name-your_domain.rhcloud.com/phpmyadmin/]https://your_app_name-your_domain.rhcloud.com/phpmyadmin/[/url] to login via the web into your phpMyAdmin web interface, click your database in the left column, in the right column scroll down to the bottom of the list of tables and click the checkbox for marking all tables, then select Check tables from the drop down menu. This will check the tables for problems, and you can then checkmark only those tables with problems, and select Repair table from the same drop down menu at the bottom.
+[*] Use the database username and password OpenShift creates for your instance at [url=https://your_app_name-your_domain.rhcloud.com/phpmyadmin/]https://your_app_name-your_domain.rhcloud.com/phpmyadmin/[/url] to login via the web into your phpMyAdmin web interface, click your database in the left column, in the right column scroll down to the bottom of the list of tables and click the checkbox for marking all tables, then select Check tables from the drop down menu. This will check the tables for problems, and you can then checkmark only those tables with problems, and select Repair table from the same drop down menu at the bottom.
 [*] You can login to your instance with SSH - see OpenShift for details - then
 
 [code]cd mysql/data/your_database
@@ -64,7 +64,9 @@ and hopefully your database tables are now okay.
 [/list]
 
 [b]Notes[/b]
-Note 1: definitely DO turn off feeds and discovery by default if you are on the Free or Bronze plan on OpenShift with a single 1Gb gear by visiting [observer.baseurl]admin/site when logged in as administrator of your Hubzilla site. 
-Note 2: DO add the above defaults into the deploy script.
-Note 3: DO add git gc to the deploy script
-Note 4: MAYBE DO add myisamchk - only checking? to the end of the deploy script.
+[list]
+[*] definitely DO turn off feeds and discovery by default if you are on the Free or Bronze plan on OpenShift with a single 1Gb gear by visiting [observer.baseurl]admin/site when logged in as administrator of your Hubzilla site. 
+[*] DO add the above defaults into the deploy script.
+[*] DO add git gc to the deploy script
+[*] MAYBE DO add myisamchk - only checking? to the end of the deploy script.
+[/list]

--- a/doc/Hubzilla_on_OpenShift.bb
+++ b/doc/Hubzilla_on_OpenShift.bb
@@ -1,0 +1,70 @@
+[b]Hubzilla on OpenShift[/b]
+You will notice a new .openshift folder when you fetch from upstream, i.e. from #^[url=https://github.com/redmatrix/hubzilla.git]https://github.com/redmatrix/hubzilla.git[/url] , which contains a deploy script to set up Hubzilla on OpenShift.
+
+Create an account on OpenShift, then use the registration e-mail and password to create your first Hubzilla instance. Install git and RedHat's command line tools - rhc - if you have not already done so.
+
+[code]rhc app-create your_app_name php-5.4 mysql-5.5 cron phpmyadmin --namespace your_domain --from-code https://github.com/redmatrix/hubzilla.git -l your@email.address -p your_account_password
+[/code]
+
+Make a note of the database username and password OpenShift creates for your instance, and use these at #^[url=https://your_app_name-your_domain.rhcloud.com/]https://your_app_name-your_domain.rhcloud.com/[/url] to complete the setup.
+
+NOTE: PostgreSQL is NOT support yet, see [zrl=https://zot-mor.rhcloud.com/display/3c7035f2a6febf87057d84ea0ae511223e9b38dc27913177bc0df053edecac7c@zot-mor.rhcloud.com?zid=haakon%40zot-mor.rhcloud.com]this thread[/zrl].
+
+[b]Update[/b]
+To update, consider your own workflow first. I have forked Hubzilla code into my GitHub account to be able to try things out, this remote repo is called origin. Here is how I fetch new code from upstream, merge into my local repo, then push the updated code both into origin and the remote repo called openshift.
+
+[code]git fetch upstream;git checkout master;git merge upstream/master;git push origin;git push openshift HEAD
+[/code]
+
+[b]Administration[/b]
+Symptoms of need for MySQL database administration are:
+[list]
+[*] you can visit your domain and see the Hubzilla frontpage, but trying to login throws you back to login. This can mean your session table is marked as crashed.
+[*] you can login, but your channel posts are not visible. This can mean your item table is marked as crashed.
+[*] you can login and you can see your channel posts, but apparently nobody is getting your posts, comments, likes and so on. This can mean your outq table is marked as crashed.
+[/list]
+
+[b]How to fix crashed tables in MySQL[/b]
+Using MySQL and the MyISAM database engine can result in table indexes coming out of sync, and you have at least two options for fixing tables marked as crashed.
+[list]
+[*] Use the database username and password OpenShift creates for your instance at #^[url=https://your_app_name-your_domain.rhcloud.com/phpmyadmin/]https://your_app_name-your_domain.rhcloud.com/phpmyadmin/[/url] to login via the web into your phpMyAdmin web interface, click your database in the left column, in the right column scroll down to the bottom of the list of tables and click the checkbox for marking all tables, then select Check tables from the drop down menu. This will check the tables for problems, and you can then checkmark only those tables with problems, and select Repair table from the same drop down menu at the bottom.
+[*] You can login to your instance with SSH - see OpenShift for details - then
+
+[code]cd mysql/data/your_database
+myisamchk -r *.MYI[/code]
+
+or if you get
+
+[code]Can't create new tempfile[/code]
+
+check your OpenShift's gear quota with
+
+[code]quota -gus[/code]
+
+and if you are short on space, then locally (not SSH) do
+
+[code]rhc app-tidy your_app_name -l your_login -p your_password[/code]
+
+to have rhc delete temporary files and OpenShift logs to free space first, then check the size of your local repo dir and execute
+
+[code]git gc[/code]
+
+against it and check the size again, and then to minimize your remote repo connect via SSH to your application gear and execute the same command against it by changing to the remote repo directory - your repo should be in
+
+[code]~/git/your_app_name.git[/code]
+
+(if not, do find -size +1M to find it), then do
+
+[code]
+cd
+cd mysql/data/yourdatabase
+myisamchk -r -v -f*.MYI[/code]
+
+and hopefully your database tables are now okay.
+[/list]
+
+[b]Notes[/b]
+Note 1: definitely DO turn off feeds and discovery by default if you are on the Free or Bronze plan on OpenShift with a single 1Gb gear by visiting [observer.baseurl]admin/site when logged in as administrator of your Hubzilla site. 
+Note 2: DO add the above defaults into the deploy script.
+Note 3: DO add git gc to the deploy script
+Note 4: MAYBE DO add myisamchk - only checking? to the end of the deploy script.

--- a/doc/Hubzilla_on_OpenShift.bb
+++ b/doc/Hubzilla_on_OpenShift.bb
@@ -8,7 +8,7 @@ Create an account on OpenShift, then use the registration e-mail and password to
 
 Make a note of the database username and password OpenShift creates for your instance, and use these at [url=https://your_app_name-your_domain.rhcloud.com/]https://your_app_name-your_domain.rhcloud.com/[/url] to complete the setup.
 
-NOTE: PostgreSQL is NOT supported yet, see [zrl=https://zot-mor.rhcloud.com/display/3c7035f2a6febf87057d84ea0ae511223e9b38dc27913177bc0df053edecac7c@zot-mor.rhcloud.com?zid=haakon%40zot-mor.rhcloud.com]this thread[/zrl].
+NOTE: PostgreSQL is NOT supported by the deploy script yet, see [zrl=https://zot-mor.rhcloud.com/display/3c7035f2a6febf87057d84ea0ae511223e9b38dc27913177bc0df053edecac7c@zot-mor.rhcloud.com?zid=haakon%40zot-mor.rhcloud.com]this thread[/zrl].
 
 [b]Update[/b]
 To update, consider your own workflow first. I have forked Hubzilla code into my GitHub account to be able to try things out, this remote repo is called origin. Here is how I fetch new code from upstream, merge into my local repo, then push the updated code both into origin and the remote repo called openshift.

--- a/doc/Hubzilla_on_OpenShift.bb
+++ b/doc/Hubzilla_on_OpenShift.bb
@@ -69,4 +69,5 @@ and hopefully your database tables are now okay.
 [*] DO add the above defaults into the deploy script.
 [*] DO add git gc to the deploy script
 [*] MAYBE DO add myisamchk - only checking? to the end of the deploy script.
+[*] mysqlcheck is similar in function to myisamchk, but works differently. The main operational difference is that mysqlcheck must be used when the mysqld server is running, whereas myisamchk should be used when it is not. The benefit of using mysqlcheck is that you do not have to stop the server to perform table maintenance - this means this documenation should be fixed.  
 [/list]

--- a/doc/Hubzilla_on_OpenShift.bb
+++ b/doc/Hubzilla_on_OpenShift.bb
@@ -24,6 +24,14 @@ Symptoms of need for MySQL database administration are:
 [*] you can login and you can see your channel posts, but apparently nobody is getting your posts, comments, likes and so on. This can mean your outq table is marked as crashed.
 [/list]
 
+You can check your OpenShift logs by doing
+
+[code]
+rhc tail -a your_app_name -n your_domain -l your@email.address -p your_account_password
+[/code]
+
+and you might be able to confirm the above suspicions about crashed tables, or other problems you need to fix.
+
 [b]How to fix crashed tables in MySQL[/b]
 Using MySQL and the MyISAM database engine can result in table indexes coming out of sync, and you have at least two options for fixing tables marked as crashed.
 [list]

--- a/doc/admins.bb
+++ b/doc/admins.bb
@@ -4,7 +4,7 @@
 
 [zrl=[baseurl]/help/install]Install[/zrl]
 [zrl=[baseurl]/help/red2pi]Installing $Projectname on the Raspberry Pi[/zrl]
-[zrl=[baseurl]/help/Hubzilla_on_OpenShift]Hubzilla on OpenShift[/zrl]
+[zrl=[baseurl]/help/Hubzilla_on_OpenShift]$Projectname on OpenShift[/zrl]
 [zrl=[baseurl]/help/troubleshooting]Troubleshooting Tips[/zrl]
 [zrl=[baseurl]/help/hidden_configs]Tweaking $Projectname's Hidden Configurations[/zrl]
 [zrl=[baseurl]/help/faq_admins]FAQ For Admins[/zrl]

--- a/doc/admins.bb
+++ b/doc/admins.bb
@@ -4,6 +4,7 @@
 
 [zrl=[baseurl]/help/install]Install[/zrl]
 [zrl=[baseurl]/help/red2pi]Installing $Projectname on the Raspberry Pi[/zrl]
+[zrl=[baseurl]/help/Hubzilla_on_OpenShift]Hubzilla on OpenShift[/zrl]
 [zrl=[baseurl]/help/troubleshooting]Troubleshooting Tips[/zrl]
 [zrl=[baseurl]/help/hidden_configs]Tweaking $Projectname's Hidden Configurations[/zrl]
 [zrl=[baseurl]/help/faq_admins]FAQ For Admins[/zrl]


### PR DESCRIPTION
Updated admin.bb with a link to new help page Hubzilla_on_OpenShift.bb and fixed some types in .openshift/README.md

Note: after submitting this pull request, I noticed had forgotten to describe myisamchk should be used with mysqld stopped, whilst mysqlcheck needs mysqld running to do checks and repairs, and I have added a short note about this at the bottom of the help page.