### PR TITLE
Hubzilla on OpenShift - now with plugins and extra themes

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -189,5 +189,3 @@ util/config system disable_discover_tab 1
 echo "Try to add or update Hubzilla addons"
 cd ${OPENSHIFT_REPO_DIR}
 util/add_addon_repo https://github.com/redmatrix/hubzilla-addons.git HubzillaAddons 
-D
-ihttps://github.com/redmatrix/hubzilla-addons.git

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -179,7 +179,15 @@ echo "chmod done, permissions set to 777 on poller script."
 
 # Hubzilla configuration - changes to default settings
 # to make Hubzilla on OpenShift a more pleasant experience 
+echo "Changing default configuration to conserve space"
 cd ${OPENSHIFT_REPO_DIR}
 util/config system expire_delivery_reports 3
 util/config system feed_contacts 0
 util/config system disable_discover_tab 1
+
+# Hubzill addons
+echo "Try to add or update Hubzilla addons"
+cd ${OPENSHIFT_REPO_DIR}
+util/add_addon_repo https://github.com/redmatrix/hubzilla-addons.git HubzillaAddons 
+D
+ihttps://github.com/redmatrix/hubzilla-addons.git

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -189,3 +189,8 @@ util/config system disable_discover_tab 1
 echo "Try to add or update Hubzilla addons"
 cd ${OPENSHIFT_REPO_DIR}
 util/add_addon_repo https://github.com/redmatrix/hubzilla-addons.git HubzillaAddons 
+
+# Hubzilla themes
+echo "Try to add or update Hubzilla themes"
+cd ${OPENSHIFT_REPO_DIR}
+util/add_theme_repo https://github.com/DeadSuperHero/redmatrix-themes.git DeadSuperHeroThemes 

--- a/doc/Hubzilla_on_OpenShift.bb
+++ b/doc/Hubzilla_on_OpenShift.bb
@@ -1,5 +1,5 @@
 [b]Hubzilla on OpenShift[/b]
-You will notice a new .openshift folder when you fetch from upstream, i.e. from [url=https://github.com/redmatrix/hubzilla.git]https://github.com/redmatrix/hubzilla.git[/url] , which contains a deploy script to set up Hubzilla on OpenShift.
+You will notice a new .openshift folder when you fetch from upstream, i.e. from [url=https://github.com/redmatrix/hubzilla.git]https://github.com/redmatrix/hubzilla.git[/url] , which contains a deploy script to set up Hubzilla on OpenShift with plugins and extra themes.
 
 Create an account on OpenShift, then use the registration e-mail and password to create your first Hubzilla instance. Install git and RedHat's command line tools - rhc - if you have not already done so.
 


### PR DESCRIPTION
I have updated the Hubzilla on OpenShift deploy script to add plugins and themes from https://github.com/redmatrix/hubzilla-addons.git and https://github.com/DeadSuperHero/redmatrix-themes.git . A quick note has also been added to the help page.