### PR TITLE
extends util/config and util/pconfig

### DIFF
--- a/util/config
+++ b/util/config
@@ -3,6 +3,11 @@
 
 // Red config utility
 
+if(!file_exists('include/cli_startup.php')) {
+	echo 'Run config from the top level Hubzilla web directory, as util/config <args>' . PHP_EOL;
+	exit(1);
+}
+
 require_once('include/cli_startup.php');
 
 cli_startup();

--- a/util/config
+++ b/util/config
@@ -7,9 +7,45 @@ require_once('include/cli_startup.php');
 
 cli_startup();
 
-if($argc > 3) {
-	
 
+$helpArgs = getopt('h', array('help'));
+if (count($helpArgs) === 1) {
+	echo <<<'EndOfOutput'
+Gets, sets, or lists site-wide configuration settings.
+
+Usage: util/config 
+       util/config <family>
+       util/config <family> <key>
+       util/config <family> <key> <value>
+
+  util/config
+	Displays all config entries
+
+  util/config <family>
+	Displays all config entries for family (system, database, etc)
+
+  util/config <family> <key>
+	Displays single config entry for the specified family and key
+
+  util/config <family> <key> <value>
+	Set config entry for specified family and key to value and display result
+
+Notes:
+  Setting config entries which are manually set in .htconfig.php may result 
+  in conflict between database settings and the manual startup settings. 
+
+  For channel-specific configuration settings, use util/pconfig
+
+  Details for configuration options can be found at:
+
+EndOfOutput;
+	echo '    ' . App::get_baseurl() . '/help/hidden_configs' . PHP_EOL . PHP_EOL;
+	return;
+}
+
+
+
+if($argc > 3) {
 	set_config($argv[1],$argv[2],$argv[3]);
 	echo "config[{$argv[1]}][{$argv[2]}] = " . printable_config(get_config($argv[1],$argv[2])) . "\n";
 }

--- a/util/pconfig
+++ b/util/pconfig
@@ -8,6 +8,40 @@ require_once('include/zot.php');
 
 cli_startup();
 
+$helpArgs = getopt('h', array('help'));
+if (count($helpArgs) === 1) {
+	echo <<<'EndOfOutput'
+Gets, sets, or lists personal (per channel) configuration settings.
+
+Usage: util/pconfig <channel_id>
+       util/pconfig <channel_id> <family>
+       util/pconfig <channel_id> <family> <key>
+       util/pconfig <channel_id> <family> <key> <value>
+
+  util/pconfig <channel_id>
+	Displays all of the the channel's config entries
+
+  util/pconfig <channel_id> <family>
+	Displays all of the channel's config entries for the specified family 
+	(system, database, etc)
+
+  util/pconfig <channel_id> <family> <key>
+	Displays single config entry for the specified family and key
+
+  util/pconfig <channel_id> <family> <key> <value>
+	Set config entry for specified family and key to value and display result
+
+Notes:
+  For site-wide configuration settings, use util/config
+
+  Details for configuration options can be found at:
+
+EndOfOutput;
+	echo '    ' . App::get_baseurl() . '/help/hidden_configs' . PHP_EOL . PHP_EOL;
+	return;
+}
+
+
 if($argc > 4) {
 	set_pconfig($argv[1],$argv[2],$argv[3],$argv[4]);
 	build_sync_packet($argv[1]);

--- a/util/pconfig
+++ b/util/pconfig
@@ -13,10 +13,14 @@ if (count($helpArgs) === 1) {
 	echo <<<'EndOfOutput'
 Gets, sets, or lists personal (per channel) configuration settings.
 
-Usage: util/pconfig <channel_id>
+Usage: util/pconfig
+       util/pconfig <channel_id>
        util/pconfig <channel_id> <family>
        util/pconfig <channel_id> <family> <key>
        util/pconfig <channel_id> <family> <key> <value>
+
+  util/pconfig
+	List all channel IDs
 
   util/pconfig <channel_id>
 	Displays all of the the channel's config entries
@@ -68,3 +72,11 @@ if($argc == 2) {
 	}
 }
 
+if($argc == 1) {
+	$r = q("select channel_id, channel_name from channel");
+	if($r) {
+		foreach($r as $rr) {
+			echo sprintf('%4u %s', $rr['channel_id'], $rr['channel_name']) . PHP_EOL;
+		}
+	}
+}

--- a/util/pconfig
+++ b/util/pconfig
@@ -3,6 +3,14 @@
 
 // Red pconfig utility
 
+
+if(!file_exists('include/cli_startup.php')) {
+	echo 'Run pconfig from the top level Hubzilla web directory, as util/pconfig <args>' . PHP_EOL;
+	exit(1);
+}
+
+
+
 require_once('include/cli_startup.php');
 require_once('include/zot.php');
 


### PR DESCRIPTION
Gives `util/pconfig` the ability to list all the channel IDs, and adds command-line help to both utils.

Before merging this, someone who's more familiar with hubzilla should check my assumptions:
* these scripts are only intended to be used from the command-line, so improving their command-line UI should be safe with regard to the rest of hubzilla
* There'll never be a configuration family named "-h" or "--help", so `util/config -h` is unambiguous. (if "-h" isn't the first argument then `getopt()` will ignore it)