### PR TITLE
Active wiki highlighting, move wiki edit panel into wiki list

### DIFF
--- a/include/widgets.php
+++ b/include/widgets.php
@@ -941,8 +941,20 @@ function widget_wiki_list($arr) {
 				// Not the channel owner 
 				$owner_acl = $x = array();
 		}
-
+		if(argc()>1) {
+			$activeWikiURLname = argv(2);
+		} else {
+			$activeWikiURLname = '';
+		}
+		logger($activeWikiURLname, LOGGER_DEBUG);
 		$wikis = wiki_list($channel, get_observer_hash());
+		foreach($wikis['wikis'] as &$w) {
+			if($w['urlName'] === $activeWikiURLname) {
+				$w['active'] = true;
+			} else {
+				$w['active'] = false;
+			}
+		}
 		if ($wikis) {
 				return replace_macros(get_markup_template('wikilist.tpl'), array(
 						'$header' => t('Wiki List'),

--- a/include/widgets.php
+++ b/include/widgets.php
@@ -899,32 +899,72 @@ function widget_chatroom_members() {
 
 function widget_wiki_list($arr) {
 
-	require_once("include/wiki.php");
-	$channel = null;
-	if (argc() < 2 && local_channel()) {
-		// This should not occur because /wiki should redirect to /wiki/channel ...
-		$channel = \App::get_channel();
-	} else {
-		$channel = channelx_by_nick(argv(1));	// Channel being viewed by observer
-	}
-	if (!$channel) {
+		require_once("include/wiki.php");
+		$channel = null;
+		if (argc() < 2 && local_channel()) {
+				// This should not occur because /wiki should redirect to /wiki/channel ...
+				$channel = \App::get_channel();
+		} else {
+				$channel = channelx_by_nick(argv(1)); // Channel being viewed by observer
+		}
+		if (!$channel) {
+				return '';
+		}
+		// init() should have forced the URL to redirect to /wiki/channel so assume argc() > 1
+		$nick = argv(1);
+		$owner = channelx_by_nick($nick);  // The channel who owns the wikis being viewed
+		// Determine if the observer is the channel owner so the ACL dialog can be populated
+		if (local_channel() === intval($owner['channel_id'])) {
+
+				// Obtain the default permission settings of the channel
+				$owner_acl = array(
+						'allow_cid' => $owner['channel_allow_cid'],
+						'allow_gid' => $owner['channel_allow_gid'],
+						'deny_cid' => $owner['channel_deny_cid'],
+						'deny_gid' => $owner['channel_deny_gid']
+				);
+				// Initialize the ACL to the channel default permissions
+				$x = array(
+						'lockstate' => (( $owner['channel_allow_cid'] ||
+						$owner['channel_allow_gid'] ||
+						$owner['channel_deny_cid'] ||
+						$owner['channel_deny_gid']) ? 'lock' : 'unlock'
+						),
+						'acl' => populate_acl($owner_acl),
+						'allow_cid' => acl2json($owner_acl['allow_cid']),
+						'allow_gid' => acl2json($owner_acl['allow_gid']),
+						'deny_cid' => acl2json($owner_acl['deny_cid']),
+						'deny_gid' => acl2json($owner_acl['deny_gid']),
+						'bang' => ''
+				);
+		} else {
+				// Not the channel owner 
+				$owner_acl = $x = array();
+		}
+
+		$wikis = wiki_list($channel, get_observer_hash());
+		if ($wikis) {
+				return replace_macros(get_markup_template('wikilist.tpl'), array(
+						'$header' => t('Wiki List'),
+						'$channel' => $channel['channel_address'],
+						'$wikis' => $wikis['wikis'],
+						// If the observer is the local channel owner, show the wiki controls
+						'$owner' => ((local_channel() && local_channel() === intval(\App::$profile['uid'])) ? true : false),
+						'$edit' => t('Edit'),
+						'$download' => t('Download'),
+						'$view' => t('View'),
+						'$addnew' => t('Add new wiki'),
+						'$wikiName' => array('wikiName', t('Enter the name of your new wiki:'), '', ''),
+						'$lockstate' => $x['lockstate'],
+						'$acl' => $x['acl'],
+						'$allow_cid' => $x['allow_cid'],
+						'$allow_gid' => $x['allow_gid'],
+						'$deny_cid' => $x['deny_cid'],
+						'$deny_gid' => $x['deny_gid'],
+						'$bang' => $x['bang'],
+				));
+		}
 		return '';
-	}
-	$wikis = wiki_list($channel, get_observer_hash());
-	if ($wikis) {
-		return replace_macros(get_markup_template('wikilist.tpl'), array(
-			'$header' => t('Wiki List'),
-			'$channel' => $channel['channel_address'],
-			'$wikis' => $wikis['wikis'],
-			// If the observer is the local channel owner, show the wiki controls
-			'$owner' => ((local_channel() && local_channel() === intval(\App::$profile['uid'])) ? true : false),
-			'$edit' => t('Edit'),
-			'$download' => t('Download'),
-			'$view' => t('View'),
-			'$addnew' => t('Add new wiki')
-		));
-	}
-	return '';
 }
 
 function widget_wiki_pages($arr) {

--- a/view/tpl/wiki.tpl
+++ b/view/tpl/wiki.tpl
@@ -43,35 +43,6 @@
     <h2><span id="wiki-header-name">{{$wikiheaderName}}</span>: <span id="wiki-header-page">{{$wikiheaderPage}}</span></h2>
     <div class="clear"></div>
   </div>
-	<div id="new-wiki-form-wrapper" class="section-content-tools-wrapper" style="display:none;">
-      <form id="new-wiki-form" action="wiki/{{$channel}}/create/wiki" method="post" class="acl-form" data-form_id="new-wiki-form" data-allow_cid='{{$allow_cid}}' data-allow_gid='{{$allow_gid}}' data-deny_cid='{{$deny_cid}}' data-deny_gid='{{$deny_gid}}'>
-        <div class="clear"></div>
-        {{include file="field_input.tpl" field=$wikiName}}
-        
-        <div id="post-visible-container" class="form-group field checkbox"> 
-          <span style="font-size:1.2em;" class="pull-left">Send notification post?</span>                            
-          <div style="margin-left:20px" class="pull-left">
-              <input name="postVisible" id="postVisible" value="0" type="checkbox">
-              <label class="switchlabel" for="postVisible"> 
-                  <span class="onoffswitch-inner" data-on="Post" data-off="None"></span>
-                  <span class="onoffswitch-switch"></span>
-              </label>
-          </div>
-        </div>
-        
-        <div class="btn-group pull-right">
-            <div id="profile-jot-submit-right" class="btn-group">
-                <button id="dbtn-acl" class="btn btn-default btn-sm" data-toggle="modal" data-target="#aclModal" title="Permission settings" onclick="return false;">
-                    <i id="jot-perms-icon" class="fa fa-{{$lockstate}} jot-icons"></i>{{$bang}}
-                </button>
-                <button id="new-wiki-submit" class="btn btn-primary" type="submit" name="submit" >Create Wiki</button>
-            </div>
-        </div>
-      </form>        
-     {{$acl}}
-     <div class="clear"></div>
-     <hr>
-    </div>
   
 	<div id="edit-wiki-form-wrapper" class="section-content-tools-wrapper" style="display:none;">
       <form id="edit-wiki-form" action="wiki/edit/wiki" method="post" >

--- a/view/tpl/wiki.tpl
+++ b/view/tpl/wiki.tpl
@@ -44,17 +44,6 @@
     <div class="clear"></div>
   </div>
   
-	<div id="edit-wiki-form-wrapper" class="section-content-tools-wrapper" style="display:none;">
-      <form id="edit-wiki-form" action="wiki/edit/wiki" method="post" >
-        <div class="clear"></div>
-        
-        <div class="btn-group pull-right">
-            <!--<button id="edit-wiki-submit" class="btn btn-success" type="submit" name="submit" >Edit Wiki</button>-->
-						<button class="btn btn-md btn-danger" onclick="wiki_delete_wiki(window.wiki_title, window.wiki_resource_id); return false;"><i class="fa fa-trash-o"></i>&nbsp;Delete Wiki</button>
-        </div>
-      </form>        <div class="clear"></div>
-      <hr>
-    </div>
 		
 	<div id="new-page-form-wrapper" class="section-content-tools-wrapper" style="display:none;">
       <form id="new-page-form" action="wiki/create/page" method="post" >

--- a/view/tpl/wikilist.tpl
+++ b/view/tpl/wikilist.tpl
@@ -11,5 +11,35 @@
 		{{/if}}
 		{{if $owner}}<li><a href="#" class="fakelink" onclick="wiki_show_new_wiki_form(); return false;"><i id="new-wiki-button" class="fa fa-plus-circle"></i>&nbsp;{{$addnew}}</a></li>{{/if}}
 		</ul>
+		{{if $owner}}
+	<div id="new-wiki-form-wrapper" class="section-content-tools-wrapper" style="display:none;">
+      <form id="new-wiki-form" action="wiki/{{$channel}}/create/wiki" method="post" class="acl-form" data-form_id="new-wiki-form" data-allow_cid='{{$allow_cid}}' data-allow_gid='{{$allow_gid}}' data-deny_cid='{{$deny_cid}}' data-deny_gid='{{$deny_gid}}'>
+        <div class="clear"></div>
+        {{include file="field_input.tpl" field=$wikiName}}
+        
+        <div id="post-visible-container" class="form-group field checkbox"> 
+          <span style="font-size:1.2em;" class="pull-left">Send notification post?</span>                            
+          <div style="margin-left:20px" class="pull-left">
+              <input name="postVisible" id="postVisible" value="0" type="checkbox">
+              <label class="switchlabel" for="postVisible"> 
+                  <span class="onoffswitch-inner" data-on="Post" data-off="None"></span>
+                  <span class="onoffswitch-switch"></span>
+              </label>
+          </div>
+        </div>
+				<br><br>
+        <div class="btn-group pull-right">
+            <div id="profile-jot-submit-right" class="btn-group">
+                <button id="dbtn-acl" class="btn btn-default btn-sm" data-toggle="modal" data-target="#aclModal" title="Permission settings" onclick="return false;">
+                    <i id="jot-perms-icon" class="fa fa-{{$lockstate}} jot-icons"></i>{{$bang}}
+                </button>
+                <button id="new-wiki-submit" class="btn btn-primary btn-sm" type="submit" name="submit" >Create Wiki</button>
+            </div>
+        </div>
+      </form>        
+     {{$acl}}
+     <div class="clear"></div>
+    </div>
+		{{/if}}
 </div>
 

--- a/view/tpl/wikilist.tpl
+++ b/view/tpl/wikilist.tpl
@@ -3,7 +3,7 @@
 		<ul class="nav nav-pills nav-stacked">
 		{{if $wikis}}		
 		{{foreach $wikis as $wiki}}
-		<li>{{if $owner}}<a href="#" onclick="$('div[id^=\'edit-wiki-form-wrapper\']').hide(); $('div[id^=\'new-wiki-form-wrapper\']').hide(); openClose('edit-wiki-form-wrapper-{{$wiki.resource_id}}'); return false;" class="pull-right wikilist" title="{{$edit}}"><i class="fa fa-pencil"></i></a>{{/if}}
+		<li {{if $wiki.active}}class="active"{{/if}}>{{if $owner}}<a href="#" onclick="$('div[id^=\'edit-wiki-form-wrapper\']').hide(); $('div[id^=\'new-wiki-form-wrapper\']').hide(); openClose('edit-wiki-form-wrapper-{{$wiki.resource_id}}'); return false;" class="pull-right wikilist" title="{{$edit}}"><i class="fa fa-pencil"></i></a>{{/if}}
 				<a href="#" onclick="wiki_download_wiki('{{$wiki.resource_id}}'); return false;" title="{{$download}}" class="pull-right wikilist"><i class="fa fa-download"></i></a>
 				<a href="/wiki/{{$channel}}/{{$wiki.urlName}}/Home" title="{{$view}}">{{$wiki.title}}</a>
 				{{if $owner}}

--- a/view/tpl/wikilist.tpl
+++ b/view/tpl/wikilist.tpl
@@ -3,42 +3,54 @@
 		<ul class="nav nav-pills nav-stacked">
 		{{if $wikis}}		
 		{{foreach $wikis as $wiki}}
-        <li>{{if $owner}}<a href="#" onclick="wiki_show_edit_wiki_form('{{$wiki.title}}', '{{$wiki.resource_id}}'); return false;" class="pull-right wikilist" title="{{$edit}}"><i class="fa fa-pencil"></i></a>{{/if}}
-			<a href="#" onclick="wiki_download_wiki('{{$wiki.resource_id}}'); return false;" title="{{$download}}" class="pull-right wikilist"><i class="fa fa-download"></i></a>
-			<a href="/wiki/{{$channel}}/{{$wiki.urlName}}/Home" title="{{$view}}">{{$wiki.title}}</a>
-        </li> 
+		<li>{{if $owner}}<a href="#" onclick="$('div[id^=\'edit-wiki-form-wrapper\']').hide(); $('div[id^=\'new-wiki-form-wrapper\']').hide(); openClose('edit-wiki-form-wrapper-{{$wiki.resource_id}}'); return false;" class="pull-right wikilist" title="{{$edit}}"><i class="fa fa-pencil"></i></a>{{/if}}
+				<a href="#" onclick="wiki_download_wiki('{{$wiki.resource_id}}'); return false;" title="{{$download}}" class="pull-right wikilist"><i class="fa fa-download"></i></a>
+				<a href="/wiki/{{$channel}}/{{$wiki.urlName}}/Home" title="{{$view}}">{{$wiki.title}}</a>
+				{{if $owner}}
+
+				<div id="edit-wiki-form-wrapper-{{$wiki.resource_id}}" class="section-content-tools-wrapper" style="display:none;">
+						<form id="edit-wiki-form" action="wiki/edit/wiki" method="post" >
+								<div class="clear"></div>
+								<div class="btn-group pull-right">
+										<button class="btn btn-xs btn-danger" onclick="wiki_delete_wiki('{{$wiki.title}}', '{{$wiki.resource_id}}'); return false;"><i class="fa fa-trash-o"></i>&nbsp;Delete Wiki</button>
+								</div>
+						</form>        
+						<div class="clear"></div>
+				</div>
+				{{/if}}
+		</li> 
 		{{/foreach}}
 		{{/if}}
 		{{if $owner}}<li><a href="#" class="fakelink" onclick="wiki_show_new_wiki_form(); return false;"><i id="new-wiki-button" class="fa fa-plus-circle"></i>&nbsp;{{$addnew}}</a></li>{{/if}}
 		</ul>
 		{{if $owner}}
-	<div id="new-wiki-form-wrapper" class="section-content-tools-wrapper" style="display:none;">
-      <form id="new-wiki-form" action="wiki/{{$channel}}/create/wiki" method="post" class="acl-form" data-form_id="new-wiki-form" data-allow_cid='{{$allow_cid}}' data-allow_gid='{{$allow_gid}}' data-deny_cid='{{$deny_cid}}' data-deny_gid='{{$deny_gid}}'>
-        <div class="clear"></div>
-        {{include file="field_input.tpl" field=$wikiName}}
-        
-        <div id="post-visible-container" class="form-group field checkbox"> 
-          <span style="font-size:1.2em;" class="pull-left">Send notification post?</span>                            
-          <div style="margin-left:20px" class="pull-left">
-              <input name="postVisible" id="postVisible" value="0" type="checkbox">
-              <label class="switchlabel" for="postVisible"> 
-                  <span class="onoffswitch-inner" data-on="Post" data-off="None"></span>
-                  <span class="onoffswitch-switch"></span>
-              </label>
-          </div>
-        </div>
-				<br><br>
-        <div class="btn-group pull-right">
-            <div id="profile-jot-submit-right" class="btn-group">
-                <button id="dbtn-acl" class="btn btn-default btn-sm" data-toggle="modal" data-target="#aclModal" title="Permission settings" onclick="return false;">
-                    <i id="jot-perms-icon" class="fa fa-{{$lockstate}} jot-icons"></i>{{$bang}}
-                </button>
-                <button id="new-wiki-submit" class="btn btn-primary btn-sm" type="submit" name="submit" >Create Wiki</button>
-            </div>
-        </div>
-      </form>        
-     {{$acl}}
-     <div class="clear"></div>
+		<div id="new-wiki-form-wrapper" class="section-content-tools-wrapper" style="display:none;">
+				<form id="new-wiki-form" action="wiki/{{$channel}}/create/wiki" method="post" class="acl-form" data-form_id="new-wiki-form" data-allow_cid='{{$allow_cid}}' data-allow_gid='{{$allow_gid}}' data-deny_cid='{{$deny_cid}}' data-deny_gid='{{$deny_gid}}'>
+						<div class="clear"></div>
+						{{include file="field_input.tpl" field=$wikiName}}
+
+						<div id="post-visible-container" class="form-group field checkbox"> 
+								<span style="font-size:1.2em;" class="pull-left">Send notification post?</span>                            
+								<div style="margin-left:20px" class="pull-left">
+										<input name="postVisible" id="postVisible" value="0" type="checkbox">
+										<label class="switchlabel" for="postVisible"> 
+												<span class="onoffswitch-inner" data-on="Post" data-off="None"></span>
+												<span class="onoffswitch-switch"></span>
+										</label>
+								</div>
+						</div>
+						<br><br>
+						<div class="btn-group pull-right">
+								<div id="profile-jot-submit-right" class="btn-group">
+										<button id="dbtn-acl" class="btn btn-default btn-sm" data-toggle="modal" data-target="#aclModal" title="Permission settings" onclick="return false;">
+												<i id="jot-perms-icon" class="fa fa-{{$lockstate}} jot-icons"></i>{{$bang}}
+										</button>
+										<button id="new-wiki-submit" class="btn btn-primary btn-sm" type="submit" name="submit" >Create Wiki</button>
+								</div>
+						</div>
+				</form>        
+				{{$acl}}
+				<div class="clear"></div>
     </div>
 		{{/if}}
 </div>

--- a/view/tpl/wikilist.tpl
+++ b/view/tpl/wikilist.tpl
@@ -21,7 +21,7 @@
 		</li> 
 		{{/foreach}}
 		{{/if}}
-		{{if $owner}}<li><a href="#" class="fakelink" onclick="wiki_show_new_wiki_form(); return false;"><i id="new-wiki-button" class="fa fa-plus-circle"></i>&nbsp;{{$addnew}}</a></li>{{/if}}
+		{{if $owner}}<li><a href="#" class="fakelink" onclick="$('div[id^=\'edit-wiki-form-wrapper\']').hide(); openClose('new-wiki-form-wrapper'); return false;"><i id="new-wiki-button" class="fa fa-plus-circle"></i>&nbsp;{{$addnew}}</a></li>{{/if}}
 		</ul>
 		{{if $owner}}
 		<div id="new-wiki-form-wrapper" class="section-content-tools-wrapper" style="display:none;">


### PR DESCRIPTION
@git-marijus Here's another idea.  	

Highlight active wiki in list in preparation for removing active wiki name from content section header to make room for page list viewer