### PR TITLE
Add filter to wiki content to prevent JavaScript code injection

### DIFF
--- a/Zotlabs/Module/Wiki.php
+++ b/Zotlabs/Module/Wiki.php
@@ -167,7 +167,7 @@ class Wiki extends \Zotlabs\Web\Controller {
 		if((argc() > 2) && (argv(2) === 'preview')) {
 			$content = $_POST['content'];
 			require_once('library/markdown.php');
-			$html = Markdown($content);
+			$html = purify_html(Markdown($content));
 			json_return_and_die(array('html' => $html, 'success' => true));
 		}
 		
@@ -182,19 +182,7 @@ class Wiki extends \Zotlabs\Web\Controller {
 			// more detail permissions framework
 			if (local_channel() !== intval($channel['channel_id'])) {
 				goaway('/'.argv(0).'/'.$nick.'/');
-			} else {				
-				/*
-				$channel = get_channel_by_nick($nick);
-				// Figure out who the page owner is.
-				$perms = get_all_perms(intval($channel['channel_id']), $observer_hash);
-				// TODO: Create a new permission setting for wiki analogous to webpages. Until
-				// then, use webpage permissions
-				if (!$perms['write_pages']) {
-					notice(t('Permission denied.') . EOL);
-					goaway('/'.argv(0).'/'.argv(1).'/');
-				}
-				*/
-			}
+			} 
 			$wiki = array(); 
 			// Generate new wiki info from input name
 			$wiki['rawName'] = $_POST['wikiName'];
@@ -306,7 +294,7 @@ class Wiki extends \Zotlabs\Web\Controller {
 			$resource_id = $_POST['resource_id']; 
 			$pageUrlName = $_POST['name'];
 			$pageHtmlName = escape_tags($_POST['name']);
-			$content = escape_tags($_POST['content']); //Get new content
+			$content = $_POST['content']; //Get new content
 			$commitMsg = $_POST['commitMsg']; 
 			if ($commitMsg === '') {
 				$commitMsg = 'Updated ' . $pageHtmlName;

--- a/include/wiki.php
+++ b/include/wiki.php
@@ -279,7 +279,7 @@ function wiki_page_history($arr) {
 
 function wiki_save_page($arr) {
 	$pageUrlName = ((array_key_exists('pageUrlName',$arr)) ? $arr['pageUrlName'] : '');
-	$content = ((array_key_exists('content',$arr)) ? $arr['content'] : '');
+	$content = ((array_key_exists('content',$arr)) ? purify_html($arr['content']) : '');
 	$resource_id = ((array_key_exists('resource_id',$arr)) ? $arr['resource_id'] : '');
 	$w = wiki_get_wiki($resource_id);
 	if (!$w['path']) {


### PR DESCRIPTION
While fixing a bug that prevented proper display of HTML characters in a wiki page, I introduced the ability to save arbitrary JavaScript code with the page. This update applies the purify_html() function to the content when generating a preview as well as when saving the page.