### PR TITLE
fix typo in postgres schema

### DIFF
--- a/install/schema_postgres.sql
+++ b/install/schema_postgres.sql
@@ -560,7 +560,7 @@ CREATE TABLE "iconfig" (
   "k" text NOT NULL DEFAULT '',
   "v" text NOT NULL DEFAULT '',
   "sharing" int NOT NULL DEFAULT '0',
-  PRIMARY_KEY("id")
+  PRIMARY KEY("id")
 );
 create index "iconfig_iid" on iconfig ("iid");
 create index "iconfig_cat" on iconfig ("cat");


### PR DESCRIPTION
Initialisation of postgres database didn't work.
Here is my patch.