### PR TITLE
Addon repo management GUI

### DIFF
--- a/Zotlabs/Module/Admin/Plugins.php
+++ b/Zotlabs/Module/Admin/Plugins.php
@@ -36,7 +36,7 @@ class Plugins {
 							json_return_and_die(array('message' => 'Error creating extend folder: ' . $extendDir, 'success' => false));
 						}
 						else {
-							if (!symlink('extend/addon', $addonDir)) {
+							if (!symlink(realpath('extend/addon'), $addonDir)) {
 								logger('Error creating symlink to addon folder: ' . $addonDir);
 								json_return_and_die(array('message' => 'Error creating symlink to addon folder: ' . $addonDir, 'success' => false));
 							}
@@ -57,7 +57,7 @@ class Plugins {
 							$files = array_diff(scandir($repoDir), array('.', '..'));
 							foreach ($files as $file) {
 								if (is_dir($repoDir . '/' . $file) && $file !== '.git') {
-									$source = 'extend/addon/' . $repoName . '/' . $file;
+									$source = '../extend/addon/' . $repoName . '/' . $file;
 									$target = realpath('addon/') . '/' . $file;
 									unlink($target);
 									if (!symlink($source, $target)) {
@@ -86,7 +86,7 @@ class Plugins {
 							logger('Error creating extend folder: ' . $extendDir);
 							json_return_and_die(array('message' => 'Error creating extend folder: ' . $extendDir, 'success' => false));
 						} else {
-							if (!symlink('extend/addon', $addonDir)) {
+							if (!symlink(realpath('extend/addon'), $addonDir)) {
 								logger('Error creating symlink to addon folder: ' . $addonDir);
 								json_return_and_die(array('message' => 'Error creating symlink to addon folder: ' . $addonDir, 'success' => false));
 							}
@@ -119,7 +119,7 @@ class Plugins {
 								logger('Error creating extend folder: ' . $extendDir);
 								json_return_and_die(array('message' => 'Error creating extend folder: ' . $extendDir, 'success' => false));
 							} else {
-								if (!symlink('extend/addon', $addonDir)) {
+								if (!symlink(realpath('extend/addon'), $addonDir)) {
 									logger('Error creating symlink to addon folder: ' . $addonDir);
 									json_return_and_die(array('message' => 'Error creating symlink to addon folder: ' . $addonDir, 'success' => false));
 								}
@@ -156,7 +156,7 @@ class Plugins {
 						$files = array_diff(scandir($repoDir), array('.', '..'));
 						foreach ($files as $file) {
 							if (is_dir($repoDir . '/' . $file) && $file !== '.git') {
-								$source = 'extend/addon/' . $repoName . '/' . $file;
+								$source = '../extend/addon/' . $repoName . '/' . $file;
 								$target = realpath('addon/') . '/' . $file;
 								unlink($target);
 								if (!symlink($source, $target)) {
@@ -176,13 +176,13 @@ class Plugins {
 						$repoURL = $_REQUEST['repoURL'];
 						$extendDir = 'store/[data]/git/sys/extend';
 						$addonDir = $extendDir . '/addon';
-						$tempAddonDir = 'store/[data]/git/sys/temp';
+						$tempAddonDir = realpath('store/[data]') . '/git/sys/temp';
 						if (!file_exists($extendDir)) {
 							if (!mkdir($extendDir, 0770, true)) {
 								logger('Error creating extend folder: ' . $extendDir);
 								json_return_and_die(array('message' => 'Error creating extend folder: ' . $extendDir, 'success' => false));
 							} else {
-								if (!symlink('extend/addon', $addonDir)) {
+								if (!symlink(realpath('extend/addon'), $addonDir)) {
 									logger('Error creating symlink to addon folder: ' . $addonDir);
 									json_return_and_die(array('message' => 'Error creating symlink to addon folder: ' . $addonDir, 'success' => false));
 								}
@@ -395,6 +395,10 @@ class Plugins {
 	
 		usort($plugins,'self::plugin_sort');
 
+		$allowManageRepos = false;
+		if(is_writable('extend/addon') && is_writable('store/[data]')) {
+			$allowManageRepos = true;
+		} 
 		
 		$admin_plugins_add_repo_form= replace_macros(
 			get_markup_template('admin_plugins_addrepo.tpl'), array(
@@ -432,6 +436,7 @@ class Plugins {
 			'$plugins' => $plugins,
 			'$disabled' => t('Disabled - version incompatibility'),
 			'$form_security_token' => get_form_security_token('admin_plugins'),
+			'$allowManageRepos' => $allowManageRepos,
 			'$managerepos' => t('Manage Repos'),
 			'$installedtitle' => t('Installed Plugin Repositories'),
 			'$addnewrepotitle' =>	t('Install a New Plugin Repository'),

--- a/doc/context/en/admin/plugins/help.html
+++ b/doc/context/en/admin/plugins/help.html
@@ -1,0 +1,11 @@
+<dl class="dl-horizontal">
+    <dt>General</dt>
+    <dd>This page manages which addons (also known as plugins) are installed.</dd>
+    <dt>Manage Repos</dt>
+    <dd>If your webserver has the necessary write permissions, you will see a button labeled <b>Manage Repos</b>, 
+		which opens a control panel for managing what addon <i>repositories</i> are installed. These repos are 
+		stored in <span style="font-family: monospace;">extend/addon/[repo name]/</span>. The official Hubzilla 
+		addon repo can be added by entering the repo URL
+		<span style="font-family: monospace;">https://github.com/redmatrix/hubzilla-addons.git</span>
+		and choosing a name for the repo such as <b>official</b>.</dd>
+</dl>

--- a/view/tpl/admin_plugins.tpl
+++ b/view/tpl/admin_plugins.tpl
@@ -1,8 +1,10 @@
 <div class="generic-content-wrapper">
 	<div class="section-title-wrapper">
+		{{if $allowManageRepos}}
 		<div class="pull-right">
 			<button class="btn btn-success btn-xs" onclick="openClose('form');">{{$managerepos}}</button>
 		</div>
+		{{/if}}
 		<h2 id="title">{{$title}} - {{$page}}</h2>
 		<div class="clear"></div>
 	</div>
@@ -18,7 +20,7 @@
         {{foreach $addonrepos as $repo}}
         <tr>
             <td style="width: 70%;">
-              <span class="pull-left">{{$repo.name}}</span>
+				<span class="pull-left">{{$repo.name}}</span><span id="update-message-{{$repo.name}}" style="margin-left: 20px;"></span>
             </td>
             <td style="width: 15%;">
               <button class="btn btn-xs btn-primary pull-right" style="margin-left: 10px; margin-right: 10px;" onclick="updateAddonRepo('{{$repo.name}}'); return false;"><i class='fa fa-download'></i>&nbsp;{{$repoUpdateButton}}</button>
@@ -139,10 +141,20 @@
             function(response) {
                 if (response.success) {
                   window.console.log('Addon repo '+repoName+' successfully updated :' + response['message']);
-                  alert('Addon repo updated.');
+                  //alert('Addon repo updated.');
+				  $('#update-message-' + repoName).css('background-color', 'yellow');
+				  $('#update-message-' + repoName).html('Repo updated!');
+				  setTimeout(function () {
+					  $('#update-message-' + repoName).html('');
+				  }, 60000);
                 } else {
                   window.console.log('Error updating repo :' + response['message']);
-                  alert('Error updating addon repo!');
+                  //alert('Error updating addon repo!');
+				  $('#update-message-' + repoName).css('background-color', 'red');
+				  $('#update-message-' + repoName).html('Error updating repo!');
+				  setTimeout(function () {
+					  $('#update-message-' + repoName).html('');
+				  }, 60000);
                 }
                 return false;
             },


### PR DESCRIPTION
Fixed numerous bugs with the addon repo management GUI. 
Only show Manage Repos button if webserver has write permission on extend/addon/.
Add some context help.