### PR TITLE
Unify permissions dialog for network posts, channel posts, and remote posts

### DIFF
--- a/Zotlabs/Module/Channel.php
+++ b/Zotlabs/Module/Channel.php
@@ -126,21 +126,13 @@ function get($update = 0, $load = false) {
 
 		if($perms['post_wall']) {
 
-			// I'm trying to make two points in this description text - warn about finality of wall
-			// post permissions, and try to clear up confusion that these permissions set who is
-			// *shown* the post, istead of who is able to see the post, i.e. make it clear that clicking
-			// the "Show"  button on a group does not post it to the feed of people in that group, it
-			// mearly allows those people to view the post if they are viewing/following this channel.
-			$aclDesc = t('Post permissions <b>cannot be changed</b> after a post is sent.</br />These permissions set who is allowed to view the post.');
-			$aclContextHelpCmd = 'acl_dialog_post';
-
 			$x = array(
 				'is_owner' => $is_owner,
 				'allow_location' => ((($is_owner || $observer) && (intval(get_pconfig(\App::$profile['profile_uid'],'system','use_browser_location')))) ? true : false),
 				'default_location' => (($is_owner) ? \App::$profile['channel_location'] : ''),
 				'nickname' => \App::$profile['channel_address'],
 				'lockstate' => (((strlen(\App::$profile['channel_allow_cid'])) || (strlen(\App::$profile['channel_allow_gid'])) || (strlen(\App::$profile['channel_deny_cid'])) || (strlen(\App::$profile['channel_deny_gid']))) ? 'lock' : 'unlock'),
-				'acl' => (($is_owner) ? populate_acl($channel_acl,true,((\App::$profile['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), $aclDesc, $aclContextHelpCmd) : ''),
+				'acl' => (($is_owner) ? populate_acl($channel_acl,true,((\App::$profile['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), get_post_aclDialogDescription(), 'acl_dialog_post') : ''),
 				'showacl' => (($is_owner) ? 'yes' : ''),
 				'bang' => '',
 				'visitor' => (($is_owner || $observer) ? true : false),

--- a/Zotlabs/Module/Network.php
+++ b/Zotlabs/Module/Network.php
@@ -155,14 +155,6 @@ class Network extends \Zotlabs\Web\Controller {
 	
 			nav_set_selected('network');
 
-			// I'm trying to make two points in this description text - warn about finality of wall
-			// post permissions, and try to clear up confusion that these permissions set who is
-			// *shown* the post, istead of who is able to see the post, i.e. make it clear that clicking
-			// the "Show"  button on a group does not post it to the feed of people in that group, it
-			// mearly allows those people to view the post if they are viewing/following this channel.
-			$aclDesc = t('Post permissions <b>cannot be changed</b> after a post is sent.</br />These permissions set who is allowed to view the post.');
-			$aclContextHelpCmd = 'acl_dialog_post';
-	
 			$channel_acl = array(
 				'allow_cid' => $channel['channel_allow_cid'], 
 				'allow_gid' => $channel['channel_allow_gid'], 
@@ -178,7 +170,7 @@ class Network extends \Zotlabs\Web\Controller {
 				'default_location' => $channel['channel_location'],
 				'nickname'         => $channel['channel_address'],
 				'lockstate'        => (($private_editing || $channel['channel_allow_cid'] || $channel['channel_allow_gid'] || $channel['channel_deny_cid'] || $channel['channel_deny_gid']) ? 'lock' : 'unlock'),
-				'acl'              => populate_acl((($private_editing) ? $def_acl : $channel_acl), true, (($channel['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), $aclDesc, $aclContextHelpCmd),
+				'acl'              => populate_acl((($private_editing) ? $def_acl : $channel_acl), true, (($channel['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), get_post_aclDialogDescription(), 'acl_dialog_post'),
 				'bang'             => (($private_editing) ? '!' : ''),
 				'visitor'          => true,
 				'profile_uid'      => local_channel(),

--- a/Zotlabs/Module/Rpost.php
+++ b/Zotlabs/Module/Rpost.php
@@ -115,7 +115,7 @@ class Rpost extends \Zotlabs\Web\Controller {
 			'default_location' => $channel['channel_location'],
 			'nickname' => $channel['channel_address'],
 			'lockstate' => (($acl->is_private()) ? 'lock' : 'unlock'),
-			'acl' => populate_acl($channel_acl,true,(($channel['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : '')),
+			'acl' => populate_acl($channel_acl,true,(($channel['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), get_post_aclDialogDescription(), 'acl_dialog_post'),
 			'bang' => '',
 			'visitor' => true,
 			'profile_uid' => local_channel(),

--- a/doc/acl_dialog_post.html
+++ b/doc/acl_dialog_post.html
@@ -5,7 +5,12 @@
 
 <p>Sometimes called Access Control List, or ACL, the permissions set who is able to see your new post.</p>
 
-<p>Pressing the ACL button (<i class="fa fa-lock"></i> or <i class="fa fa-unlock"></i>) beside the Submit button will display a dialog in which you can select what channels and/or privacy groups can see the post. You can also select who is explicitly denied access. For example, say you are planning a surprise party for a friend. You can send an invitation post to everyone in your <b>Friends</b> group <i>except</i> the friend you are surprising. In this case you "Show" the <b>Friends</b> group but "Don't show" that one person.
+<p>Pressing the ACL button (<i class="fa fa-lock"></i> or <i class="fa fa-unlock"></i>) beside the Submit button will display a dialog in which you can select what channels and/or privacy groups can see the post. You can also select who is explicitly denied access. For example, say you are planning a surprise party for a friend. You can send an invitation post to everyone in your <b>Friends</b> group <i>except</i> the friend you are surprising. In this case you "Show" the <b>Friends</b> group but "Don't show" that one person.</p>
+
+<dl>
+<dt>Tip:</dt>
+<dd>The border color of each channel indicates whether that channel &mdash; or one of the groups it belongs to &mdash; has access to the post. The border color will also indicate when a channel [or group it belongs to] has been expliciyly set to "Don't show".</dd>
+</dl>
 
 <h3>Why can't I edit a post's permissions after I saved it?</h3>
 

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -213,14 +213,14 @@ function fixacl(&$item) {
 /**
 * Builds a modal dialog for editing permissions, using acl_selector.tpl as the template.
 *
-* @param array $default Optional access control list for the initial state of the dialog.
+* @param array   $default Optional access control list for the initial state of the dialog.
 * @param boolean $show_jotnets Whether plugins for federated networks should be included in the permissions dialog
-* @param string $showall_caption An optional caption to describe the scope of an unrestricted post. e.g. "Public"
-* @param string $dialog_description Optional message to include at the top of the dialog. E.g. "Warning: Post permissions cannot be changed once sent".
-* @param string $context_help Allows the dialog to present a help icon. E.g. "acl_dialog_post"
+* @param string  $showall_caption An optional caption to describe the scope of an unrestricted post. e.g. "Public"
+* @param string  $dialog_description Optional message to include at the top of the dialog. E.g. "Warning: Post permissions cannot be changed once sent".
+* @param string  $context_help Allows the dialog to present a help icon. E.g. "acl_dialog_post"
 * @param boolean $readonly Not implemented yet. When implemented, the dialog will use acl_readonly.tpl instead, so that permissions may be viewed for posts that can no longer have their permissions changed.
 *
-* @return string html modal dialog build from acl_selector.tpl
+* @return string html modal dialog built from acl_selector.tpl
 */
 function populate_acl($defaults = null,$show_jotnets = true, $showall_caption = '', $dialog_description = '', $context_help = '', $readonly = false) {
 
@@ -271,5 +271,32 @@ function populate_acl($defaults = null,$show_jotnets = true, $showall_caption = 
 
 	return $o;
 
+}
+
+/**
+* Returns a string that's suitable for passing as the $dialog_description argument to a
+* populate_acl() call for wall posts or network posts.
+*
+* This string is needed in 3 different files, and our .po translation system currently
+* cannot be used as a string table (because the value is always the key is english) so
+* I've centralized the value here (making this function name the "key") until we have a
+* better way.
+*
+* @return string Description to present to user in modal permissions dialog
+*/
+function get_post_aclDialogDescription() {
+
+	// I'm trying to make two points in this description text - warn about finality of wall
+	// post permissions, and try to clear up confusion that these permissions set who is
+	// *shown* the post, istead of who is able to see the post, i.e. make it clear that clicking
+	// the "Show"  button on a group does not post it to the feed of people in that group, it
+	// mearly allows those people to view the post if they are viewing/following this channel.
+	$description = t('Post permissions %s cannot be changed %s after a post is shared.</br />These permissions set who is allowed to view the post.');
+
+	// Lets keep the emphasis styling seperate from the translation. It may change.
+	$emphasisOpen  = '<b><a href="' . z_root() . '/help/acl_dialog_post" target="hubzilla-help">';
+	$emphasisClose = '</a></b>';
+
+	return sprintf($description, $emphasisOpen, $emphasisClose);
 }
 


### PR DESCRIPTION
Adds the warning and help link to Rpost.php, and has all 3 files read the warning string from the same place instead of duplicating it (I put it in acl_selectors.php, but can move it if there's somewhere more suitable)

Also
* changes the warning from being about when a post is "sent" to when it's "shared", to match the Share button.
* hyperlinks the "cannot be changed" part of the warning to the help file
* adds some help