### PR TITLE
if there is no site record, site_dead won't be 0, in a left join it w…

### DIFF
--- a/Zotlabs/Daemon/Notifier.php
+++ b/Zotlabs/Daemon/Notifier.php
@@ -480,7 +480,7 @@ class Notifier {
 		// Let's reduce this to a set of hubs; checking that the site is not dead.
 
 		$r = q("select hubloc.*, site.site_crypto from hubloc left join site on site_url = hubloc_url where hubloc_hash in (" . implode(',',$recipients) . ") 
-			and hubloc_error = 0 and hubloc_deleted = 0 and site_dead = 0"
+			and hubloc_error = 0 and hubloc_deleted = 0 and ( site_dead = 0 OR site_dead is null ) "
 		);		
  
 


### PR DESCRIPTION
…ill in fact be null. As long as it isn't 1, we should attempt delivery.