### PR TITLE
Redbasic: Fix the issue with derived themes and schemas

### DIFF
--- a/doc/DerivedTheme1.md
+++ b/doc/DerivedTheme1.md
@@ -63,7 +63,6 @@ In it, put the following:
 
 That's it. This tells the software to read the PCSS information for the redbasic theme first, and then read our CSS file which will just consist of changes we want to make from our parent theme (redbasic). 
 
-
 Now create the actual CSS file for your theme.  Put it in view/theme/mytheme/css/style.css (where we just told the software to look for it). For our example, we'll just change the body background color so you can see that it works. You can use any CSS you'd like. 
 
 
@@ -73,5 +72,30 @@ Now create the actual CSS file for your theme.  Put it in view/theme/mytheme/css
 
 
 You've just successfully created a derived theme. This needs to be enabled in the admin "themes" panel, and then anybody on the site can use it by selecting it in Settings->Display Settings as their default theme.  
+
+**Lesson 2**
+
+If you want to use the redbasic schemas for your derived theme, you have to do a bit more.
+
+Do everything as above, but don't create view/theme/mytheme/php/style.php, but copy instead  view/theme/redbasic/php/style.php to view/theme/mytheme/php/style.php. Modify that file and remove (or comment out) these two lines:
+
+	if($a->channel['channel_theme'] != 'redbasic')
+	set_pconfig(local_channel(), 'redbasic', 'schema', '---');
+	
+Also add this line at the bottom:
+
+	echo @file_get_contents('view/theme/mytheme/css/style.css');
+
+To show the schema selector you have to copy view/theme/redbasic/tpl/theme_settings.tpl to  view/theme/mytheme/tpl/theme_settings.tpl. Modify that file and replace the lines:
+
+	{{if $theme == redbasic}}
+	{{include file="field_select.tpl" field=$schema}}
+	{{/if}}
+
+with:
+
+	{{include file="field_select.tpl" field=$schema}}
+	
+
 
 #include doc/macros/main_footer.bb;

--- a/view/theme/redbasic/php/config.php
+++ b/view/theme/redbasic/php/config.php
@@ -98,6 +98,7 @@ if(feature_enabled(local_channel(),'expert'))
 	  $o .= replace_macros($t, array(
 		'$submit' => t('Submit'),
 		'$baseurl' => $a->get_baseurl(),
+		'$theme' => $a->channel['channel_theme'],
 		'$expert' => $expert,
 		'$title' => t("Theme settings"),
 		'$schema' => array('redbasic_schema', t('Select scheme'), $arr['schema'], '', $scheme_choices),

--- a/view/theme/redbasic/php/style.php
+++ b/view/theme/redbasic/php/style.php
@@ -215,3 +215,8 @@ if($align_left && file_exists('view/theme/redbasic/css/align_left.css')) {
 if($schemecss) {
 	echo $schemecss;
 }
+
+// Set the schema to the default schema in derived themes. See the documentation for creating derived themes how to override this. 
+
+if($a->channel['channel_theme'] != 'redbasic')
+	set_pconfig(local_channel(), 'redbasic', 'schema', '---');

--- a/view/theme/redbasic/tpl/theme_settings.tpl
+++ b/view/theme/redbasic/tpl/theme_settings.tpl
@@ -1,4 +1,6 @@
+{{if $theme == redbasic}}
 {{include file="field_select.tpl" field=$schema}}
+{{/if}}
 {{include file="field_checkbox.tpl" field=$align_left}}
 {{include file="field_checkbox.tpl" field=$narrow_navbar}}
 {{include file="field_input.tpl" field=$converse_width}}


### PR DESCRIPTION
Change the schema to the default Redbasic schema *only* when a derived theme is loaded and do not show the schema selector if it is a derived theme. If derived themes want to override this they can still copy and modify the files. See the updated documentation.