### PR TITLE
Add definition lists to bbcode

### DIFF
--- a/doc/bbcode.html
+++ b/doc/bbcode.html
@@ -27,12 +27,31 @@
 <li>[list=a]<br />
 <li>[list=A] <br />
 <li>[ul]<br />
-<li>[ol]
+<li>[ol]<br />
+<li>[dl]<br />
+<li>[dl terms="biumlh"] &mdash; where style of the terms can be any combination of:
+	<dl class="bb-dl dl-horizontal">
+	<dt>b</dt><dd>bold</dd>
+	<dt>i</dt><dd>italic</dd>
+	<dt>u</dt><dd>underline</dd>
+	<dt>m</dt><dd>monospace</dd>
+	<dt>l</dt><dd>large</dd>
+	<dt>h</dt><dd>horizontal &mdash; like <em>this</em> defintion list</dd>
+	</dl>
+</li>
 
 </ul>For example:<br />[ul]<br />[*] First list element<br />[*] Second list element<br />[/ul]<br /><br />Will render something like: <br />
 <ul class="listbullet" style="list-style-type: circle;">
 <li> First list element<br />
-<li> Second list element</ul><br /> 
+<li> Second list element</ul>
+
+or<br /><br />[dl terms="b"]<br />[*= First element term] First element description<br />[*= Second element term] Second element description<br />[/dl]<br /><br />Will render something like: <br /><br />
+<dl class="bb-dl dl-terms-bold">
+<dt> First element term </dt><dd>First element description</dd>
+<dt> Second element term </dt><dd>Second element description</dd>
+</dl><br /> 
+
+
 <br />There's also:<br />
 <ul class="listloweralpha" style="list-style-type: lower-alpha;">
 <li>[hr]<br />

--- a/doc/hidden_configs.bb
+++ b/doc/hidden_configs.bb
@@ -1,10 +1,7 @@
-[b]Advanced Configurations for Administrators[/b]
-
+[h1]Advanced Configurations for Administrators[/h1]
 $Projectname contains many configuration options hidden from the main admin panel.
 
-These are generally options considered too niche, confusing, or advanced for 
-the average member.  These settings can be activated from the the top level web 
-directory with the syntax
+These are generally options considered too niche, confusing, or advanced for the average member.  These settings can be activated from the the top level web directory with the syntax
 
 [code]util/config cat key value[/code] 
 for a site configuration, or 
@@ -13,221 +10,96 @@ for a site configuration, or
 for a member configuration.
 
 This document assumes you're an administrator.
+[h2]pconfig[/h2][dl terms="mb"]
+  [*= system.always_my_theme ] Always use your own theme when viewing channels on the same hub.  This will break in some quite imaginative ways when viewing channels with  theme dependent Comanche.
+  [*= system.blocked ] An array of xchans blocked by this channel.  Technically, this is a hidden config and does belong here, however, addons (notably  superblock) have made this available in the UI.
+  [*= system.default_cipher ] Set the default cipher used for E2EE items.
+  [*= system.display_friend_count ] Set the number of connections to display in the connections profile  widget.
+  [*= system.do_not_track ] As the browser header.  This will break many identity based features.   You should really just set permissions that make sense.
+  [*= system.forcepublicuploads ] Force uploaded photos to be public when uploaded as wall items.  It makes far more sense to just set your permissions properly in the first place.  Do that instead.
+  [*= system.network_page_default ] Set default params when viewing the network page.  This should contain the same querystring as manual filtering.
+  [*= system.paranoia ] Sets the security level of IP checking. If the IP address of a logged-in session changes apply this level to determine if the account should be logged out as a security breach.     
+Options are:
+        0 &mdash; no IP checking             
+        1 &mdash; check 3 octets             
+        2 &mdash; check 2 octets             
+        3 &mdash; check for any difference at all
 
-[b]pconfig[/b]
-    [b]system.user_scalable[/b]
-        Determine if the app is scalable on touch screens.  Defaults to on, to 
-        disable, set to zero - real zero, not just false.
-    [b]system.always_my_theme[/b]
-        Always use your own theme when viewing channels on the same hub.  This
-        will break in some quite imaginative ways when viewing channels with 
-        theme dependent Comanche.
-    [b]system.paranoia[/b]
-        Sets the security level of IP checking. If the IP address of a logged-in session changes
-		apply this level to determine if the account should be logged out as a security breach.
-            Options are: 
-                    0 - no IP checking 
-                    1 - check 3 octets
-                    2 - check 2 octets
-                    3 - check for any difference at all
-    [b]system.prevent_tag_hijacking[/b]
-        Prevent foreign networks hijacking hashtags in your posts and directing them at its own resources.
-    [b]system.blocked[/b]
-        An array of xchans blocked by this channel.  Technically, this is a
-        hidden config and does belong here, however, addons (notably 
-        superblock) have made this available in the UI.
-    [b]system.default_cipher[/b]
-        Set the default cipher used for E2EE items.
-    [b]system.network_page_default[/b]
-        Set default params when viewing the network page.  This should contain
-        the same querystring as manual filtering.
-    [b]system.display_friend_count[/b]
-        Set the number of connections to display in the connections profile 
-        widget.
-    [b]system.taganyone[/b]
-        Requires the config of the same name to be enabled.  Allow the @mention tagging
-        of anyone, whether you are connected or not.  This doesn't scale.
-    [b]system.startpage[/b]
-        Another of those technically hidden configs made available by addons.
-        Sets the default page to view when logging in.  This is exposed to the
-        UI by the startpage addon.
-    [b]system.forcepublicuploads[/b]
-        Force uploaded photos to be public when uploaded as wall items.  It
-        makes far more sense to just set your permissions properly in the first
-        place.  Do that instead.
-    [b]system.do_not_track[/b]
-        As the browser header.  This will break many identity based features.  
-        You should really just set permissions that make sense.
+  [*= system.prevent_tag_hijacking ] Prevent foreign networks hijacking hashtags in your posts and directing them at its own resources.
+  [*= system.startpage ] Another of those technically hidden configs made available by addons. Sets the default page to view when logging in.  This is exposed to the UI by the startpage addon.
+  [*= system.taganyone ] Requires the config of the same name to be enabled.  Allow the @mention tagging of anyone, whether you are connected or not.  This doesn't scale.
+  [*= system.user_scalable ] Determine if the app is scalable on touch screens.  Defaults to on, to  disable, set to zero - real zero, not just false.
+[/dl]
+[h2]Site config[/h2][dl terms="mb"]
+  [*= randprofile.check ] When requesting a random profile, check that it actually exists first
+  [*= randprofile.retry ] Number of times to retry getting a random profile
+  [*= system.admin_email ] Specifies the administrator's email for this site.  This is initially set during install.
+  [*= system.authlog ] Logfile to use for logging auth errors.  Used to plug in to server side software such as fail2ban.  Auth failures are still logged to the main logs as well.
+  [*= system.auto_channel_create ] Add the necessary form elements to create the first channel on the account registration page, and create it (possibly following email validation or administrator approval). This precludes the ability to import a channel from another site as the first channel created on this site for a new account.  Use with system.default_permissions_role to streamline registration. 
+  [*= system.auto_follow ] Make the first channel of an account auto-follow channels listed here - comma separated list of webbies (member@hub addresses).
+  [*= system.blacklisted_sites ] An array of specific hubs to block from this hub completely.
+  [*= system.block_public_search ] Similar to block_public, except only blocks public access to  search features.  Useful for sites that want to be public, but keep getting hammered by search engines.
+  [*= system.cron_hour ] Specify an hour in which to run cron_daily.  By default with no config, this will run at midnight UTC.
+  [*= system.default_permissions_role ] If set to a valid permissions role name, use that role for the first channel created by a new account and don't ask for the "Channel Type" on the channel creation form. Examples of valid names are: 'social', 'social_restricted', 'social_private',  'forum', 'forum_restricted' and 'forum_private'.  Read more about permissions roles [zrl=[baseurl]/help/roles]here[/zrl].
+  [*= system.default_photo_profile ] Set the profile photo that new channels start with. This should contain the name of a directory located under [font=courier]images/default_profile_photos/[/font], or be left unset. If not set then 'rainbow_man' is assumed.
+  [*= system.directorytags ] Set the number of keyword tags displayed on the directory page. Default is 50 unless set to a  positive integer.
+  [*= system.disable_directory_keywords ] If '1', do not show directory keywords. If the hub is a directory server, prevent returning tags to any directory clients. Please do not set this for directory servers in the RED_GLOBAL realm. 
+  [*= system.disable_discover_tab ] This allows you to completely disable the ability to discover public content from external sites.
+  [*= system.disable_dreport ] If '1', don't store or link to delivery reports
+  [*= system.dlogfile ] Logfile to use for logging development errors.  Exactly the same as logger otherwise.  This isn't magic, and requires your own logging statements.  Developer tool.
+  [*= system.email_notify_icon_url ] URL of image (32x32) to display in email notifications (HTML bodies).
+  [*= system.expire_delivery_reports ] Expiration in days for delivery reports - default 10
+  [*= system.expire_limit ] Don't expire any more than this number of posts per channel per expiration run to keep from exhausting memory. Default 5000.
+  [*= system.hidden_version_siteinfo ] If true, do not report the software version on siteinfo pages (system.hide_version also hides the version on these pages, this setting *only* hides the version on siteinfo pages).
+  [*= system.hide_help ] Don't display help documentation link in nav bar
+  [*= system.hide_in_statistics ] Tell the red statistics servers to completely hide this hub in hub lists.
+  [*= system.hide_version ] If true, do not report the software version on webpages and tools. (*) Must be set in .htconfig.php
+  [*= system.ignore_imagick ] Ignore imagick and use GD, even if imagick is installed on the server. Prevents some issues with PNG files in older versions of imagick.
+  [*= system.max_daily_registrations ] Set the maximum number of new registrations allowed on any day. Useful to prevent oversubscription after a bout of publicity for the project.
+  [*= system.max_import_size ] If configured, the maximum length of an imported text message. This is normally left at 200Kbytes  or more to accomodate Friendica private photos, which are embedded.
+  [*= system.max_tagged_forums ] Spam prevention. Limits the number of tagged forums which are recognised in any post. Default is 2. Only the first 'n' tags will be delivered as forums, the others will not cause any delivery. 
+  [*= system.minimum_feedcheck_minutes ] The minimum interval between polling RSS feeds.  If this is lower than the cron interval, feeds will be polled with each cronjob. Defaults to 60 if not set. The site setting can also be over-ridden on a channel by channel basis by a service class setting aptly named 'minimum_feedcheck_minutes'.
+  [*= system.no_age_restriction ] Do not restrict registration to people over the age of 13. This carries legal responsibilities in  many countries to require that age be provided and to block all personal information from minors,  so please check your local laws before changing.  
+  [*= system.openssl_conf_file ] Specify a file containing OpenSSL configuration. Needed in some Windows installations to  locate the openssl configuration file on the system.  Read the code first. If you can't read the code, don't play with it.
+  [*= system.openssl_encrypt ] Use openssl encryption engine, default is false (uses mcrypt for AES encryption)
+  [*= system.optimize_items ] Runs optimise_table during some tasks to keep your database nice and  defragmented.  This comes at a performance cost while the operations are running, but also keeps things a bit faster while it's not.   There also exist CLI utilities for performing this operation, which you may prefer, especially if you're a large site.
+  [*= system.override_poll_lockfile ] Ignore the lock file in the poller process to allow more than one process to run at a time.
+  [*= system.paranoia ] As the pconfig, but on a site-wide basis.  Can be overwritten by member settings.
+  [*= system.photo_cache_time ] How long to cache photos, in seconds. Default is 86400 (1 day). Longer time increases performance, but it also means it takes longer for changed permissions to apply.
+  [*= system.platform_name ] What to report as the platform name in webpages and statistics. (*) Must be set in .htconfig.php
+  [*= system.poco_rating_enable ] Distributed reputation reporting and data collection may be disabled. If your site does not participate  in distributed reputation you will also not be able to make use of the data from your connections on  other sites. By default and in the absence of any setting it is enabled. Individual members can opt out  by restricting who can see their connections or by not providing any reputation information for their  connections.
+  [*= system.poke_basic ] Reduce the number of poke verbs to exactly 1 ("poke"). Disable other verbs. 
+  [*= system.proc_run_use_exec ] If 1, use the exec system call in proc_run to run background tasks. By default we use proc_open and proc_close. On some (currently rare) systems this does not work well.
+  [*= system.projecthome ] Display the project page on your home page for logged out viewers.
+  [*= system.projecthome ] Set the project homepage as the homepage of your hub. (Obsolete)
+  [*= system.register_link ] path to direct to from the "register" link on the login form. On closed sites this will direct to  'pubsites'. For open sites it will normally redirect to 'register' but you may change this to a  custom site page offering subscriptions or whatever. 
+  [*= system.reserved_channels ] Don't allow members to register channels with this comma separated list of names (no spaces)
+  [*= system.sellpage ] A URL shown in the public sites list to sell your hub - display service classes, etc.
+  [*= system.startpage ] Set the default page to be taken to after a login for all channels at this website.  Can be overwritten by user settings.
+  [*= system.sys_expire_days ] How many days to keep discovered public content from other sites
+  [*= system.taganyone ] Allow the @mention tagging of anyone whether you are connected or not.
+  [*= system.tempdir ] Place to store temporary files (currently unused), default is defined in the PHP configuration  
+  [*= system.tos_url ] Set an alternative link for the ToS location.
+  [*= system.transport_security_header ] if non-zero and SSL is being used, include a strict-transport-security header on webpages
+  [*= system.uploaddir ] Location to upload files (default is system.tempdir, currently used only by js_upload plugin)
+  [*= system.workflow_channel_next ] The page to direct new members to immediately after creating a channel.
+  [*= system.workflow_register_next ] The page to direct members to immediately after creating an account (only when auto_channel_create or UNO is enabled).
+[/dl]
+[h2]Directory config[/h2]
+[h3]Directory search defaults[/h3][dl terms="mb"]
+  [*= directory.globaldir ] 0 or 1. Default 0.  If you visit the directory on a site you'll just see the members of that site by default. You have to go through an extra step to see the people in the rest of the network; and by doing so there's a clear delineation that these people *aren't* members of that site but of a larger network.
+  [*= directory.pubforums ] 0 or 1. Public forums [i]should[/i] be default 0.
+  [*= directory.safemode ] 0 or 1.  
+[/dl]
+[h3]Directory server configuration[/h3][i](see [zrl=[baseurl]/help/directories]help/directories[/zrl])[/i]
 
-[b]Site config[/b]
-    [b]system.taganyone[/b]
-        Allow the @mention tagging of anyone whether you are connected or not.
-    [b]system.directorytags[/b]
-        Set the number of keyword tags displayed on the directory page. Default is 50 unless set to a 
-        positive integer.
-    [b]system.disable_directory_keywords[/b]
-        If '1', do not show directory keywords. If the hub is a directory server, prevent returning
-        tags to any directory clients. Please do not set this for directory servers in the RED_GLOBAL realm. 
-    [b]system.disable_dreport[/b]
-        If '1', don't store or link to delivery reports
-    [b]system.startpage[/b]
-        Set the default page to be taken to after a login for all channels at
-        this website.  Can be overwritten by user settings.
-    [b]system.projecthome[/b]
-        Set the project homepage as the homepage of your hub. (Obsolete)
-    [b]system.auto_channel_create[/b]
-        Add the necessary form elements to create the first channel on the account registration page, and create it
-        (possibly following email validation or administrator approval). This precludes the ability to import a channel
-        from another site as the first channel created on this site for a new account. 
-        Use with system.default_permissions_role to streamline registration. 
-    [b]system.default_permissions_role[/b]
-        If set to a valid permissions role name, use that role for
-        the first channel created by a new account and don't ask for the "Channel Type" on
-        the channel creation form. Examples of valid names are: 'social', 'social_restricted', 'social_private', 
-        'forum', 'forum_restricted' and 'forum_private'. 
-        Read more about permissions roles [zrl=[baseurl]/help/roles]here[/zrl].
-    [b]system.default_photo_profile[/b]
-        Set the profile photo that new channels start with. This should contain the name of a directory located
-        under [font=courier]images/default_profile_photos/[/font], or be left unset. If not set then 'rainbow_man' is assumed.
-    [b]system.workflow_channel_next[/b]
-        The page to direct new members to immediately after creating a channel.
-    [b]system.workflow_register_next[/b]
-        The page to direct members to immediately after creating an account (only when auto_channel_create or UNO is enabled).
-    [b]system.max_daily_registrations[/b]
-        Set the maximum number of new registrations allowed on any day.
-        Useful to prevent oversubscription after a bout of publicity
-        for the project.
-    [b]system.tos_url[/b]
-        Set an alternative link for the ToS location.
-    [b]system.block_public_search[/b]
-        Similar to block_public, except only blocks public access to 
-        search features.  Useful for sites that want to be public, but
-        keep getting hammered by search engines.
-    [b]system.proc_run_use_exec[/b]
-        If 1, use the exec system call in proc_run to run background tasks. By default
-        we use proc_open and proc_close. On some (currently rare) systems this does not work well.
-    [b]system.paranoia[/b]
-        As the pconfig, but on a site-wide basis.  Can be overwritten
-        by member settings.
-    [b]system.transport_security_header[/b]
-        if non-zero and SSL is being used, include a strict-transport-security header on webpages
-    [b]system.poke_basic[/b]
-        Reduce the number of poke verbs to exactly 1 ("poke"). Disable other verbs. 
-    [b]system.openssl_conf_file[/b]
-        Specify a file containing OpenSSL configuration. Needed in some Windows installations to 
-        locate the openssl configuration file on the system. 
-        Read the code first. If you can't read the code, don't play with it.
-    [b]system.optimize_items[/b]
-        Runs optimise_table during some tasks to keep your database nice and 
-        defragmented.  This comes at a performance cost while the operations
-        are running, but also keeps things a bit faster while it's not.  
-        There also exist CLI utilities for performing this operation, which you
-        may prefer, especially if you're a large site.
-    [b]system.expire_limit[/b]
-        Don't expire any more than this number of posts per channel per
-        expiration run to keep from exhausting memory. Default 5000.
-    [b]system.dlogfile[/b]
-        Logfile to use for logging development errors.  Exactly the same as
-        logger otherwise.  This isn't magic, and requires your own logging
-        statements.  Developer tool.
-    [b]system.authlog[/b]
-        Logfile to use for logging auth errors.  Used to plug in to server
-        side software such as fail2ban.  Auth failures are still logged to
-        the main logs as well.
-    [b]system.hide_in_statistics[/b]
-        Tell the red statistics servers to completely hide this hub in hub lists.
-    [b]system.reserved_channels[/b]
-        Don't allow members to register channels with this comma separated
-        list of names (no spaces)
-    [b]system.auto_follow[/b]
-        Make the first channel of an account auto-follow channels listed here - comma separated list of webbies (member@hub addresses).
-    [b]system.admin_email[/b]
-        Specifies the administrator's email for this site.  This is initially set during install.
-    [b]system.cron_hour[/b]
-        Specify an hour in which to run cron_daily.  By default with no config, this will run at midnight UTC.
-    [b]system.minimum_feedcheck_minutes[/b]
-        The minimum interval between polling RSS feeds.  If this is lower than the cron interval, feeds
-        will be polled with each cronjob. Defaults to 60 if not set. The site setting can also be over-ridden
-        on a channel by channel basis by a service class setting aptly named 'minimum_feedcheck_minutes'.
-    [b]system.blacklisted_sites[/b]
-        An array of specific hubs to block from this hub completely.
-    [b]system.ignore_imagick[/b]
-        Ignore imagick and use GD, even if imagick is installed on the server. Prevents some issues with PNG files in older versions of imagick.
-    [b]system.no_age_restriction[/b]
-        Do not restrict registration to people over the age of 13. This carries legal responsibilities in 
-        many countries to require that age be provided and to block all personal information from minors, 
-        so please check your local laws before changing.  
-    [b]system.override_poll_lockfile[/b]
-        Ignore the lock file in the poller process to allow more than one process to run at a time.
-    [b]system.projecthome[/b]
-        Display the project page on your home page for logged out viewers.
-    [b]system.sellpage[/b]
-        A URL shown in the public sites list to sell your hub - display service classes, etc.
-    [b]randprofile.check[/b]
-        When requesting a random profile, check that it actually exists first
-    [b]randprofile.retry[/b]
-        Number of times to retry getting a random profile
-    [b]system.photo_cache_time[/b]
-        How long to cache photos, in seconds. Default is 86400 (1 day).
-        Longer time increases performance, but it also means it takes longer for changed permissions to apply.
-    [b]system.poco_rating_enable[/b]
-        Distributed reputation reporting and data collection may be disabled. If your site does not participate 
-        in distributed reputation you will also not be able to make use of the data from your connections on 
-        other sites. By default and in the absence of any setting it is enabled. Individual members can opt out 
-        by restricting who can see their connections or by not providing any reputation information for their 
-        connections.
-    [b]system.register_link[/b]
-        path to direct to from the "register" link on the login form. On closed sites this will direct to 
-        'pubsites'. For open sites it will normally redirect to 'register' but you may change this to a 
-        custom site page offering subscriptions or whatever. 
-    [b]system.max_import_size[/b]
-        If configured, the maximum length of an imported text message. This is normally left at 200Kbytes 
-        or more to accomodate Friendica private photos, which are embedded.
-    [b]system.tempdir[/b]
-        Place to store temporary files (currently unused), default is defined in the PHP configuration  
-    [b]system.uploaddir[/b]
-        Location to upload files (default is system.tempdir, currently used only by js_upload plugin)
-	[b]system.disable_discover_tab[/b]
-		This allows you to completely disable the ability to discover public content from external sites.
-	[b]system.sys_expire_days[/b]
-		How many days to keep discovered public content from other sites
-	[b]system.openssl_encrypt[/b]
-		Use openssl encryption engine, default is false (uses mcrypt for AES encryption)
-	[b]system.max_tagged_forums[/b]
-		Spam prevention. Limits the number of tagged forums which are recognised in any post. 
-		Default is 2. Only the first 'n' tags will be delivered as forums, the others will not cause any delivery. 
- 	[b]system.hide_help[/b]
-		Don't display help documentation link in nav bar
- 	[b]system.expire_delivery_reports[/b]
-		Expiration in days for delivery reports - default 10
-	[b]system.platform_name[/b] *
-		What to report as the platform name in webpages and statistics. (*) Must be set in .htconfig.php
-	[b]system.hide_version[/b] *
-		If true, do not report the software version on webpages and tools. (*) Must be set in .htconfig.php
-	[b]system.hidden_version_siteinfo[/b]
-		If true, do not report the software version on siteinfo pages (system.hide_version also hides 
-		the version on these pages, this setting *only* hides the version on siteinfo pages).
-	[b]system.email_notify_icon_url[/b]
-		URL of image (32x32) to display in email notifications (HTML bodies).
+[dl terms="mb"]
+  [*= system.directory_mode ]
+  [*= system.directory_primary ]
+  [*= system.directory_realm ]
+  [*= system.directory_server ]
+  [*= system.realm_token ]
+[/dl]
 
-[b]Directory config[/b]
-[b]Directory search defaults[/b]
-	[b]directory.safemode[/b]
-		0 or 1. 	
-    [b]directory.globaldir[/b]
-	    0 or 1. Default 0.  If you visit the directory on a site you'll just see the members of that site by default. You have to go through an extra step to see the people in the rest of the network; and by doing so there's a clear delineation that these people *aren't* members of that site but of a larger network.
-    [b]directory.pubforums[/b]
-	    0 or 1. Public forums *should* be default 0.
-[b]Directory server configuration (see [zrl=[baseurl]/help/directories]help/directories[/zrl])[/b]
-	[b]system.directory_server[/b]
-	[b]system.directory_primary[/b]
-	[b]system.directory_realm[/b]
-	[b]system.realm_token[/b]
-	[b]system.directory_mode[/b]
-
-
-
-
-		
 #include doc/macros/main_footer.bb;
 

--- a/doc/permissions.bb
+++ b/doc/permissions.bb
@@ -1,6 +1,6 @@
-[b]Permissions[/b]
-
+[h1]Permissions[/h1]
 Permissions in the $Projectname are more complete than you may be used to. This allows us to define more fine graded relationships than the black and white &quot;this person is my friend, so they can do everything&quot; or &quot;this person is not my friend, so they can't do anything&quot; permissions you may find elsewhere.
+
 
 [b]Default Permissions[/b]
 
@@ -13,89 +13,57 @@ Be aware that altering the scope of who can see your "public" items is a more or
 A more useful privacy setup is to leave "public" items visible to anybody on the internet; but force everything you create to be restricted. This can be done on your Channel Settings page by selecting the role "Social - restricted". This ensures a Default Privacy Group for all new contacts, and sets your Default Post Permissions to restrict all your posts to that group. We use the Default Post Permissions for everything you create - posts, photos, events, webpages, and everything else. However you can then edit the permissions when you create any individual thing and remove your default privacy group to make just that item visible to anybody.   
 
 
+[dl terms="l"]
+[*= The scopes of permissions are:]
+[dl terms="i"]
+  [*= Nobody Except Yourself ] This is self explanatory. Only you will be allowed access.
+  
+  [*= Only those you specifically allow ] By default, people you are not connected to, and all new contacts will   have this permission denied. You will be able to make exceptions for individual channels on their contact edit   screen.
+  
+  [*= Anybody in your address book ] Anybody you do not know will have this permission denied, but anybody you   accept as a contact will have this permission approved. This is the way most legacy platforms handle   permissions.
+  
+  [*= Anybody On This Hub ] Anybody using the same hub as you will have permission approved. Anybody who   registered at a different hub will have this permission denied.
+  
+  [*= Anybody in this network ] Anybody in the $Projectname will have this permission approved. Even complete   strangers. However, anybody not logged in/authenticated will have this permission denied.
+  
+  [*= Anybody authenticated ] This is similar to "anybody in this network" except that it can include anybody   who can authenticate by any means - and therefore may include visitors from other networks.
+  
+  [*= Anybody on the internet ] Completely public. This permission will be approved for anybody at all.
+[/dl]
+[*= The individual permissions are:]
+[dl terms="i"]
+  [*= Can view my &quot;public&quot; stream and posts. ] This permision determines who can view your channel &quot;stream&quot; that is, the non-private posts that appear on the &quot;home&quot; tab when you're logged in.
 
-The scopes of permissions are:
+  [*= Can view my &quot;public&quot; channel profile. ] This permission determines who can view your channel's profile. This refers to the &quot;about&quot; tab
 
-[li]Nobody Except Yourself. This is self explanatory. Only you will be allowed access.[/li]
+  [*= Can view my &quot;public&quot; photo albums. ] This permission determines who can view your photo albums. Individual photographs may still be posted to a more private audience.
 
-[li]Only those you specifically allow. By default, people you are not connected to, and all new contacts will have this permission denied. You will be able to make exceptions for individual channels on their contact edit screen.[/li]
+  [*= Can view my &quot;public&quot; address book. ] This permission determines who can view your contacts. These are the connections displayed in the &quot;View connections&quot; section.
 
-[li]Anybody in your address book. Anybody you do not know will have this permission denied, but anybody you accept as a contact will have this permission approved. This is the way most legacy platforms handle permissions.[/li]
+  [*= Can view my &quot;public&quot; file storage. ] This permission determines who can view your public files stored in your cloud.
 
-[li]Anybody On This Hub. Anybody using the same hub as you will have permission approved. Anybody who registered at a different hub will have this permission denied.[/li]
+  [*= Can view my &quot;public&quot; pages. ] This permission determines who can view your public web pages. 
 
-[li]Anybody in this network. Anybody in the $Projectname will have this permission approved. Even complete strangers. However, anybody not logged in/authenticated will have this permission denied.[/li]
+  [*= Can send me their channel stream and posts. ] This permission determines whose posts you will view. If your channel is a personal channel (ie, you as a person), you would probably want to set this to &quot;anyone in my address book&quot; at a minimum. A personal notes channel would probably want to choose &quot;nobody except myself&quot;. Setting this to &quot;Anybody in the network&quot; will show you posts from complete strangers, which is a good form of discovery.
 
-[li]Anybody authenticated. This is similar to "anybody in this network" except that it can include anybody who can authenticate by any means - and therefore may include visitors from other networks.[/li]
+  [*= Can post on my channel page (&quot;wall&quot;). ] This permission determines who can write to your wall when clicking through to your channel.
 
-[li]Anybody on the internet. Completely public. This permission will be approved for anybody at all.[/li]
+  [*= Can comment on my posts. ] This permission determines who can comment on posts you create. Normally, you would want this to match your &quot;can view my public stream and posts&quot; permission
 
-The individual permissions are:
+  [*= Can send me private mail messages. ] This determines who can send you private messages (zotmail).
 
-[i]Can view my &quot;public&quot; stream and posts.[/i]
+  [*= Can post photos to my photo albums. ] This determines who can post photographs in your albums. This is very useful for forum-like channels where connections may not be connected to each other.
 
-This permision determines who can view your channel &quot;stream&quot; that is, the non-private posts that appear on the &quot;home&quot; tab when you're logged in.
+  [*= Can forward to all my channel contacts via post tags. ] Using @- mentions will reproduce a copy of your post on the profile specified, as though you posted on the channel wall. This determines if people can post to your channel in this way.
 
-[i]Can view my &quot;public&quot; channel profile.[/i]
+  [*= Can chat with me (when available). ] This determines who can join the public chat rooms created by your channel.
 
-This permission determines who can view your channel's profile. This refers to the &quot;about&quot; tab
+  [*= Can write to my &quot;public&quot; file storage. ] This determines who can upload files to your public file storage, or 'cloud'.
 
-[i]Can view my &quot;public&quot; photo albums.[/i]
+  [*= Can edit my &quot;public&quot; pages. ] This determines who can edit your webpages. This is useful for wikis or sites with multiple editors.
 
- This permission determines who can view your photo albums. Individual photographs may still be posted to a more private audience.
-
-[i]Can view my &quot;public&quot; address book.[/i]
-
-This permission determines who can view your contacts. These are the connections displayed in the &quot;View connections&quot; section.
-
-[i]Can view my &quot;public&quot; file storage.[/i]
-
-This permission determines who can view your public files stored in your cloud.
-
-[i]Can view my &quot;public&quot; pages.[/i]
-
-This permission determines who can view your public web pages. 
-
-[i]Can send me their channel stream and posts.[/i]
-
-This permission determines whose posts you will view. If your channel is a personal channel (ie, you as a person), you would probably want to set this to &quot;anyone in my address book&quot; at a minimum. A personal notes channel would probably want to choose &quot;nobody except myself&quot;. Setting this to &quot;Anybody in the network&quot; will show you posts from complete strangers, which is a good form of discovery.
-
-[i]Can post on my channel page (&quot;wall&quot;).[/i]
-
-This permission determines who can write to your wall when clicking through to your channel.
-
-[i]Can comment on my posts.[/i]
-
-This permission determines who can comment on posts you create. Normally, you would want this to match your &quot;can view my public stream and posts&quot; permission
-
-[i]Can send me private mail messages.[/i]
-
-This determines who can send you private messages (zotmail).
-
-[i]Can post photos to my photo albums.[/i]
-
-This determines who can post photographs in your albums. This is very useful for forum-like channels where connections may not be connected to each other.
-
-[i]Can forward to all my channel contacts via post tags.[/i]
-
-Using @- mentions will reproduce a copy of your post on the profile specified, as though you posted on the channel wall. This determines if people can post to your channel in this way.
-
-[i]Can chat with me (when available).[/i]
-
-This determines who can join the public chat rooms created by your channel.
-
-[i]Can write to my &quot;public&quot; file storage.[/i]
-
-This determines who can upload files to your public file storage, or 'cloud'.
-
-[i]Can edit my &quot;public&quot; pages.[/i]
-
-This determines who can edit your webpages. This is useful for wikis or sites with multiple editors.
-
-[i]Can administer my channel resources.[/i]
-
-This determines who can have full control of your channel. This should normally be set to &quot;nobody except myself&quot;.
-
+  [*= Can administer my channel resources. ] This determines who can have full control of your channel. This should normally be set to &quot;nobody except myself&quot;.
+[/dl][/dl]
 [i]Note:[/i]
 Plugins/addons may provide special permission settings, so you may be offered additional permission settings beyond what is described here.
 

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -360,14 +360,16 @@ function bb_definitionList($match) {
 
 	// The bbcode transformation will be:
 	// [*=term-text] description-text   =>   </dd> <dt>term-text<dt><dd> description-text
-	// then after all replacements have been made, the </dd> remaining the start of the 
-	// string can be removed. HTML5 allows the missing end tag.
+	// then after all replacements have been made, the extra </dd> at the start of the 
+	// first line can be removed. HTML5 allows the tag to be missing from the end of the last line.
 	// Using '(?<!\\\)' to allow backslash-escaped closing braces to appear in the term-text.
 	$closeDescriptionTag = "</dd>\n";
+	$eatLeadingSpaces = '(?:&nbsp;|[ \t])*'; // prevent spaces infront of [*= from adding another line to the previous element
+	$listElements = preg_replace('/^(\n|<br \/>)/', '', $match[2]); // ltrim the first newline
 	$listElements = preg_replace(
-		'/\[\*=([[:print:]]*?)(?<!\\\)\]/ism', 
+		'/' . $eatLeadingSpaces . '\[\*=([[:print:]]*?)(?<!\\\)\]/ism', 
 		$closeDescriptionTag . '<dt>$1</dt><dd>', 
-		$match[2]
+		$listElements
 	);
 	// Unescape any \] inside the <dt> tags
 	$listElements = preg_replace_callback('/<dt>(.*?)<\/dt>/ism', 'bb_definitionList_unescapeBraces', $listElements);

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -345,6 +345,46 @@ function bb_spoilertag($match) {
 	return '<div onclick="openClose(\'opendiv-' . $rnd . '\'); return false;" class="fakelink">' . $openclose . '</div><blockquote id="opendiv-' . $rnd . '" style="display: none;">' . $text . '</blockquote>';
 }
 
+function bb_definitionList($match) {
+	// $match[1] is the markup styles for the "terms" in the definition list.
+	// $match[2] is the content between the [dl]...[/dl] tags
+
+	$classes = '';
+	if (stripos($match[1], "b") !== false) $classes .= 'dl-terms-bold ';
+	if (stripos($match[1], "i") !== false) $classes .= 'dl-terms-italic ';
+	if (stripos($match[1], "u") !== false) $classes .= 'dl-terms-underline ';
+	if (stripos($match[1], "l") !== false) $classes .= 'dl-terms-large ';
+	if (stripos($match[1], "m") !== false) $classes .= 'dl-terms-monospace ';
+	if (stripos($match[1], "h") !== false) $classes .= 'dl-horizontal '; // dl-horizontal is already provided by bootstrap
+	if (strlen($classes) === 0) $classes = "dl-terms-plain";
+
+	// The bbcode transformation will be:
+	// [*=term-text] description-text   =>   </dd> <dt>term-text<dt><dd> description-text
+	// then after all replacements have been made, the </dd> remaining the start of the 
+	// string can be removed. HTML5 allows the missing end tag.
+	// Using '(?<!\\\)' to allow backslash-escaped closing braces to appear in the term-text.
+	$closeDescriptionTag = "</dd>\n";
+	$listElements = preg_replace(
+		'/\[\*=([[:print:]]*?)(?<!\\\)\]/ism', 
+		$closeDescriptionTag . '<dt>$1</dt><dd>', 
+		$match[2]
+	);
+	// Unescape any \] inside the <dt> tags
+	$listElements = preg_replace_callback('/<dt>(.*?)<\/dt>/ism', 'bb_definitionList_unescapeBraces', $listElements);
+	
+	// Remove the extra </dd> at the start of the string, if there is one.
+	$firstOpenTag  = strpos($listElements, '<dd>');
+	$firstCloseTag = strpos($listElements, $closeDescriptionTag);
+	if ($firstCloseTag !== false && ($firstOpenTag === false || ($firstCloseTag < $firstOpenTag))) {		
+		$listElements = preg_replace( '/<\/dd>/ism', '', $listElements, 1);
+	}
+
+	return '<dl class="bb-dl ' . rtrim($classes) . '">' . $listElements . '</dl>';;
+}
+function bb_definitionList_unescapeBraces($match) {
+	return '<dt>' . str_replace('\]', ']', $match[1]) . '</dt>';
+}
+
 /**
  * @brief Sanitize style properties from BBCode to HTML.
  *
@@ -713,6 +753,7 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $cache = false) 
 	while ((((strpos($Text, "[/list]") !== false) && (strpos($Text, "[list") !== false)) ||
 			((strpos($Text, "[/ol]") !== false) && (strpos($Text, "[ol]") !== false)) ||
 			((strpos($Text, "[/ul]") !== false) && (strpos($Text, "[ul]") !== false)) ||
+			((strpos($Text, "[/dl]") !== false) && (strpos($Text, "[dl")  !== false)) ||
 			((strpos($Text, "[/li]") !== false) && (strpos($Text, "[li]") !== false))) && (++$endlessloop < 20)) {
 		$Text = preg_replace("/\[list\](.*?)\[\/list\]/ism", '<ul class="listbullet" style="list-style-type: circle;">$1</ul>', $Text);
 		$Text = preg_replace("/\[list=\](.*?)\[\/list\]/ism", '<ul class="listnone" style="list-style-type: none;">$1</ul>', $Text);
@@ -724,6 +765,13 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $cache = false) 
 		$Text = preg_replace("/\[ul\](.*?)\[\/ul\]/ism", '<ul class="listbullet" style="list-style-type: circle;">$1</ul>', $Text);
 		$Text = preg_replace("/\[ol\](.*?)\[\/ol\]/ism", '<ul class="listdecimal" style="list-style-type: decimal;">$1</ul>', $Text);
 		$Text = preg_replace("/\[li\](.*?)\[\/li\]/ism", '<li>$1</li>', $Text);
+
+		// [dl] tags have an optional [dl terms="bi"] form where bold/italic/underline/mono/large
+		// etc. style may be specified for the "terms" in the definition list. The quotation marks 
+		// are also optional. The regex looks intimidating, but breaks down as: 
+		//   "[dl" <optional-whitespace> <optional-termStyles> "]" <matchGroup2> "[/dl]"
+		// where optional-termStyles are: "terms=" <optional-quote> <matchGroup1> <optional-quote>
+		$Text = preg_replace_callback('/\[dl[[:space:]]*(?:terms=(?:&quot;|")?([a-zA-Z]+)(?:&quot;|")?)?\](.*?)\[\/dl\]/ism', 'bb_definitionList', $Text);
 	}
 	if (strpos($Text,'[th]') !== false) {
 		$Text = preg_replace("/\[th\](.*?)\[\/th\]/sm", '<th>$1</th>', $Text);

--- a/view/js/autocomplete.js
+++ b/view/js/autocomplete.js
@@ -265,7 +265,7 @@ function string2bb(element) {
 	$.fn.bbco_autocomplete = function(type) {
 
 		if(type=='bbcode') {
-			var open_close_elements = ['bold', 'italic', 'underline', 'overline', 'strike', 'superscript', 'subscript', 'quote', 'code', 'open', 'spoiler', 'map', 'nobb', 'list', 'ul', 'ol', 'li', 'table', 'tr', 'th', 'td', 'center', 'color', 'font', 'size', 'zrl', 'zmg', 'rpost', 'qr', 'observer'];
+			var open_close_elements = ['bold', 'italic', 'underline', 'overline', 'strike', 'superscript', 'subscript', 'quote', 'code', 'open', 'spoiler', 'map', 'nobb', 'list', 'ul', 'ol', 'dl', 'li', 'table', 'tr', 'th', 'td', 'center', 'color', 'font', 'size', 'zrl', 'zmg', 'rpost', 'qr', 'observer'];
 			var open_elements = ['observer.baseurl', 'observer.address', 'observer.photo', 'observer.name', 'observer.webname', 'observer.url', '*', 'hr',  ];
 
 			var elements = open_close_elements.concat(open_elements);

--- a/view/theme/redbasic/css/style.css
+++ b/view/theme/redbasic/css/style.css
@@ -1827,6 +1827,27 @@ nav .badge.mail-update:hover {
 	margin-top:-3px;
 }
 
+dl.bb-dl > dt { 
+	/* overriding the default dl style from bootstrap, as bootstrap's
+	   style of a bold unindented line followed by a plain unindented
+	   line is already acheivable in bbcode without dl */
+	font-weight: normal; 
+} 
+dl.dl-terms-monospace > dt { font-family:     monospace; }
+dl.dl-terms-bold      > dt { font-weight:     bold; }
+dl.dl-terms-italic    > dt { font-style:      italic; }
+dl.dl-terms-underline > dt { text-decoration: underline; }
+dl.dl-terms-large     > dt { font-size:       120%; }
+dl.bb-dl:not(.dl-horizontal) > dd {
+	display: block;
+	margin-left: 2em;
+}
+dl.bb-dl > dd > li {
+	/* adding some indent so bullet-list items will line up better with 
+	   dl descriptions if someone wants to be impure and combine them */
+	margin-left: 1em;
+}
+
 .bootstrap-tagsinput .tag:before {
 	/* Copied from icon-asterisk, is there a better way to do it? */
 	font-family: FontAwesome;


### PR DESCRIPTION
People's Wall posts probably don't need definition lists, but documentation pages frequently do and most are in bbcode.

This started with not being able to fix the formatting in `hidden_configs.bb`, so I've marked that up with [dl] tags, along with another page that had some formatting issues - if anyone wants to see how it renders  (`/help/hidden_configs` and `/help/permissions`).

Simple syntax is:
```
[dl]
[*= item  ] description
[*= item2 ] description2
[/dl]
```
The full syntax is mentioned in `bbcode.html` (which I assumed is now written/maintained in html by hand rather than generated from somewhere else?) 

I don't know how conservative people are with additions to the bbcode parser, this [dl] addition is mostly self-contained in its own function.