### PR TITLE
Add string translation to auto approval option

### DIFF
--- a/mod/connedit.php
+++ b/mod/connedit.php
@@ -25,7 +25,7 @@ function connedit_init(&$a) {
 		return;
 
 	if((argc() >= 2) && intval(argv(1))) {
-		$r = q("SELECT abook.*, xchan.* 
+		$r = q("SELECT abook.*, xchan.*
 			FROM abook left join xchan on abook_xchan = xchan_hash
 			WHERE abook_channel = %d and abook_id = %d LIMIT 1",
 			intval(local_channel()),
@@ -58,14 +58,14 @@ function connedit_post(&$a) {
 	$channel = $a->get_channel();
 
 	// TODO if configured for hassle-free permissions, we'll post the form with ajax as soon as the
-	// connection enable is toggled to a special autopost url and set permissions immediately, leaving 
-	// the other form elements alone pending a manual submit of the form. The downside is that there 
+	// connection enable is toggled to a special autopost url and set permissions immediately, leaving
+	// the other form elements alone pending a manual submit of the form. The downside is that there
 	// will be a window of opportunity when the permissions have been set but before you've had a chance
 	// to review and possibly restrict them. The upside is we won't have to warn you that your connection
-	// can't do anything until you save the bloody form.  
+	// can't do anything until you save the bloody form.
 
 	$autopost = (((argc() > 2) && (argv(2) === 'auto')) ? true : false);
-		
+
 	$orig_record = q("SELECT * FROM abook WHERE abook_id = %d AND abook_channel = %d LIMIT 1",
 		intval($contact_id),
 		intval(local_channel())
@@ -145,7 +145,7 @@ function connedit_post(&$a) {
 
 		if($z) {
 			$record = $z[0]['xlink_id'];
-			$w = q("update xlink set xlink_rating = '%d', xlink_rating_text = '%s', xlink_sig = '%s', xlink_updated = '%s' 
+			$w = q("update xlink set xlink_rating = '%d', xlink_rating_text = '%s', xlink_sig = '%s', xlink_updated = '%s'
 				where xlink_id = %d",
 				intval($rating),
 				dbesc($rating_text),
@@ -172,7 +172,7 @@ function connedit_post(&$a) {
 		}
 		if($record) {
 			proc_run('php','include/ratenotif.php','rating',$record);
-		}	
+		}
 	}
 
 	if(($_REQUEST['pending']) && intval($orig_record[0]['abook_pending'])) {
@@ -181,7 +181,7 @@ function connedit_post(&$a) {
 		// @fixme it won't be common, but when you accept a new connection request
 		// the permissions will now be that of your permissions role and ignore
 		// any you may have set manually on the form. We'll probably see a bug if somebody
-		// tries to set the permissions *and* approve the connection in the same 
+		// tries to set the permissions *and* approve the connection in the same
 		// request. The workaround is to approve the connection, then go back and
 		// adjust permissions as desired.
 
@@ -210,7 +210,7 @@ function connedit_post(&$a) {
 		intval(local_channel())
 	);
 
-	if($orig_record[0]['abook_profile'] != $profile_id) { 
+	if($orig_record[0]['abook_profile'] != $profile_id) {
 		//Update profile photo permissions
 
 		logger('A new profile was assigned - updating profile photos');
@@ -224,7 +224,7 @@ function connedit_post(&$a) {
 	else
 		notice( t('Failed to update connection record.') . EOL);
 
-	if($a->poi && $a->poi['abook_my_perms'] != $abook_my_perms 
+	if($a->poi && $a->poi['abook_my_perms'] != $abook_my_perms
 		&& (! intval($a->poi['abook_self']))) {
 		proc_run('php', 'include/notifier.php', (($new_friend) ? 'permission_create' : 'permission_update'), $contact_id);
 	}
@@ -238,8 +238,8 @@ function connedit_post(&$a) {
 				group_add_member(local_channel(),'',$a->poi['abook_xchan'],$g['id']);
 		}
 
-		// Check if settings permit ("post new friend activity" is allowed, and 
-		// friends in general or this friend in particular aren't hidden) 
+		// Check if settings permit ("post new friend activity" is allowed, and
+		// friends in general or this friend in particular aren't hidden)
 		// and send out a new friend activity
 
 		$pr = q("select * from profile where uid = %d and is_default = 1 and hide_friends = 0",
@@ -285,7 +285,7 @@ function connedit_post(&$a) {
 
 	// Refresh the structure in memory with the new data
 
-	$r = q("SELECT abook.*, xchan.* 
+	$r = q("SELECT abook.*, xchan.*
 		FROM abook left join xchan on abook_xchan = xchan_hash
 		WHERE abook_channel = %d and abook_id = %d LIMIT 1",
 		intval(local_channel()),
@@ -300,7 +300,7 @@ function connedit_post(&$a) {
 		call_hooks('accept_follow', $arr);
 	}
 
-	if(! is_null($autoperms)) 
+	if(! is_null($autoperms))
 		set_pconfig(local_channel(),'system','autoperms',(($autoperms) ? $abook_my_perms : 0));
 
 	connedit_clone($a);
@@ -322,7 +322,7 @@ function connedit_clone(&$a) {
 		if(! $a->poi)
 			return;
 
-		$r = q("SELECT abook.*, xchan.* 
+		$r = q("SELECT abook.*, xchan.*
 			FROM abook left join xchan on abook_xchan = xchan_hash
 			WHERE abook_channel = %d and abook_id = %d LIMIT 1",
 			intval(local_channel()),
@@ -365,6 +365,8 @@ function connedit_content(&$a) {
 			$my_perms = $x['perms_accept'];
 	}
 
+	$yes_no = array(t('No'),t('Yes'));
+
 	if($my_perms) {
 		$o .= "<script>function connectDefaultShare() {
 		\$('.abook-edit-me').each(function() {
@@ -398,7 +400,7 @@ function connedit_content(&$a) {
 			notice( t('Could not access address book record.') . EOL);
 			goaway($a->get_baseurl(true) . '/connections');
 		}
-		
+
 		if($cmd === 'update') {
 			// pull feed and consume it, which should subscribe to the hub.
 			proc_run('php',"include/poller.php","$contact_id");
@@ -408,7 +410,7 @@ function connedit_content(&$a) {
 
 		if($cmd === 'refresh') {
 			if($orig_record[0]['xchan_network'] === 'zot') {
-				if(! zot_refresh($orig_record[0],get_app()->get_channel())) 
+				if(! zot_refresh($orig_record[0],get_app()->get_channel()))
 					notice( t('Refresh failed - channel is currently unavailable.') );
 			}
 			else {
@@ -475,13 +477,13 @@ function connedit_content(&$a) {
 			require_once('include/Contact.php');
 
 // FIXME
-// We need to send either a purge or a refresh packet to the other side (the channel being unfriended). 
+// We need to send either a purge or a refresh packet to the other side (the channel being unfriended).
 // The issue is that the abook DB record _may_ get destroyed when we call contact_remove. As the notifier runs
 // in the background there could be a race condition preventing this packet from being sent in all cases.
 // PLACEHOLDER
 
 			contact_remove(local_channel(), $orig_record[0]['abook_id']);
-			build_sync_packet(0 /* use the current local_channel */, 
+			build_sync_packet(0 /* use the current local_channel */,
 				array('abook' => array(array(
 					'abook_xchan' => $orig_record[0]['abook_xchan'],
 					'entry_deleted' => true))
@@ -505,28 +507,28 @@ function connedit_content(&$a) {
 
 			'view' => array(
 				'label' => t('View Profile'),
-				'url'   => chanlink_cid($contact['abook_id']), 
+				'url'   => chanlink_cid($contact['abook_id']),
 				'sel'   => '',
 				'title' => sprintf( t('View %s\'s profile'), $contact['xchan_name']),
 			),
 
 			'refresh' => array(
 				'label' => t('Refresh Permissions'),
-				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/refresh', 
+				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/refresh',
 				'sel'   => '',
 				'title' => t('Fetch updated permissions'),
 			),
 
 			'recent' => array(
 				'label' => t('Recent Activity'),
-				'url'   => $a->get_baseurl(true) . '/network/?f=&cid=' . $contact['abook_id'], 
+				'url'   => $a->get_baseurl(true) . '/network/?f=&cid=' . $contact['abook_id'],
 				'sel'   => '',
 				'title' => t('View recent posts and comments'),
 			),
 
 			'block' => array(
 				'label' => (intval($contact['abook_blocked']) ? t('Unblock') : t('Block')),
-				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/block', 
+				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/block',
 				'sel'   => (intval($contact['abook_blocked']) ? 'active' : ''),
 				'title' => t('Block (or Unblock) all communications with this connection'),
 				'info'   => (intval($contact['abook_blocked']) ? t('This connection is blocked!') : ''),
@@ -534,7 +536,7 @@ function connedit_content(&$a) {
 
 			'ignore' => array(
 				'label' => (intval($contact['abook_ignored']) ? t('Unignore') : t('Ignore')),
-				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/ignore', 
+				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/ignore',
 				'sel'   => (intval($contact['abook_ignored']) ? 'active' : ''),
 				'title' => t('Ignore (or Unignore) all inbound communications from this connection'),
 				'info'   => (intval($contact['abook_ignored']) ? t('This connection is ignored!') : ''),
@@ -542,7 +544,7 @@ function connedit_content(&$a) {
 
 			'archive' => array(
 				'label' => (intval($contact['abook_archived']) ? t('Unarchive') : t('Archive')),
-				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/archive', 
+				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/archive',
 				'sel'   => (intval($contact['abook_archived']) ? 'active' : ''),
 				'title' => t('Archive (or Unarchive) this connection - mark channel dead but keep content'),
 				'info'   => (intval($contact['abook_archived']) ? t('This connection is archived!') : ''),
@@ -550,7 +552,7 @@ function connedit_content(&$a) {
 
 			'hide' => array(
 				'label' => (intval($contact['abook_hidden']) ? t('Unhide') : t('Hide')),
-				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/hide', 
+				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/hide',
 				'sel'   => (intval($contact['abook_hidden']) ? 'active' : ''),
 				'title' => t('Hide or Unhide this connection from your other connections'),
 				'info'   => (intval($contact['abook_hidden']) ? t('This connection is hidden!') : ''),
@@ -558,7 +560,7 @@ function connedit_content(&$a) {
 
 			'delete' => array(
 				'label' => t('Delete'),
-				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/drop', 
+				'url'   => $a->get_baseurl(true) . '/connedit/' . $contact['abook_id'] . '/drop',
 				'sel'   => '',
 				'title' => t('Delete this connection'),
 			),
@@ -639,7 +641,7 @@ function connedit_content(&$a) {
 		$channel = $a->get_channel();
 
 		$global_perms = get_perms();
-		$existing = get_all_perms(local_channel(),$contact['abook_xchan']); 
+		$existing = get_all_perms(local_channel(),$contact['abook_xchan']);
 
 		$unapproved = array('pending', t('Approve this connection'), '', t('Accept connection to allow communication'), array(t('No'),('Yes')));
 
@@ -668,7 +670,7 @@ function connedit_content(&$a) {
 
 		$locstr = '';
 
-		$locs = q("select hubloc_addr as location from hubloc left join site on hubloc_url = site_url where hubloc_hash = '%s' 
+		$locs = q("select hubloc_addr as location from hubloc left join site on hubloc_url = site_url where hubloc_hash = '%s'
 			and hubloc_deleted = 0 and site_dead = 0",
 			dbesc($contact['xchan_hash'])
 		);
@@ -690,7 +692,7 @@ function connedit_content(&$a) {
 		$o .= replace_macros($tpl,array(
 
 			'$header'         => (($self) ? t('Connection Default Permissions') : sprintf( t('Connection: %s'),$contact['xchan_name'])),
-			'$autoperms'      => array('autoperms',t('Apply these permissions automatically'), ((get_pconfig(local_channel(),'system','autoperms')) ? 1 : 0), 'Connection requests will be approved without your interaction', array(t('No'),('Yes'))),
+			'$autoperms'      => array('autoperms',t('Apply these permissions automatically'), ((get_pconfig(local_channel(),'system','autoperms')) ? 1 : 0), t('Connection requests will be approved without your interaction'), $yes_no),
 			'$addr'           => $contact['xchan_addr'],
 			'$addr_text'      => t('This connection\'s primary address is'),
 			'$loc_text'       => t('Available locations:'),
@@ -705,8 +707,8 @@ function connedit_content(&$a) {
 			'$lbl_rating_txt' => t('Optionally explain your rating'),
 			'$connfilter'     => feature_enabled(local_channel(),'connfilter'),
 			'$connfilter_label' => t('Custom Filter'),
-			'$incl'           => array('abook_incl',t('Only import posts with this text'), $contact['abook_incl'],t('words one per line or #tags or /patterns/ or lang=xx, leave blank to import all posts')), 
-			'$excl'           => array('abook_excl',t('Do not import posts with this text'), $contact['abook_excl'],t('words one per line or #tags or /patterns/ or lang=xx, leave blank to import all posts')), 
+			'$incl'           => array('abook_incl',t('Only import posts with this text'), $contact['abook_incl'],t('words one per line or #tags or /patterns/ or lang=xx, leave blank to import all posts')),
+			'$excl'           => array('abook_excl',t('Do not import posts with this text'), $contact['abook_excl'],t('words one per line or #tags or /patterns/ or lang=xx, leave blank to import all posts')),
 			'$rating_text'    => array('rating_text', t('Optionally explain your rating'),$rating_text,''),
 			'$rating_info'    => t('This information is public!'),
 			'$rating'         => $rating,


### PR DESCRIPTION
The description for the auto-approval option was not translatable. The t-function was also missing on the Yes-option of the switch. I put the switch array into a $yes_no variable with translatable strings as it is done on other settings pages. There's just one switch on that page now but it's more consistent should there be added more later.

Note:
Looks like my editor catches a lot of space characters at the end of lines and removes them when saving the file. Should I switch that function off or is it okay if the files are cleaned that way? I like files without these unnecessary characters but the removal can make commit diffs a bit hard to read here.