### PR TITLE
Invite module UI and strings update

### DIFF
--- a/mod/invite.php
+++ b/mod/invite.php
@@ -49,15 +49,15 @@ function invite_post(&$a) {
 			notice(  sprintf( t('%s : Not a valid email address.'), $recip) . EOL);
 			continue;
 		}
-		
+
 		else
 			$nmessage = $message;
 
 		$account = $a->get_account();
 
 
-		$res = mail($recip, sprintf( t('Please join us on $Projectname'), $a->config['sitename']), 
-			$nmessage, 
+		$res = mail($recip, sprintf( t('Please join us on $Projectname'), $a->config['sitename']),
+			$nmessage,
 			"From: " . $account['account_email'] . "\n"
 			. 'Content-type: text/plain; charset=UTF-8' . "\n"
 			. 'Content-transfer-encoding: 8bit' );
@@ -98,7 +98,7 @@ function invite_content(&$a) {
 			notice( t('You have no more invitations available') . EOL);
 			return '';
 		}
-	}			
+	}
 
 		if($invonly && ($x || is_site_admin())) {
 			$invite_code = autoname(8) . rand(1000,9999);
@@ -131,11 +131,11 @@ function invite_content(&$a) {
 		'$msg_text' => t('Your message:'),
 		'$default_message' => t('Please join my community on $Projectname.') . "\r\n" . "\r\n"
 			. $linktxt
-			. (($invonly) ? "\r\n" . "\r\n" . t('You will need to supply this invitation code: ') . $invite_code . "\r\n" . "\r\n" : '') 
+			. (($invonly) ? "\r\n" . "\r\n" . t('You will need to supply this invitation code:') . " " . $invite_code . "\r\n" . "\r\n" : '')
 			. t('1. Register at any $Projectname location (they are all inter-connected)')
 			. "\r\n" . "\r\n" . z_root() . '/register'
 			. "\r\n" . "\r\n" . t('2. Enter my $Projectname network address into the site searchbar.')
-			. "\r\n" . "\r\n" . $ob['xchan_addr'] . ' (' . t('or visit ') . z_root() . '/channel/' . $channel['channel_address'] . ')'
+			. "\r\n" . "\r\n" . $ob['xchan_addr'] . ' (' . t('or visit') . " " . z_root() . '/channel/' . $channel['channel_address'] . ')'
 			. "\r\n" . "\r\n"
 			. t('3. Click [Connect]')
 			. "\r\n" . "\r\n"  ,

--- a/view/tpl/invite.tpl
+++ b/view/tpl/invite.tpl
@@ -1,32 +1,28 @@
-<div class="generic-content-wrapper-styled">
-<form action="invite" method="post" id="invite-form" >
+<div id="invite" class="generic-content-wrapper">
+  <div class="section-title-wrapper">
+    <h2>{{$invite}}</h2>
+  </div>
+  <div class="section-content-wrapper">
 
-<input type='hidden' name='form_security_token' value='{{$form_security_token}}'>
+    <form action="invite" method="post" id="invite-form" >
 
-<div id="invite-wrapper">
+      <input type='hidden' name='form_security_token' value='{{$form_security_token}}'>
 
-<h3>{{$invite}}</h3>
+      <div id="invite-recipient-textarea" class="form-group field custom">
+        <label for="recipients">{{$addr_text}}</label>
+        <textarea id="invite-recipients" name="recipients" rows="6" class="form-control"></textarea>
+      </div>
 
-<div id="invite-recipient-text">
-{{$addr_text}}
-</div>
+      <div id="invite-message-textarea" class="form-group field custom">
+        <label for="message">{{$msg_text}}</label>
+        <textarea id="invite-message" name="message" rows="12" class="form-control">{{$default_message}}</textarea>
+      </div>
 
-<div id="invite-recipient-textarea">
-<textarea id="invite-recipients" name="recipients" rows="8" cols="32" ></textarea>
-</div>
+      <div id="invite-submit-wrapper" class="form-group">
+        <button class="btn btn-primary btn-sm" type="submit" id="invite-submit" name="submit" value="{{$submit}}">{{$submit}}</button>
+      </div>
 
-<div id="invite-message-text">
-{{$msg_text}}
-</div>
+    </form>
 
-<div id="invite-message-textarea">
-<textarea id="invite-message" name="message" rows="10" cols="72" >{{$default_message}}</textarea>
-</div>
-
-<div id="invite-submit-wrapper">
-<input type="submit" name="submit" value="{{$submit}}" />
-</div>
-
-</div>
-</form>
+  </div>
 </div>


### PR DESCRIPTION
I did 2 things in this first attempt to contribute to the code:

1)
I updated the UI template for the "invite" module to reflect the overall styling.

2)
I removed trailing spaces from 2 translatable strings and separated them into additional strings behind them. Trailing spaces tend to be ignored when people translate and don't recognize them (this actually happened with the German translation for the invite message - that's how I found the the problem) so that texts or elements are smashed together later on. I think it's better not to use them.
I guess these strings have to be translated again in all languages. But I'm not aware of any other method to solve this.