### PR TITLE
Fix: german help > link to of project in github

### DIFF
--- a/doc/de/general.bb
+++ b/doc/de/general.bb
@@ -7,8 +7,8 @@
 [h3]Externe Ressourcen[/h3]
 [zrl=[baseurl]/help/external-resource-links]Links zu externen Ressourcen[/zrl]
 
-[url=https://github.com/redmatrix/redmatrix]Haupt-Website[/url]
-[url=https://github.com/redmatrix/redmatrix-addons]Addons-Website[/url]
+[url=https://github.com/redmatrix/hubzilla]Haupt-Website[/url]
+[url=https://github.com/redmatrix/hubzilla-addons]Addons-Website[/url]
 
 [url=[baseurl]/help/credits]$Projectname Credits[/url]
 


### PR DESCRIPTION
Fix: german help > link to project in github.

Was: The link Pointed toredmatrix.
Now is: The link now points to hubzilla.