### PR TITLE
feature: static page update as opposed to live update of conversation…

### DIFF
--- a/Zotlabs/Module/Channel.php
+++ b/Zotlabs/Module/Channel.php
@@ -304,6 +304,7 @@ class Channel extends \Zotlabs\Web\Controller {
 				'$nouveau' => '0',
 				'$wall' => '1',
 				'$fh' => '0',
+				'$static'  => intval(feature_enabled(\App::$profile['profile_uid'],'static_updates')),
 				'$page' => ((\App::$pager['page'] != 1) ? \App::$pager['page'] : 1),
 				'$search' => '',
 				'$order' => '',

--- a/Zotlabs/Module/Display.php
+++ b/Zotlabs/Module/Display.php
@@ -130,6 +130,7 @@ class Display extends \Zotlabs\Web\Controller {
 		if($load)
 			$simple_update = '';
 	
+		$static  = ((local_channel()) ? intval(feature_enabled(local_channel(),'static_updates')) : 0);
 	
 	
 		if((! $update) && (! $load)) {
@@ -154,6 +155,7 @@ class Display extends \Zotlabs\Web\Controller {
 				'$fh' => '0',
 				'$nouveau' => '0',
 				'$wall' => '0',
+				'$static' => $static,
 				'$page' => ((\App::$pager['page'] != 1) ? \App::$pager['page'] : 1),
 				'$list' => ((x($_REQUEST,'list')) ? intval($_REQUEST['list']) : 0),
 				'$search' => '',

--- a/Zotlabs/Module/Network.php
+++ b/Zotlabs/Module/Network.php
@@ -295,6 +295,7 @@ class Network extends \Zotlabs\Web\Controller {
 				'$fh'      => (($firehose) ? $firehose : '0'),
 				'$nouveau' => (($nouveau) ? $nouveau : '0'),
 				'$wall'    => '0',
+				'$static'  => intval(feature_enabled(local_channel(),'static_updates')),
 				'$list'    => ((x($_REQUEST,'list')) ? intval($_REQUEST['list']) : 0),
 				'$page'    => ((\App::$pager['page'] != 1) ? \App::$pager['page'] : 1),
 				'$search'  => (($search) ? $search : ''),

--- a/Zotlabs/Module/Pubstream.php
+++ b/Zotlabs/Module/Pubstream.php
@@ -21,6 +21,8 @@ class Pubstream extends \Zotlabs\Web\Controller {
 			return;
 	
 		$item_normal = item_normal();
+
+		$static  = ((local_channel()) ? intval(feature_enabled(local_channel(),'static_updates')) : 0);
 	
 		if(! $update) {
 	
@@ -49,6 +51,7 @@ class Pubstream extends \Zotlabs\Web\Controller {
 				'$nouveau' => '0',
 				'$wall'    => '0',
 				'$list'    => '0',
+				'$static'  => $static,
 				'$page'    => ((\App::$pager['page'] != 1) ? \App::$pager['page'] : 1),
 				'$search'  => '',
 				'$order'   => 'comment',

--- a/Zotlabs/Module/Search.php
+++ b/Zotlabs/Module/Search.php
@@ -96,6 +96,8 @@ class Search extends \Zotlabs\Web\Controller {
 		// OR your own posts if you are a logged in member
 		// No items will be shown if the member has a blocked profile wall. 
 	
+		$static  = ((local_channel()) ? intval(feature_enabled(local_channel(),'static_updates')) : 0);
+
 		if((! $update) && (! $load)) {
 	
 			// This is ugly, but we can't pass the profile_uid through the session to the ajax updater,
@@ -120,6 +122,7 @@ class Search extends \Zotlabs\Web\Controller {
 				'$fh' => '0',
 				'$nouveau' => '0',
 				'$wall' => '0',
+				'$static' => $static,
 				'$list' => ((x($_REQUEST,'list')) ? intval($_REQUEST['list']) : 0),
 				'$page' => ((\App::$pager['page'] != 1) ? \App::$pager['page'] : 1),
 				'$search' => (($tag) ? urlencode('#') : '') . $search,

--- a/include/features.php
+++ b/include/features.php
@@ -157,6 +157,15 @@ function get_features($filtered = true) {
 				feature_level('smart_birthdays',2),
 			],
 
+			[
+				'static_updates',       
+				t('Manual Page Updates'),          
+				t('Off = automatically update changing conversations. On = Wait until the page is re-loaded.'),
+				false,
+				get_config('feature_lock','static_updates'),
+				feature_level('static_updates',1),
+			],
+
 			[ 
 				'advanced_dirsearch', 
 				t('Advanced Directory Search'),

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -754,6 +754,13 @@ function liveUpdate() {
 			update_mode = 'append';
 	}
 	else {
+		if(bParam_static) {
+			in_progress = false;
+			if(timer) clearTimeout(timer);
+			timer = setTimeout(NavUpdate,10000);
+			return;
+		}
+
 		update_mode = 'update';
 		var orgHeight = $("#region_2").height();
 	}

--- a/view/tpl/build_query.tpl
+++ b/view/tpl/build_query.tpl
@@ -17,6 +17,7 @@
 	var bParam_wall = {{$wall}};
 	var bParam_list = {{$list}};
 	var bParam_fh = {{$fh}};
+	var bParam_static = {{$static}};
 
 	var bParam_search = "{{$search}}";
 	var bParam_order = "{{$order}}";


### PR DESCRIPTION
…s on the page. Changes will be queued until the page is reloaded. There may or may not be notifications of pending activity updates depending on your notification preferences. Endless scrolling (append) is still performed either way. This only affects changed and new/unseen items being inserted into the page.