### PR TITLE
Comment and code about UTF-8 @-sign do not match.

### DIFF
--- a/include/attach.php
+++ b/include/attach.php
@@ -1948,9 +1948,9 @@ function get_attach_binname($s) {
 
 
 function get_dirpath_by_cloudpath($channel, $path) {
-	
-	// Warning: Do not edit the following line. The first symbol is UTF-8 &#65312; 
-	$path = str_replace('@','@',notags(trim($path)));		
+
+	// Warning: Do not edit the following line. The first symbol is UTF-8 (U+FF20) &#65312;
+	$path = str_replace('＠', '@', notags(trim($path)));
 
 	$h = @parse_url($path);
 


### PR DESCRIPTION
Changed code according to comment:
First AT is now full-width AT U+FF20.
Do we also need to replace small AT U+FE6B?

What for is this needed?
Can someone check this PR if the desired behaviour is still true.