### PR TITLE
Added the installation of curl to the .homeinstall script

### DIFF
--- a/.homeinstall/hubzilla-setup.sh
+++ b/.homeinstall/hubzilla-setup.sh
@@ -220,6 +220,11 @@ function install_apache {
     nocheck_install "apache2 apache2-utils"
 }
 
+function install_curl {
+    print_info "installing curl..."
+    nocheck_install "curl"
+}
+
 function install_php {
     # openssl and mbstring are included in libapache2-mod-php5
     # to_to:  php5-suhosin
@@ -817,6 +822,7 @@ sslconf=/etc/apache2/sites-available/default-ssl.conf
 
 check_config
 update_upgrade
+install_curl
 install_apache
 install_php
 install_mysql


### PR DESCRIPTION
After reporting issue https://github.com/redmatrix/hubzilla/issues/280, I modified the .homeinstall script to add the installation of curl. I successfully installed a new hub on a fresh virtual private server using the following steps:

1. Created a new DigitalOcean droplet (Debian 8.3 x64 / 512 MB Memory / 20 GB Disk / NYC3)
1. Assigned the hub domain name to the new droplet IP address using RackSpace DNS services
1. Logged on to the new server and executed the following commands:
  1. `apt-get install git  `
  1. `mkdir -p /var/www/html`
  1. `cd /var/www/html`
  1. `git clone https://github.com/redmatrix/hubzilla.git .`
  1. `nano .homeinstall/hubzilla-config.txt `
  1. `cd .homeinstall/`
  1. `./hubzilla-setup.sh `
  1. `sed -i "s/^upload_max_filesize =.*/upload_max_filesize = 100M/g" /etc/php5/apache2/php.ini`
  1. `sed -i "s/^post_max_size =.*/post_max_size = 100M/g" /etc/php5/apache2/php.ini`
  1. `service apache2 reload`
1. Opened the hub webpage in a browser and completed the steps to finish installation

