### PR TITLE
Fixed whitescreen when creating folders via cloud files web interface

### DIFF
--- a/Zotlabs/Storage/Directory.php
+++ b/Zotlabs/Storage/Directory.php
@@ -369,6 +369,7 @@ class Directory extends DAV\Node implements DAV\ICollection, DAV\IQuota {
 		);
 
 		if ($r) {
+			require_once('include/attach.php');
 			$result = attach_mkdir($r[0], $this->auth->observer, array('filename' => $name, 'folder' => $this->folder_hash));
 
 			if($result['success']) {


### PR DESCRIPTION
I'm getting a "not found" error when I try to create folders in the cloud files web interface. I click the "Create" button beside the "Upload" button, type a bland name for a new folder, and I get a white screen. Including the attach.php file fixes the bug.

Version 1.9.1+99354ac