### PR TITLE
fixes for wiki create/delete page

### DIFF
--- a/Zotlabs/Module/Wiki.php
+++ b/Zotlabs/Module/Wiki.php
@@ -416,7 +416,7 @@ class Wiki extends \Zotlabs\Web\Controller {
 			}
 			$page = Zlib\NativeWikiPage::create_page($owner['channel_id'],$observer_hash, $name, $resource_id);
 
-			if($page['success']) {
+			if($page['item_id']) {
 				$ob = \App::get_observer();
 				$commit = Zlib\NativeWikiPage::commit(array(
 					'commit_msg'    => t('New page created'), 
@@ -547,20 +547,8 @@ class Wiki extends \Zotlabs\Web\Controller {
 
 			$deleted = Zlib\NativeWikiPage::delete_page(array('channel_id' => $owner['channel_id'], 'observer_hash' => $observer_hash, 'resource_id' => $resource_id, 'pageUrlName' => $pageUrlName));
 			if($deleted['success']) {
-				$ob = \App::get_observer();
-				$commit = Zlib\NativeWikiPage::git_commit(array(
-					'commit_msg' => 'Deleted ' . $pageUrlName, 
-					'resource_id' => $resource_id, 
-					'observer' => $ob,
-					'files' => null
-				));
-				if($commit['success']) {
-					Zlib\NativeWiki::sync_a_wiki_item($owner['channel_id'],$commit['item_id'],$resource_id);
-					json_return_and_die(array('message' => 'Wiki git repo commit made', 'success' => true));
-				}
-				else {
-					json_return_and_die(array('message' => 'Error making git commit','success' => false));					
-				}
+				Zlib\NativeWiki::sync_a_wiki_item($owner['channel_id'],$commit['item_id'],$resource_id);
+				json_return_and_die(array('message' => 'Wiki git repo commit made', 'success' => true));
 			}
 			else {
 				json_return_and_die(array('message' => 'Error deleting page', 'success' => false));					

--- a/include/items.php
+++ b/include/items.php
@@ -383,15 +383,18 @@ function post_activity_item($arr,$allow_code = false,$deliver = true) {
 	}
 
 	$post = item_store($arr,$allow_code,$deliver);
-	if($post['success'])
+
+	if($post['success']) {
 		$post_id = $post['item_id'];
+		$ret['item_id'] = $post_id;
+	}
 
 	if($post_id && $deliver) {
 		$arr['id'] = $post_id;
 		call_hooks('post_local_end', $arr);
 		Zotlabs\Daemon\Master::Summon(array('Notifier','activity',$post_id));
 		$ret['success'] = true;
-		$ret['item_id'] = $post_id;
+		//$ret['item_id'] = $post_id;
 		$ret['activity'] = $post['item'];
 	}
 


### PR DESCRIPTION
This pullrequest addresses three issues:
1. Creating a new page failed because `post_activity_item()` did not return anything if `$deliver = false`. I changed it to at least return the `$post_id` which we need to proceed...

2. Deleting a page failed because we tried to create a commit for the already deleted item. I stripped away the commit part (could probably commit before deletion but the page was deleted anyway there is no need for the commit).

3. The pagelist widget returned "(No Title)" items for deleted pages. I added `and item_hidden = 0` to the query.

Please review!