### PR TITLE
Refining the Permission settings dialog

### DIFF
--- a/Zotlabs/Module/Channel.php
+++ b/Zotlabs/Module/Channel.php
@@ -132,7 +132,7 @@ function get($update = 0, $load = false) {
 			// the "Show"  button on a group does not post it to the feed of people in that group, it
 			// mearly allows those people to view the post if they are viewing/following this channel.
 			$aclDesc = t('Post permissions <b>cannot be changed</b> after a post is sent.</br />These permissions set who is allowed to view the post.');
-			$aclContextHelpCmd = '';
+			$aclContextHelpCmd = 'acl_dialog_post';
 
 			$x = array(
 				'is_owner' => $is_owner,

--- a/Zotlabs/Module/Channel.php
+++ b/Zotlabs/Module/Channel.php
@@ -126,13 +126,21 @@ function get($update = 0, $load = false) {
 
 		if($perms['post_wall']) {
 
+			// I'm trying to make two points in this description text - warn about finality of wall
+			// post permissions, and try to clear up confusion that these permissions set who is
+			// *shown* the post, istead of who is able to see the post, i.e. make it clear that clicking
+			// the "Show"  button on a group does not post it to the feed of people in that group, it
+			// mearly allows those people to view the post if they are viewing/following this channel.
+			$aclDesc = t('Post permissions <b>cannot be changed</b> after a post is sent.</br />These permissions set who is allowed to view the post.');
+			$aclContextHelpCmd = '';
+
 			$x = array(
 				'is_owner' => $is_owner,
 				'allow_location' => ((($is_owner || $observer) && (intval(get_pconfig(\App::$profile['profile_uid'],'system','use_browser_location')))) ? true : false),
 				'default_location' => (($is_owner) ? \App::$profile['channel_location'] : ''),
 				'nickname' => \App::$profile['channel_address'],
 				'lockstate' => (((strlen(\App::$profile['channel_allow_cid'])) || (strlen(\App::$profile['channel_allow_gid'])) || (strlen(\App::$profile['channel_deny_cid'])) || (strlen(\App::$profile['channel_deny_gid']))) ? 'lock' : 'unlock'),
-				'acl' => (($is_owner) ? populate_acl($channel_acl,true,((\App::$profile['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : '')) : ''),
+				'acl' => (($is_owner) ? populate_acl($channel_acl,true,((\App::$profile['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), $aclDesc, $aclContextHelpCmd) : ''),
 				'showacl' => (($is_owner) ? 'yes' : ''),
 				'bang' => '',
 				'visitor' => (($is_owner || $observer) ? true : false),

--- a/Zotlabs/Module/Network.php
+++ b/Zotlabs/Module/Network.php
@@ -161,7 +161,7 @@ class Network extends \Zotlabs\Web\Controller {
 			// the "Show"  button on a group does not post it to the feed of people in that group, it
 			// mearly allows those people to view the post if they are viewing/following this channel.
 			$aclDesc = t('Post permissions <b>cannot be changed</b> after a post is sent.</br />These permissions set who is allowed to view the post.');
-			$aclContextHelpCmd = '';
+			$aclContextHelpCmd = 'acl_dialog_post';
 	
 			$channel_acl = array(
 				'allow_cid' => $channel['channel_allow_cid'], 

--- a/Zotlabs/Module/Network.php
+++ b/Zotlabs/Module/Network.php
@@ -154,6 +154,14 @@ class Network extends \Zotlabs\Web\Controller {
 			}
 	
 			nav_set_selected('network');
+
+			// I'm trying to make two points in this description text - warn about finality of wall
+			// post permissions, and try to clear up confusion that these permissions set who is
+			// *shown* the post, istead of who is able to see the post, i.e. make it clear that clicking
+			// the "Show"  button on a group does not post it to the feed of people in that group, it
+			// mearly allows those people to view the post if they are viewing/following this channel.
+			$aclDesc = t('Post permissions <b>cannot be changed</b> after a post is sent.</br />These permissions set who is allowed to view the post.');
+			$aclContextHelpCmd = '';
 	
 			$channel_acl = array(
 				'allow_cid' => $channel['channel_allow_cid'], 
@@ -161,7 +169,7 @@ class Network extends \Zotlabs\Web\Controller {
 				'deny_cid'  => $channel['channel_deny_cid'], 
 				'deny_gid'  => $channel['channel_deny_gid']
 			); 
-	
+
 			$private_editing = ((($group || $cid) && (! intval($_GET['pf']))) ? true : false);
 	
 			$x = array(
@@ -170,7 +178,7 @@ class Network extends \Zotlabs\Web\Controller {
 				'default_location' => $channel['channel_location'],
 				'nickname'         => $channel['channel_address'],
 				'lockstate'        => (($private_editing || $channel['channel_allow_cid'] || $channel['channel_allow_gid'] || $channel['channel_deny_cid'] || $channel['channel_deny_gid']) ? 'lock' : 'unlock'),
-				'acl'              => populate_acl((($private_editing) ? $def_acl : $channel_acl), true, (($channel['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : '')),
+				'acl'              => populate_acl((($private_editing) ? $def_acl : $channel_acl), true, (($channel['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), $aclDesc, $aclContextHelpCmd),
 				'bang'             => (($private_editing) ? '!' : ''),
 				'visitor'          => true,
 				'profile_uid'      => local_channel(),

--- a/doc/acl_dialog_post.html
+++ b/doc/acl_dialog_post.html
@@ -1,0 +1,13 @@
+<!-- Network and channel posts cannot change their permissions after being sent, this help
+     file is for items of that nature. Files and photos etc should use a different help file. -->
+
+<h2>Post Permissions</h2>
+
+<p>Sometimes called Access Control List, or ACL, the permissions set who is able to see your new post.</p>
+
+<p>Pressing the ACL button (<i class="fa fa-lock"></i> or <i class="fa fa-unlock"></i>) beside the Submit button will display a dialog in which you can select what channels and/or privacy groups can see the post. You can also select who is explicitly denied access. For example, say you are planning a surprise party for a friend. You can send an invitation post to everyone in your <b>Friends</b> group <i>except</i> the friend you are surprising. In this case you "Show" the <b>Friends</b> group but "Don't show" that one person.
+
+<h3>Why can't I edit a post's permissions after I saved it?</h3>
+
+<p>You are able to change permissons to your files, photos and the likes, but not to posts after you have saved them. The main reason is: Once you have saved a post it is being distributed either to the public channel and from there to other Hubzilla servers or to those you intended it to go. Just like you cannot reclaim something you gave to another person, you cannot change permissions to Hubzilla posts. We would need to track everywhere your posting goes, keep track of everyone you allowed to see it and then keep track of from whom to delete it.</p>
+<p>If a posting is public this is even harder, as the Hubzilla is a global network and there is no way to follow a post, let alone reclaim it reliably. Other networks that may receive your post have no reliable way to delete or reclaim the post.</p>

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -217,7 +217,7 @@ function fixacl(&$item) {
 * @param boolean $show_jotnets Whether plugins for federated networks should be included in the permissions dialog
 * @param string $showall_caption An optional caption to describe the scope of an unrestricted post. e.g. "Public"
 * @param string $dialog_description Optional message to include at the top of the dialog. E.g. "Warning: Post permissions cannot be changed once sent".
-* @param string $context_help Allows the dialog to present a context sensitive help icon. E.g. "photos/permissions"
+* @param string $context_help Allows the dialog to present a help icon. E.g. "acl_dialog_post"
 * @param boolean $readonly Not implemented yet. When implemented, the dialog will use acl_readonly.tpl instead, so that permissions may be viewed for posts that can no longer have their permissions changed.
 *
 * @return string html modal dialog build from acl_selector.tpl
@@ -253,7 +253,7 @@ function populate_acl($defaults = null,$show_jotnets = true, $showall_caption = 
 	$o = replace_macros($tpl, array(
 		'$showall'         => $showall_caption,
 		'$showlimited'     => t("Limit access:"),
-		'$showlimitedDesc' => t('Select "Show" to allow access. "Don\'t show" lets you override and limit the scope of "Show".'),
+		'$showlimitedDesc' => t('Select "Show" to allow viewing. "Don\'t show" lets you override and limit the scope of "Show".'),
 		'$show'	           => t("Show"),
 		'$hide'	           => t("Don't show"),
 		'$search'          => t("Search"),
@@ -266,7 +266,7 @@ function populate_acl($defaults = null,$show_jotnets = true, $showall_caption = 
 		'$aclModalTitle'   => t('Permissions'),
 		'$aclModalDesc'    => $dialog_description,
 		'$aclModalDismiss' => t('Close'),
-		'$helpUrl'         => (($context_help == '') ? '' : (z_root() . '/help?f=&cmd=' . $context_help))
+		'$helpUrl'         => (($context_help == '') ? '' : (z_root() . '/help/' . $context_help))
 	));
 
 	return $o;

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -210,12 +210,24 @@ function fixacl(&$item) {
 	$item = str_replace(array('<','>'),array('',''),$item);
 }
 
-function populate_acl($defaults = null,$show_jotnets = true, $showall = '') {
+/**
+* Builds a modal dialog for editing permissions, using acl_selector.tpl as the template.
+*
+* @param array $default Optional access control list for the initial state of the dialog.
+* @param boolean $show_jotnets Whether plugins for federated networks should be included in the permissions dialog
+* @param string $showall_caption An optional caption to describe the scope of an unrestricted post. e.g. "Public"
+* @param string $dialog_description Optional message to include at the top of the dialog. E.g. "Warning: Post permissions cannot be changed once sent".
+* @param string $context_help Allows the dialog to present a context sensitive help icon. E.g. "photos/permissions"
+* @param boolean $readonly Not implemented yet. When implemented, the dialog will use acl_readonly.tpl instead, so that permissions may be viewed for posts that can no longer have their permissions changed.
+*
+* @return string html modal dialog build from acl_selector.tpl
+*/
+function populate_acl($defaults = null,$show_jotnets = true, $showall_caption = '', $dialog_description = '', $context_help = '', $readonly = false) {
 
 	$allow_cid = $allow_gid = $deny_cid = $deny_gid = false;
 
-	if(! $showall)
-		$showall = t('Visible to your default audience');
+	if(! $showall_caption)
+		$showall_caption = t('Visible to your default audience');
 
 	if(is_array($defaults)) {
 		$allow_cid = ((strlen($defaults['allow_cid'])) 
@@ -239,9 +251,12 @@ function populate_acl($defaults = null,$show_jotnets = true, $showall = '') {
 
 	$tpl = get_markup_template("acl_selector.tpl");
 	$o = replace_macros($tpl, array(
-		'$showall'         => $showall,
+		'$showall'         => $showall_caption,
+		'$showlimited'     => t("Limit access:"),
+		'$showlimitedDesc' => t('Select "Show" to allow access. "Don\'t show" lets you override and limit the scope of "Show".'),
 		'$show'	           => t("Show"),
 		'$hide'	           => t("Don't show"),
+		'$search'          => t("Search"),
 		'$allowcid'        => json_encode($allow_cid),
 		'$allowgid'        => json_encode($allow_gid),
 		'$denycid'         => json_encode($deny_cid),
@@ -249,7 +264,9 @@ function populate_acl($defaults = null,$show_jotnets = true, $showall = '') {
 		'$jnetModalTitle'  => t('Other networks and post services'),
 		'$jotnets'         => $jotnets,
 		'$aclModalTitle'   => t('Permissions'),
-		'$aclModalDismiss' => t('Close')
+		'$aclModalDesc'    => $dialog_description,
+		'$aclModalDismiss' => t('Close'),
+		'$helpUrl'         => (($context_help == '') ? '' : (z_root() . '/help?f=&cmd=' . $context_help))
 	));
 
 	return $o;

--- a/view/theme/redbasic/css/style.css
+++ b/view/theme/redbasic/css/style.css
@@ -912,19 +912,43 @@ a.rconnect:hover, a.rateme:hover, div.rateme:hover {
 	clear: both;
 }
 
+.modal-header .contextual-help-tool {
+	/* Mostly duplicating ".modal-header .close" and ".close" layout settings from bootstrap */
+	float: right;
+	font-size: 21px;
+	padding: 0;
+	margin-top: -4px;
+	margin-right: 15px;
+	line-height: 1;
+}
+
 #acl-search {
-	margin-top: 20px;
-	padding: 8px;
+	padding: 4px;
 	border: 1px solid #ccc;
-	width: 100%;
+	width: 90%; /* fallback if browser does not support calc() */
+	width: calc(100% - 10px);
+	margin: 0px 0px 10px 10px;
 }
 
 #acl-search::-webkit-input-placeholder {
-	font-family: FontAwesome;
+	/* non-fontawesome fonts set a fallback for text parts of the placeholder*/
+	font-family: FontAwesome, sans-serif, arial, freesans;
 }
 
 #acl-search::-moz-placeholder {
-	font-family: FontAwesome;
+	/* non-fontawesome fonts set a fallback for text parts of the placeholder*/
+	font-family: FontAwesome, sans-serif, arial, freesans;
+}
+
+#acl-dialog-description {
+	font-size: 90%;
+	color: #888;
+}
+#acl-showlimited-description {
+	font-size: 90%;
+	color: #888;
+	margin-left: 10px;
+	margin-bottom: 4px;
 }
 
 #acl-list {
@@ -933,11 +957,11 @@ a.rconnect:hover, a.rateme:hover, div.rateme:hover {
 	overflow: auto;
 	clear: both;
 	min-height: 62px;
-	margin-top: 20px;
 	padding: 10px 10px 0px 0px;
 	-webkit-border-radius: $radiuspx ;
 	-moz-border-radius: $radiuspx;
 	border-radius: $radiuspx;
+	background-color: rgb(238,238,238);
 }
 
 #jotnets-wrapper, #jotnets-collapse {
@@ -957,6 +981,7 @@ a.rconnect:hover, a.rateme:hover, div.rateme:hover {
 	-webkit-border-radius: $radiuspx ;
 	-moz-border-radius: $radiuspx;
 	border-radius: $radiuspx;
+	background-color: white;
 }
 
 .acl-list-item.grouphide {
@@ -993,6 +1018,26 @@ a.rconnect:hover, a.rateme:hover, div.rateme:hover {
 .acl-button-hide {
 	float: right;
 	margin-left: 5px;
+}
+
+#acl-showlimited-caption,
+#acl-showall-caption {
+	font-size: 115%;
+}
+
+#acl-radiowrapper-showall {
+	margin-bottom: 20px;
+}
+#acl-radiowrapper-showlimited {
+	margin-bottom: 0;
+}
+
+#acl-showall + i {
+	font-size: 140%;
+}
+
+#acl-showall-caption {
+	margin-left: 0.35em;
 }
 
 .contact-block-content {

--- a/view/theme/redbasic/css/style.css
+++ b/view/theme/redbasic/css/style.css
@@ -940,10 +940,19 @@ a.rconnect:hover, a.rateme:hover, div.rateme:hover {
 	font-family: FontAwesome, sans-serif, arial, freesans;
 }
 
+#aclModal .modal-body {
+	padding-top: 10px;
+}
+
 #acl-dialog-description {
 	font-size: 90%;
 	color: #888;
+	padding-bottom: 4px;
 }
+#acl-dialog-description b {
+	color: black;
+}
+
 #acl-showlimited-description {
 	font-size: 90%;
 	color: #888;
@@ -1026,6 +1035,7 @@ a.rconnect:hover, a.rateme:hover, div.rateme:hover {
 }
 
 #acl-radiowrapper-showall {
+	margin-top: 20px;
 	margin-bottom: 20px;
 }
 #acl-radiowrapper-showlimited {

--- a/view/tpl/acl_selector.tpl
+++ b/view/tpl/acl_selector.tpl
@@ -3,9 +3,13 @@
 		<div class="modal-content">
 			<div class="modal-header">
 				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-				<h4 class="modal-title">{{$aclModalTitle}}</h4>
+				{{if $helpUrl}}
+				<a type="button" target="hubzilla-help" href="{{$helpUrl}}" class="contextual-help-tool" title="Help and documentation"><i class="fa fa-question-circle-o"></i></a>
+				{{/if}}
+				<h4 class="modal-title"><i id="dialog-perms-icon" class="fa fa-fw"></i> {{$aclModalTitle}}</h4>
 			</div>
 			<div class="modal-body">
+				<div id="acl-dialog-description">{{$aclModalDesc}}</div>
 				{{if $jotnets}}
 				<div class="jotnets-wrapper" role="tab" id="jotnets-wrapper">
 					<a data-toggle="collapse" class="btn btn-block btn-default" href="#jotnets-collapse" aria-expanded="false" aria-controls="jotnets-collapse">{{$jnetModalTitle}} <span class="caret"></span></a>
@@ -16,11 +20,24 @@
 				</div>
 				{{/if}}
 				<div id="acl-wrapper">
-					<button id="acl-showall" class="btn btn-block btn-default"><i class="fa fa-globe"></i> {{$showall}}</button>
-					<input type="text" id="acl-search" placeholder="&#xf002;">
-					<div id="acl-list">
-						<div id="acl-list-content"></div>
+					<div id="acl-radiowrapper-showall" class="radio">
+					  <label>
+					    <input id="acl-showall" type="radio" name="optionsRadios" value="option1" checked>
+					    <i class="fa fa-globe"></i><span id=acl-showall-caption>{{$showall}}</span>
+					  </label>
 					</div>
+					<div id="acl-radiowrapper-showlimited" class="radio">
+						<label>
+							<input id="acl-showlimited" type="radio" name="optionsRadios" style="readonly" value="option2">
+							<span id=acl-showlimited-caption>{{$showlimited}}</span>
+					    </label>
+						<div id="acl-list">
+							<input type="text" id="acl-search" placeholder="&#xf002; {{$search}}">
+							<div id=acl-showlimited-description>{{$showlimitedDesc}}</div>
+							<div id="acl-list-content"></div>
+						</div>
+					</div>
+
 					<span id="acl-fields"></span>
 				</div>
 

--- a/view/tpl/acl_selector.tpl
+++ b/view/tpl/acl_selector.tpl
@@ -4,12 +4,14 @@
 			<div class="modal-header">
 				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 				{{if $helpUrl}}
-				<a type="button" target="hubzilla-help" href="{{$helpUrl}}" class="contextual-help-tool" title="Help and documentation"><i class="fa fa-question-circle-o"></i></a>
+				<a type="button" target="hubzilla-help" href="{{$helpUrl}}" class="contextual-help-tool" title="Help and documentation"><i class="fa fa-question"></i></a>
 				{{/if}}
 				<h4 class="modal-title"><i id="dialog-perms-icon" class="fa fa-fw"></i> {{$aclModalTitle}}</h4>
 			</div>
 			<div class="modal-body">
-				<div id="acl-dialog-description">{{$aclModalDesc}}</div>
+				{{if $aclModalDesc}}
+					<div id="acl-dialog-description">{{$aclModalDesc}}</div>
+				{{/if}}
 				{{if $jotnets}}
 				<div class="jotnets-wrapper" role="tab" id="jotnets-wrapper">
 					<a data-toggle="collapse" class="btn btn-block btn-default" href="#jotnets-collapse" aria-expanded="false" aria-controls="jotnets-collapse">{{$jnetModalTitle}} <span class="caret"></span></a>


### PR DESCRIPTION
![hubzilla permissions dialog](https://cloud.githubusercontent.com/assets/6390507/15021873/77a802f4-126c-11e6-94a5-fadf1b34a2f9.png)

This pull-request might look like meaningless bike-shedding changes if someone already knows how Hubzilla permissions work, but I'm trying to make the permission system deducible from the user interface.

I could sorta guess how things most likely worked, but not being certain, and flip-flopping a few times in my interpretation undermined my trust in the permissions. I ended up reading the code to find out and to have some certainty.

I won't assume these changes are an improvement for everyone, they add a little bit of clutter, so I'm going to post waaay too much text about the rationale and problem each change solves - that way alternative proposals can also address these problems:

To put yourself in the head of a new user, imagine the following:

> You can see there's some kind of relationship between the "Public" button and the "Show"/ "Don't show" buttons, but can't be certain what it is - the "Public" colour sometimes changes, but it's not clear what orange or white means.

> You click public, then click a "show" button - which shouldn't stop it from being public because you haven't set anything to "Don't show", but the public button changes colour anyway.

> So perhaps "Show" is setting something slightly different to public-ness? The word "Show" suggests an active role - perhaps the "Show" buttons are for which channels are notified of the post - where it's shown, rather than who is allowed to see it?

> Channels have 3 states (normal, show, don't show), but you're not certain what "Show" means, and the normal state could mean lots of things: Use default permission, allow people to see it but don't spam it to them, etc. It could mean don't show it, but the presence of a "Don't show" button hints that the default action isn't to deny access.

Some other confusion I had was:
* Permissions button missing from the edit screen (addressed in FAQ)
* Search button was so wide and same colour as background that I never noticed the icon and never paid attention to it - it became a background shape, like an unlabelled button or spacer. Its position was associated with the Public button, not with channel selection.

Yeah, yeah, I'm an idiot.

With all that in mind, here's what this pull request changes:
* Radio buttons with labels used to explicitly show the exclusive relationship between public and restricted, and which of the two you're "on".
* brief text to warn that permissions can't be changed after a post (not shown if you're editing photos etc)
* brief text to reinforce this is *only* about permissions and not about actively "showing" anything. (this one is a candidate for being culled, thanks to context help and clever wording in the brief text about Show/Dont show)
* brief text to clarify how "Show" and "Don't show" differ from "normal". Also hints that "Show" is passive.
* "Search" placeholder in the search box to make its purpose harder to miss.
* Layout now associates search box with the channels and groups, instead of being with the public button.
* lock icon to help people subliminally learn what the lock states represent in terms of permissions. Also helps emphasize when a post is public.
* Context help icon. This brings up help in a seperate tab/target because the existing context help window needs to be underneath the dialog. (I've also used fontawesome locks in the help file, which I'm not certain I'm allowed to assume?)

Possible future improvements:
* make it pretty. Fancy radio buttons etc.
* Implement the read-only mode, so permissions for posts you have already sent can still be viewed.
* Add help for items like photos (they work differently to the items that currently have a help file).
* Suggestions from others for better phrasing.

Read-only mode can wait until I know what will happen with the permissions dialog.