### PR TITLE
Updated contextual help in Spanish

### DIFF
--- a/doc/context/es/admin/logs/help.html
+++ b/doc/context/es/admin/logs/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Esta página</span> <span>le
@@ -32,5 +27,3 @@
             especialmente</span> <span>en</span> <span>los hubs</span> <span>con</span>
           <span>más que unos pocos</span> <span>miembros</span><span class="">.</span></span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/admin/queue/help.html
+++ b/doc/context/es/admin/queue/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Las estadísticas</span>
@@ -13,5 +8,3 @@
           que <span>la entrega</span> <span>se ha intentado</span><span>, sin
             éxito</span><span>.</span></span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/admin/security/help.html
+++ b/doc/context/es/admin/security/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Esta página</span> <span>contiene</span>
@@ -13,5 +8,3 @@
             class="">realice en</span> <span>estos ajustes</span><span>, debe
             pulsar</span> <span class="">el botón Enviar.</span></span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/channel/help.html
+++ b/doc/context/es/channel/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Esta</span> <span>es
@@ -31,5 +26,3 @@
           enlaza con los ficheros de cualquier tipo compartidos por el canal.<span
             class=""></span></span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/chat/help.html
+++ b/doc/context/es/chat/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Creación y uso de</span>
@@ -26,5 +21,3 @@
           <span>el panel lateral</span>, <span>en</span><span></span> <span>"</span><span
             class="">Miembros del chat</span><span>"</span><span class="">.</span></span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/cloud/help.html
+++ b/doc/context/es/cloud/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Esta página</span> <span>muestra
@@ -26,5 +21,3 @@
           enlaza con las galerías de fotos. La pestaña "Ficheros" enlaza con los
           ficheros de cualquier tipo compartidos por el canal.</span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/connections/help.html
+++ b/doc/context/es/connections/help.html
@@ -1,8 +1,25 @@
-<dl class="dl-horizontal">
-    <dt>General</dt>
-    <dd>This page displays a list of all this channel's connections. The list can be <a href='#' onclick='contextualHelpFocus(".section-title-wrapper", 0); return false;' title="Click to highlight element...">sorted and filtered using the menu button beside the search button</a>. </dd>
-    <dt>Connection Details</dt>
-    <dd>Each list entry shows the details of a specific connection. A translucent avatar image indicates an archived connection.</dd>
-    <dt>Connection Status</dt>
-    <dd>A connection can be in different states: <ul><li>Archived</li><li>Ignored</li><li>Blocked</li><li>Hidden</li></ul></dd>
-</dl>
+    <dl class="dl-horizontal">
+      <dt>General</dt>
+      <dd><span id="result_box" class="" lang="es"><span>Esta página</span> <span>muestra
+            una lista de</span> <span>todas</span> <span>las conexiones</span>
+          <span class="">de este canal</span><span class="">.</span> <span class="">La</span>
+          <span class="">lista se puede&nbsp;</span></span><a href="file:///home/manuel/sourcecode/fork/doc/context/es/connections/ifpending/help.html#"
+          onclick='contextualHelpFocus(".section-title-wrapper", 0); return false;'
+          title="Pulsar sobre el elemento resaltado...">ordenar y filtrar usando
+          el botón de menú al lado del botón de búsqueda</a>.</dd>
+      <dt>Detalles de la conexión</dt>
+      <dd><span id="result_box" class="" lang="es"><span>Cada</span> <span>entrada
+            de la lista</span> <span>muestra los</span> <span>detalles de una
+            conexión</span> <span>específica</span><span>.</span> <span>Una</span>
+          <span>imagen de avatar</span> <span>translúcida</span> <span>indica
+            una conexión</span> <span class="">archivada.</span></span></dd>
+      <dt>Estado de la conexión</dt>
+      <dd>Una conexión puede estar en diferentes estados:
+        <ul>
+          <li>Archivada</li>
+          <li>Ignorada</li>
+          <li>Bloqueada</li>
+          <li>Oculta</li>
+        </ul>
+      </dd>
+    </dl>

--- a/doc/context/es/connections/ifpending/help.html
+++ b/doc/context/es/connections/ifpending/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Esta página</span> <span>muestra
@@ -27,5 +22,3 @@
         </ul>
       </dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/events/help.html
+++ b/doc/context/es/events/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Esta página</span> <span>muestra
@@ -19,5 +14,3 @@
       <dd>Exportar o importar eventos del calendario usando el formato estándar
         de los ficheros de iCalendar (.ics).</dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/mail/help.html
+++ b/doc/context/es/mail/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Los mensajes que
@@ -34,5 +29,3 @@
             style="font-style: italic;"> <span>aún no lo ha</span> </span><span
             class=""><span style="font-style: italic;">leído</span>.</span></span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/network/help.html
+++ b/doc/context/es/network/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>La</span> <span>página
@@ -67,5 +62,3 @@
           <span>"</span><span>no se mostrará</span><span>"</span> <span>a esa
             única</span><span class=""> persona.</span></span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/photos/help.html
+++ b/doc/context/es/photos/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Esta página</span> <span>muestra</span>
@@ -23,5 +18,3 @@
           enlaza con las galerías de fotos. La pestaña "<span style="font-weight: bold;">Ficheros</span>"
           enlaza con los ficheros de cualquier tipo compartidos por el canal.</span></dd>
     </dl>
-  </body>
-</html>

--- a/doc/context/es/profile/help.html
+++ b/doc/context/es/profile/help.html
@@ -1,8 +1,3 @@
-<html>
-  <head>
-    <meta content="text/html; charset=windows-1252" http-equiv="content-type">
-  </head>
-  <body>
     <dl class="dl-horizontal">
       <dt>General</dt>
       <dd><span id="result_box" class="" lang="es"><span>Esta</span> <span>es
@@ -28,5 +23,3 @@
           enlaza con las galerías de fotos. La pestaña "<span style="font-weight: bold;">Ficheros</span>"
           enlaza con los ficheros de cualquier tipo compartidos por el canal.</span></dd>
     </dl>
-  </body>
-</html>


### PR DESCRIPTION
I deleted the unnecessary html header added by the editor BlueGriffon, which is what I used for the translation, to help.html files. I didn't realize, I'm sorry.