### PR TITLE
abook_not_here flag created to indicate singleton connections which a…

### DIFF
--- a/Zotlabs/Module/Import.php
+++ b/Zotlabs/Module/Import.php
@@ -318,6 +318,7 @@ class Import extends \Zotlabs\Web\Controller {
 				unset($abook['abconfig']);
 				unset($abook['abook_their_perms']);
 				unset($abook['abook_my_perms']);
+				unset($abook['abook_not_here']);
 
 				$abook['abook_account'] = $account_id;
 				$abook['abook_channel'] = $channel['channel_id'];
@@ -347,7 +348,7 @@ class Import extends \Zotlabs\Web\Controller {
 						continue;
 				}
 
-				create_table_from_array('abook',$abook);
+				abook_store_lowlevel($abook);
 
 				$friends ++;
 				if(intval($abook['abook_feed']))

--- a/boot.php
+++ b/boot.php
@@ -52,7 +52,7 @@ define ( 'PLATFORM_NAME',           'hubzilla' );
 define ( 'STD_VERSION',             '2.3.5' );
 define ( 'ZOT_REVISION',            '1.2' );
 
-define ( 'DB_UPDATE_VERSION',       1190  );
+define ( 'DB_UPDATE_VERSION',       1191  );
 
 define ( 'PROJECT_BASE',   __DIR__ );
 

--- a/include/connections.php
+++ b/include/connections.php
@@ -23,6 +23,7 @@ function abook_store_lowlevel($arr) {
 		'abook_unconnected' => ((array_key_exists('abook_unconnected',$arr)) ? $arr['abook_unconnected'] : 0),
 		'abook_self'        => ((array_key_exists('abook_self',$arr))        ? $arr['abook_self']        : 0),
 		'abook_feed'        => ((array_key_exists('abook_feed',$arr))        ? $arr['abook_feed']        : 0),
+		'abook_not_here'    => ((array_key_exists('abook_not_here',$arr))    ? $arr['abook_not_here']    : 0),
 		'abook_profile'     => ((array_key_exists('abook_profile',$arr))     ? $arr['abook_profile']     : ''),
 		'abook_incl'        => ((array_key_exists('abook_incl',$arr))        ? $arr['abook_incl']        : ''),
 		'abook_excl'        => ((array_key_exists('abook_excl',$arr))        ? $arr['abook_excl']        : ''),

--- a/include/zot.php
+++ b/include/zot.php
@@ -3226,11 +3226,9 @@ function process_channel_sync_delivery($sender, $arr, $deliveries) {
 			}
 
 
-			$disallowed = array('abook_id','abook_account','abook_channel','abook_rating','abook_rating_text');
+			$disallowed = array('abook_id','abook_account','abook_channel','abook_rating','abook_rating_text','abook_not_here');
 
 			foreach($arr['abook'] as $abook) {
-
-
 
 				$abconfig = null;
 

--- a/install/schema_mysql.sql
+++ b/install/schema_mysql.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS `abook` (
   `abook_unconnected` tinyint(4) NOT NULL DEFAULT '0',
   `abook_self` tinyint(4) NOT NULL DEFAULT '0',
   `abook_feed` tinyint(4) NOT NULL DEFAULT '0',
+  `abook_not_here` tinyint(4) NOT NULL DEFAULT '0',
   `abook_profile` char(64) NOT NULL DEFAULT '',
   `abook_incl` TEXT NOT NULL DEFAULT '',
   `abook_excl` TEXT NOT NULL DEFAULT '',
@@ -58,6 +59,7 @@ CREATE TABLE IF NOT EXISTS `abook` (
   KEY `abook_pending` (`abook_pending`),
   KEY `abook_unconnected` (`abook_unconnected`),
   KEY `abook_self` (`abook_self`),
+  KEY `abook_not_here` (`abook_not_here`),
   KEY `abook_feed` (`abook_feed`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;
 

--- a/install/schema_postgres.sql
+++ b/install/schema_postgres.sql
@@ -32,6 +32,7 @@ CREATE TABLE "abook" (
   "abook_unconnected" smallint NOT NULL DEFAULT '0',
   "abook_self" smallint NOT NULL DEFAULT '0',
   "abook_feed" smallint NOT NULL DEFAULT '0',
+  "abook_not_here" smallint NOT NULL DEFAULT '0',
   "abook_profile" char(64) NOT NULL DEFAULT '',
   "abook_incl" TEXT NOT NULL DEFAULT '',
   "abook_excl" TEXT NOT NULL DEFAULT '',
@@ -55,6 +56,7 @@ CREATE TABLE "abook" (
   create index  "abook_unconnected"  on abook ("abook_unconnected");
   create index  "abook_self"  on abook ("abook_self");
   create index  "abook_feed"  on abook ("abook_feed");
+  create index  "abook_not_here"  on abook ("abook_not_here");
   create index  "abook_profile" on abook  ("abook_profile");
   create index  "abook_dob" on abook  ("abook_dob");
   create index  "abook_connected" on abook  ("abook_connected");

--- a/install/update.php
+++ b/install/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'UPDATE_VERSION' , 1190 );
+define( 'UPDATE_VERSION' , 1191 );
 
 /**
  *
@@ -2532,3 +2532,12 @@ function update_r1189() {
 
 }
 
+function update_r1190() {
+	$r1 = q("alter table abook add abook_not_here int(11) not null default '0' ");
+
+	$r2 = q("create index abook_not_here on abook (abook_not_here)");
+
+	if($r1 && $r2)
+		return UPDATE_SUCCESS;
+    return UPDATE_FAILED;
+}


### PR DESCRIPTION
…re connected to this channel but not on this hub. abook_instance enumerates which hubs the connections is valid, but we ultimately need something more efficiently searchable to decide what operations are supported w/r/t this connection in the context of this hub. This flag is ignored during sync to clones although the code to set it correctly during channel creation, import, and sync has not yet been implemented.