### PR TITLE
Changed default config for Hubzilla on Openshift

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -183,8 +183,12 @@ echo "Changing default configuration to conserve space"
 cd ${OPENSHIFT_REPO_DIR}
 util/config system expire_delivery_reports 3
 util/config system feed_contacts 0
+util/config system diaspora_enabled 0
 util/config system disable_discover_tab 1
 util/config system directory_server https://blablanet.com
+util/config directory safemode 0
+util/config directory globaldir 1
+util/config directory pubforums 0
 
 # Hubzill addons
 echo "Try to add or update Hubzilla addons"

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -184,6 +184,7 @@ cd ${OPENSHIFT_REPO_DIR}
 util/config system expire_delivery_reports 3
 util/config system feed_contacts 0
 util/config system disable_discover_tab 1
+util/config system https://blablanet.com
 
 # Hubzill addons
 echo "Try to add or update Hubzilla addons"

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -184,7 +184,7 @@ cd ${OPENSHIFT_REPO_DIR}
 util/config system expire_delivery_reports 3
 util/config system feed_contacts 0
 util/config system disable_discover_tab 1
-util/config system https://blablanet.com
+util/config system directory_server https://blablanet.com
 
 # Hubzill addons
 echo "Try to add or update Hubzilla addons"


### PR DESCRIPTION
New changes to default config are there to conserve space and life easier for starting out with Hubzilla on OpenShift. Delivery reports are reduced to three days, RSS is off, Diaspora is off, Discovery tab is off, directory server is blablanet.com, and the directory is supposed to only let you see your local directory.

util/config system expire_delivery_reports 3
util/config system feed_contacts 0
util/config system diaspora_enabled 0
util/config system disable_discover_tab 1
util/config system directory_server https://blablanet.com
util/config directory safemode 0
util/config directory globaldir 1
util/config directory pubforums 0