### PR TITLE
markdown autolinks - hubzilla bug #752

### DIFF
--- a/Zotlabs/Lib/MarkdownSoap.php
+++ b/Zotlabs/Lib/MarkdownSoap.php
@@ -77,13 +77,20 @@ class MarkdownSoap {
 	}
 
 	function purify($s) {
-//		$s = str_replace("\n",'<br>',$s);
-//		$s = str_replace("\t",'&nbsp;&nbsp;&nbsp;&nbsp;',$s);
-//		$s = str_replace(' ','&nbsp;',$s);
+		$s = $this->protect_autolinks($s);
 		$s = purify_html($s);
-//		$s = str_replace(['&nbsp;', mb_convert_encoding('&#x00a0;','UTF-8','HTML-ENTITIES')], [ ' ', ' ' ],$s);
-//		$s = str_replace(['<br>','<br />', '&lt;', '&gt;' ],["\n","\n", '<', '>'],$s);
+		$s = $this->unprotect_autolinks($s);
 		return $s;
+	}
+
+	function protect_autolinks($s) {
+		$s = preg_replace('/\<(https?\:\/\/)(.*?)\>/','[$1$2]($1$2)',$s);
+		return $s;
+	}
+
+	function unprotect_autolinks($s) {
+		return $s;
+
 	}
 
 	function escape($s) {


### PR DESCRIPTION
Fixed for the case of simple http/https links. Will need further work for email addresses. Basically the autolinks are converted to regular markdown links prior to html purification. They are not converted back so view source after storage will show them as regular markdown links. 