### PR TITLE
ACL dialogs: Make the non-ACL-option description more accurate

### DIFF
--- a/Zotlabs/Module/Channel.php
+++ b/Zotlabs/Module/Channel.php
@@ -9,6 +9,7 @@ require_once('include/security.php');
 require_once('include/conversation.php');
 require_once('include/acl_selectors.php');
 require_once('include/permissions.php');
+require_once('include/PermissionDescription.php');
 
 class Channel extends \Zotlabs\Web\Controller {
 
@@ -132,7 +133,7 @@ function get($update = 0, $load = false) {
 				'default_location' => (($is_owner) ? \App::$profile['channel_location'] : ''),
 				'nickname' => \App::$profile['channel_address'],
 				'lockstate' => (((strlen(\App::$profile['channel_allow_cid'])) || (strlen(\App::$profile['channel_allow_gid'])) || (strlen(\App::$profile['channel_deny_cid'])) || (strlen(\App::$profile['channel_deny_gid']))) ? 'lock' : 'unlock'),
-				'acl' => (($is_owner) ? populate_acl($channel_acl,true,((\App::$profile['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), get_post_aclDialogDescription(), 'acl_dialog_post') : ''),
+				'acl' => (($is_owner) ? populate_acl($channel_acl,true, \PermissionDescription::fromGlobalPermission('view_stream'), get_post_aclDialogDescription(), 'acl_dialog_post') : ''),
 				'showacl' => (($is_owner) ? 'yes' : ''),
 				'bang' => '',
 				'visitor' => (($is_owner || $observer) ? true : false),

--- a/Zotlabs/Module/Editwebpage.php
+++ b/Zotlabs/Module/Editwebpage.php
@@ -3,6 +3,7 @@ namespace Zotlabs\Module;
 
 require_once('include/identity.php');
 require_once('include/acl_selectors.php');
+require_once('include/PermissionDescription.php');
 
 
 class Editwebpage extends \Zotlabs\Web\Controller {
@@ -195,7 +196,7 @@ class Editwebpage extends \Zotlabs\Web\Controller {
 			'$baseurl' => z_root(),
 			'$defloc' => $itm[0]['location'],
 			'$visitor' => ($is_owner) ? true : false,
-			'$acl' => populate_acl($itm[0],false),
+			'$acl' => populate_acl($itm[0],false,\PermissionDescription::fromGlobalPermission('view_pages')),
 			'$showacl' => ($is_owner) ? true : false,
 			'$public' => t('Public post'),
 			'$jotnets' => $jotnets,

--- a/Zotlabs/Module/Events.php
+++ b/Zotlabs/Module/Events.php
@@ -6,6 +6,7 @@ require_once('include/bbcode.php');
 require_once('include/datetime.php');
 require_once('include/event.php');
 require_once('include/items.php');
+require_once('include/PermissionDescription.php');
 
 
 class Events extends \Zotlabs\Web\Controller {
@@ -237,7 +238,7 @@ class Events extends \Zotlabs\Web\Controller {
 	
 	
 	
-		function get() {
+	function get() {
 	
 		if(argc() > 2 && argv(1) == 'ical') {
 			$event_id = argv(2);
@@ -468,7 +469,9 @@ class Events extends \Zotlabs\Web\Controller {
 				'$share' => array('share', t('Share this event'), $sh_checked, '', array(t('No'),t('Yes'))),
 				'$preview' => t('Preview'),
 				'$permissions' => t('Permission settings'),
-				'$acl' => (($orig_event['event_xchan']) ? '' : populate_acl(((x($orig_event)) ? $orig_event : $perm_defaults),false)),
+				// populating the acl dialog was a permission description from view_stream because Cal.php, which
+				// displays events, says "since we don't currently have an event permission - use the stream permission"
+				'$acl' => (($orig_event['event_xchan']) ? '' : populate_acl(((x($orig_event)) ? $orig_event : $perm_defaults), false, \PermissionDescription::fromGlobalPermission('view_stream'))),
 				'$submit' => t('Submit'),
 				'$advanced' => t('Advanced Options')
 	

--- a/Zotlabs/Module/Filestorage.php
+++ b/Zotlabs/Module/Filestorage.php
@@ -6,6 +6,8 @@ namespace Zotlabs\Module;
  */
 
 require_once('include/attach.php');
+require_once('include/PermissionDescription.php');
+
 
 /**
  *
@@ -132,7 +134,7 @@ class Filestorage extends \Zotlabs\Web\Controller {
 			$cloudpath = get_cloudpath($f) . (intval($f['is_dir']) ? '?f=&davguest=1' : '');
 			$parentpath = get_parent_cloudpath($channel['channel_id'], $channel['channel_address'], $f['hash']);
 	
-			$aclselect_e = populate_acl($f, false);
+			$aclselect_e = populate_acl($f, false, \PermissionDescription::fromGlobalPermission('view_storage'));
 			$is_a_dir = (intval($f['is_dir']) ? true : false);
 	
 			$lockstate = (($f['allow_cid'] || $f['allow_gid'] || $f['deny_cid'] || $f['deny_gid']) ? 'lock' : 'unlock'); 

--- a/Zotlabs/Module/Network.php
+++ b/Zotlabs/Module/Network.php
@@ -6,6 +6,7 @@ require_once('include/group.php');
 require_once('include/contact_widgets.php');
 require_once('include/conversation.php');
 require_once('include/acl_selectors.php');
+require_once('include/PermissionDescription.php');
 
 
 
@@ -170,7 +171,7 @@ class Network extends \Zotlabs\Web\Controller {
 				'default_location' => $channel['channel_location'],
 				'nickname'         => $channel['channel_address'],
 				'lockstate'        => (($private_editing || $channel['channel_allow_cid'] || $channel['channel_allow_gid'] || $channel['channel_deny_cid'] || $channel['channel_deny_gid']) ? 'lock' : 'unlock'),
-				'acl'              => populate_acl((($private_editing) ? $def_acl : $channel_acl), true, (($channel['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), get_post_aclDialogDescription(), 'acl_dialog_post'),
+				'acl'              => populate_acl((($private_editing) ? $def_acl : $channel_acl), true, \PermissionDescription::fromGlobalPermission('view_stream'), get_post_aclDialogDescription(), 'acl_dialog_post'),
 				'bang'             => (($private_editing) ? '!' : ''),
 				'visitor'          => true,
 				'profile_uid'      => local_channel(),

--- a/Zotlabs/Module/Photos.php
+++ b/Zotlabs/Module/Photos.php
@@ -9,6 +9,7 @@ require_once('include/security.php');
 require_once('include/Contact.php');
 require_once('include/attach.php');
 require_once('include/text.php');
+require_once('include/PermissionDescription.php');
 
 
 
@@ -632,7 +633,7 @@ class Photos extends \Zotlabs\Web\Controller {
 				$lockstate = (($acl->is_private()) ? 'lock' : 'unlock');
 			}
 	
-			$aclselect = (($_is_owner) ? populate_acl($channel_acl,false) : '');
+			$aclselect = (($_is_owner) ? populate_acl($channel_acl,false, \PermissionDescription::fromGlobalPermission('view_storage')) : '');
 	
 			// this is wrong but is to work around an issue with js_upload wherein it chokes if these variables
 			// don't exist. They really should be set to a parseable representation of the channel's default permissions 
@@ -1022,7 +1023,7 @@ class Photos extends \Zotlabs\Web\Controller {
 			if($can_post) {
 				$album_e = $ph[0]['album'];
 				$caption_e = $ph[0]['description'];
-				$aclselect_e = (($_is_owner) ? populate_acl($ph[0]) : '');
+				$aclselect_e = (($_is_owner) ? populate_acl($ph[0], true, \PermissionDescription::fromGlobalPermission('view_storage')) : '');
 				$albums = ((array_key_exists('albums', \App::$data)) ? \App::$data['albums'] : photos_albums_list(\App::$data['channel'],\App::$data['observer']));
 	
 				$_SESSION['album_return'] = bin2hex($ph[0]['album']);

--- a/Zotlabs/Module/Rpost.php
+++ b/Zotlabs/Module/Rpost.php
@@ -7,6 +7,7 @@ require_once('include/items.php');
 require_once('include/taxonomy.php');
 require_once('include/conversation.php');
 require_once('include/zot.php');
+require_once('include/PermissionDescription.php');
 
 /**
  * remote post
@@ -115,7 +116,7 @@ class Rpost extends \Zotlabs\Web\Controller {
 			'default_location' => $channel['channel_location'],
 			'nickname' => $channel['channel_address'],
 			'lockstate' => (($acl->is_private()) ? 'lock' : 'unlock'),
-			'acl' => populate_acl($channel_acl,true,(($channel['channel_r_stream'] & PERMS_PUBLIC) ? t('Public') : ''), get_post_aclDialogDescription(), 'acl_dialog_post'),
+			'acl' => populate_acl($channel_acl, true, \PermissionDescription::fromGlobalPermission('view_stream'), get_post_aclDialogDescription(), 'acl_dialog_post'),
 			'bang' => '',
 			'visitor' => true,
 			'profile_uid' => local_channel(),

--- a/Zotlabs/Module/Settings.php
+++ b/Zotlabs/Module/Settings.php
@@ -2,6 +2,8 @@
 namespace Zotlabs\Module; /** @file */
 
 require_once('include/zot.php');
+require_once('include/PermissionDescription.php');
+
 
 
 class Settings extends \Zotlabs\Web\Controller {
@@ -1064,7 +1066,7 @@ class Settings extends \Zotlabs\Web\Controller {
 				'$maxreq' 	=> array('maxreq', t('Maximum Friend Requests/Day:'), intval($channel['channel_max_friend_req']) , t('May reduce spam activity')),
 				'$permissions' => t('Default Post Permissions'),
 				'$permdesc' => t("\x28click to open/close\x29"),
-				'$aclselect' => populate_acl($perm_defaults,false),
+				'$aclselect' => populate_acl($perm_defaults, false, \PermissionDescription::fromDescription(t('Use my default audience setting for the type of channel'))),
 				'$suggestme' => $suggestme,
 				'$group_select' => $group_select,
 				'$role' => array('permissions_role' , t('Channel permissions category:'), $permissions_role, '', get_roles()),

--- a/Zotlabs/Module/Webpages.php
+++ b/Zotlabs/Module/Webpages.php
@@ -4,6 +4,7 @@ namespace Zotlabs\Module;
 require_once('include/identity.php');
 require_once('include/conversation.php');
 require_once('include/acl_selectors.php');
+require_once('include/PermissionDescription.php');
 
 
 class Webpages extends \Zotlabs\Web\Controller {
@@ -111,7 +112,7 @@ class Webpages extends \Zotlabs\Web\Controller {
 			'nickname'    => \App::$profile['channel_address'],
 			'lockstate'   => (($channel['channel_allow_cid'] || $channel['channel_allow_gid'] || $channel['channel_deny_cid'] || $channel['channel_deny_gid']) ? 'lock' : 'unlock'),
 			'bang'        => '',
-			'acl'         => (($is_owner) ? populate_acl($channel_acl,false) : ''),
+			'acl'         => (($is_owner) ? populate_acl($channel_acl,false, \PermissionDescription::fromGlobalPermission('view_pages')) : ''),
 			'showacl'     => (($is_owner) ? true : false),
 			'visitor'     => true,
 			'profile_uid' => intval($owner),

--- a/boot.php
+++ b/boot.php
@@ -313,15 +313,14 @@ define ( 'PERMS_A_REPUBLISH',      0x10000);
 define ( 'PERMS_W_LIKE',           0x20000);
 
 // General channel permissions
-
-define ( 'PERMS_PUBLIC'     , 0x0001 );
-define ( 'PERMS_NETWORK'    , 0x0002 );
-define ( 'PERMS_SITE'       , 0x0004 );
-define ( 'PERMS_CONTACTS'   , 0x0008 );
-define ( 'PERMS_SPECIFIC'   , 0x0080 );
-define ( 'PERMS_AUTHED'     , 0x0100 );
-define ( 'PERMS_PENDING'    , 0x0200 );
-
+                                        // 0 = Only you
+define ( 'PERMS_PUBLIC'     , 0x0001 ); // anybody
+define ( 'PERMS_NETWORK'    , 0x0002 ); // anybody in this network
+define ( 'PERMS_SITE'       , 0x0004 ); // anybody on this site
+define ( 'PERMS_CONTACTS'   , 0x0008 ); // any of my connections
+define ( 'PERMS_SPECIFIC'   , 0x0080 ); // only specific connections
+define ( 'PERMS_AUTHED'     , 0x0100 ); // anybody authenticated (could include visitors from other networks)
+define ( 'PERMS_PENDING'    , 0x0200 ); // any connections including those who haven't yet been approved
 
 // Address book flags
 

--- a/include/PermissionDescription.php
+++ b/include/PermissionDescription.php
@@ -1,0 +1,167 @@
+<?php
+
+if(class_exists('PermissionDescription')) return;
+
+require_once("include/permissions.php");
+require_once("include/language.php");
+require_once("include/text.php");
+
+
+/**
+ * Encapsulates information the ACL dialog requires to describe
+ * permission settings for an item with an empty ACL.
+ * i.e the caption, icon, and tooltip for the no-ACL option in the ACL dialog.
+ */
+class PermissionDescription  {
+
+	private $global_perm;
+	private $channel_perm;
+	private $fallback_description;
+	
+	/**
+	 * Constructor is private.
+	 * Use static methods fromGlobalPermission(), fromStandalonePermission(), or fromDescription()
+	 * to create instances.
+	 */
+	private function __construct($global_perm, $channel_perm, $description = '') {
+
+		$this->global_perm  = $global_perm;
+		$this->channel_perm = $channel_perm;
+		
+		$this->fallback_description = ($description  == '') ? t('Visible to your default audience') : $description;
+	}
+
+	/**
+	 * If the interpretation of an empty ACL can't be summarised with a global default permission 
+	 * or a specific permission setting then use this method and describe what it means instead.
+	 *
+	 * @param  string $description - the caption for the no-ACL option in the ACL dialog.
+	 * @return a new instance of PermissionDescription
+	 */
+	public static function fromDescription($description) {
+		return new PermissionDescription('', 0x80000, $description);
+	}
+
+
+	/**
+	 * Use this method only if the interpretation of an empty ACL doesn't fall back to a global 
+	 * default permission. You should pass one of the constants from boot.php - PERMS_PUBLIC, PERMS_NETWORK etc.
+	 * 
+	 * @param  integer $perm - a single enumerated constant permission - PERMS_PUBLIC, PERMS_NETWORK etc.
+	 * @return a new instance of PermissionDescription
+	 */
+	public static function fromStandalonePermission($perm) {
+
+		$result = new PermissionDescription('', $perm);
+		
+		$checkPerm = $this->get_permission_description();
+		if ($checkPerm == $this->fallback_description) {
+			$result = null;
+			logger('null PermissionDescription from unknown standalone permission: ' . $perm ,LOGGER_DEBUG, LOG_ERROR);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * This is the preferred way to create a PermissionDescription, as it provides the most details.
+	 * Use this method if you know an empty ACL will result in one of the global default permissions 
+	 * being used, such as channel_r_stream (for which you would pass 'view_stream').
+	 * 
+	 * @param  string $permname - a key for the global perms array from get_perms() in permissions.php,
+	 *         e.g. 'view_stream', 'view_profile', etc.
+	 * @return a new instance of PermissionDescription
+	 */
+	public static function fromGlobalPermission($permname) {
+
+		$result = null;
+
+		$global_perms = get_perms();
+
+		if (array_key_exists($permname, $global_perms)) {
+
+			$permDetails = $global_perms[$permname];
+			$channelPerm = \App::$channel[$permDetails[0]];
+			$result = new PermissionDescription($permDetails[1], $channelPerm);
+		} else {
+			// The acl dialog can handle null arguments, but it shouldn't happen
+			logger('null PermissionDescription from unknown global permission: ' . $permname ,LOGGER_DEBUG, LOG_ERROR);
+		}
+		return $result;
+	}
+
+
+	/**
+	 * Gets a localized description of the permission, or a generic message if the permission
+	 * is unknown.
+	 *
+	 * @return string description
+	 */
+	public function get_permission_description() {
+
+		switch($this->channel_perm) {			
+
+			case 0:              return t('Only me');
+			case PERMS_PUBLIC:   return t('Public');
+			case PERMS_NETWORK:  return t('Anybody in the $Projectname network');
+			case PERMS_SITE:     return sprintf(t('Any account on %s'), \App::get_hostname());
+			case PERMS_CONTACTS: return t('Any of my connections');
+			case PERMS_SPECIFIC: 
+				// Because we're describing the permissions of an item with an empty ACL,
+				// the owner will be the only person able to see it if the permissions are 
+				// set to "only specified connections".
+				return t('Only me (only specified contacts and me)'); 
+			case PERMS_AUTHED:   return t('Anybody authenticated (could include visitors from other networks)');
+			case PERMS_PENDING:  return t('Any connections including those who haven\'t yet been approved');
+			default:             return $this->fallback_description;
+		}
+	}
+
+	/**
+	 * Returns an icon css class name if an appropriate one is available, e.g. "fa-globe" for Public,
+	 * otherwise returns empty string. 
+	 *
+	 * @return string icon css class name (often FontAwesome)
+	 */
+	public function get_permission_icon() {
+
+		switch($this->channel_perm) {			
+
+			case 0:/* only me */ return 'fa-eye-slash';
+			case PERMS_PUBLIC:   return 'fa-globe';
+			case PERMS_NETWORK:  return 'fa-share-alt-square'; // fa-share-alt-square is very similiar to the hubzilla logo, but we should create our own logo class to use
+			case PERMS_SITE:     return 'fa-sitemap'; 
+			case PERMS_CONTACTS: return 'fa-group'; 
+			case PERMS_SPECIFIC: 
+				// Because we're describing the permissions of an item with an empty ACL,
+				// the owner will be the only person able to see it if the permissions are 
+				// set to "only specified connections".
+				return 'fa-eye-slash'; 
+			case PERMS_AUTHED:   return '';
+			case PERMS_PENDING:  return '';
+			default:             return '';
+		}
+	}
+
+
+	/**
+	 * Returns a localized description of where the permission came from, if this is known.
+	 * If it's not know, or if the permission is standalone and didn't come from a default
+	 * permission setting, then empty string is returned.
+	 *
+	 * @return string description or empty string
+	*/
+	public function get_permission_origin_description() {
+
+		switch($this->global_perm) {			
+
+			case PERMS_R_STREAM:  return t('This is your default setting for the audience of your normal stream, and posts.');
+			case PERMS_R_PROFILE: return t('This is your default setting for who can view your default channel profile');
+			case PERMS_R_ABOOK:   return t('This is your default setting for who can view your connections');
+			case PERMS_R_STORAGE: return t('This is your default setting for who can view your file storage and photos');
+			case PERMS_R_PAGES:   return t('This is your default setting for the audience of your webpages');
+			default:              return '';
+		}
+	}
+
+}

--- a/view/theme/redbasic/css/style.css
+++ b/view/theme/redbasic/css/style.css
@@ -1046,6 +1046,13 @@ a.rconnect:hover, a.rateme:hover, div.rateme:hover {
 	font-size: 140%;
 }
 
+#acl-info-icon,
+#acl-info-icon:active {
+	font-size: 110%;
+	color: $link_colour;
+	text-decoration: none;
+}
+
 #acl-showall-caption {
 	margin-left: 0.35em;
 }

--- a/view/tpl/acl_selector.tpl
+++ b/view/tpl/acl_selector.tpl
@@ -25,8 +25,12 @@
 					<div id="acl-radiowrapper-showall" class="radio">
 					  <label>
 					    <input id="acl-showall" type="radio" name="optionsRadios" value="option1" checked>
-					    <i class="fa fa-globe"></i><span id=acl-showall-caption>{{$showall}}</span>
+					    {{if $showallIcon}}<i class="fa {{$showallIcon}}"></i>{{/if}}
+					    <span id="acl-showall-caption">{{$showall}}</span>
 					  </label>
+					  {{if $showallOrigin}}
+					    &nbsp;<a id="acl-info-icon" role="button" tabindex="0" class="fa fa-info-circle" data-trigger="focus" data-toggle="popover" data-placement="top" data-content="{{$showallOrigin}}"></a>
+					  {{/if}}
 					</div>
 					<div id="acl-radiowrapper-showlimited" class="radio">
 						<label>
@@ -61,6 +65,8 @@
 </div><!-- /.modal -->
 
 <script>
+	$('[data-toggle="popover"]').popover(); // Init the popover, if present
+
 	if(typeof acl=="undefined"){
 		acl = new ACL(
 			baseurl+"/acl",


### PR DESCRIPTION
![hubzilla permissions dialog2](https://cloud.githubusercontent.com/assets/6390507/15097649/36cce1ea-1565-11e6-8351-56311086cb8c.png)

It could still do with better ideas than mine for theming/layout/icon choices, but this code gets the information into the ACL dialog.

The ACL dialog is fully backwards compatible, but you can pass it a higher-level permissions description if desired.

I've updated the populate_acl() calls in the following modules with what an empty-ACL means:
* Photos.php (view_storage)
* Rpost.php (view_stream)
* Network.php (view_stream)
* Webpages.php (view_pages)
* Filestorage.php (view_storage)
* Editwebpage.php (view_pages)
* Channel.php (view_stream)
* Events.php (view_stream - because Cal.php is what displays these and it has a comment saying "since we don't currently have an event permission - use the stream permission")
* Settings.php (displays the string "Use my default audience setting for the type of channel")

But it's not always clear to me how an empty ACL is going to be interpretted by Hubzilla, so for now I've left the following the way they were:
* Chat.php
* Mitem.php
* Display.php (I think this falls back to public, so populate_acl() should be called with `\PermissionDescription::fromStandalonePermission(PERMS_PUBLIC)`, but I'm not certain)
* Thing.php


I wasn't sure if PermissionDescription was supposed to be a Zotlabs module, it's a class, but it has no use outside of `include\acl_selectors.php`. If there's a refactoring move happening from include -> Zotlabs I may have just made more work.