### PR TITLE
Better handling for SSL reverse proxy

### DIFF
--- a/include/plugin.php
+++ b/include/plugin.php
@@ -505,17 +505,12 @@ function script_path() {
 	else
 		$scheme = 'http';
 
-	if(x($_SERVER,'SERVER_NAME')) {
-		$hostname = $_SERVER['SERVER_NAME'];
+	if(x($_SERVER,'HTTP_HOST')) {
+		$hostname = $_SERVER['HTTP_HOST'];
 	}
 	else {
 		return z_root();
 	}
-
-	if(x($_SERVER,'SERVER_PORT') && $_SERVER['SERVER_PORT'] != 80 && $_SERVER['SERVER_PORT'] != 443) {
-		$hostname .= ':' . $_SERVER['SERVER_PORT'];
-	}
-
 	return $scheme . '://' . $hostname;
 }
 


### PR DESCRIPTION
Hello Community,

As follow up for issue #98, I have created this patch to construct the server URLs reverse proxy/virtual host and SSL proxy proof. It relies on HTTP_HOST, which return the request host + port (in case it is a non standard port) instead of SERVER_NAME, which relies on the server configuration.

I have tested the following situations:

HTTP:80 (standard)
![http_80](https://cloud.githubusercontent.com/assets/663776/10717337/ef523784-7b54-11e5-8208-6b365f99bcc4.jpg)

HTTP:8080 (non-standard)
![http_8080](https://cloud.githubusercontent.com/assets/663776/10717339/fb08acde-7b54-11e5-9a29-048caa3f3d01.jpg)

HTTPS:443 (standard)
![https_443](https://cloud.githubusercontent.com/assets/663776/10717341/04b9680e-7b55-11e5-833b-6c7aecb835d8.jpg)

HTTPS:8080 (non-standard)
![https_8080](https://cloud.githubusercontent.com/assets/663776/10717342/0e7d80c8-7b55-11e5-9df3-436713bc2b05.jpg)

You can see at the stylesheet URLs that the hostnames + ports are set correctly.

Best Regards,
Stefan
