### PR TITLE
:construction_worker::white_check_mark: Add MySQL 5.7 in TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,12 @@ matrix:
       dist: precise
       services:
         - mysql
+    # MySQL 5.7 with Docker container
+    - php: '7.1'
+      env: DB=mysql MYSQL_VERSION=5.7
+      sudo: required
+      services:
+        - docker
    # Excludes from default matrix combinations
 #  exclude:
 #    - php: hhvm
@@ -100,6 +106,8 @@ cache:
 
 before_install:
   - travis_retry composer self-update
+  # Start MySQL 5.7 Docker container, needs some time to come up
+  - if [[ "$MYSQL_VERSION" == "5.7" ]]; then sudo service mysql stop; docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:5.7 && sleep 25 && docker ps; fi
 
 # Install composer dev libs
 install:

--- a/tests/travis/prepare_mysql.sh
+++ b/tests/travis/prepare_mysql.sh
@@ -27,22 +27,27 @@ set -e
 
 echo "Preparing for MySQL ..."
 
+if [[ "$MYSQL_VERSION" == "5.7" ]]; then
+	echo "Using MySQL 5.7 in Docker container, need to use TCP"
+	export PROTO="--protocol=TCP"
+fi
+
 # Print out some MySQL information
 mysql --version
-mysql -e "SELECT VERSION();"
-mysql -e "SHOW VARIABLES LIKE 'max_allowed_packet';"
-mysql -e "SHOW VARIABLES LIKE 'collation_%';"
-mysql -e "SHOW VARIABLES LIKE 'character_set%';"
-mysql -e "SELECT @@sql_mode;"
+mysql $PROTO -e "SELECT VERSION();"
+mysql $PROTO -e "SHOW VARIABLES LIKE 'max_allowed_packet';"
+mysql $PROTO -e "SHOW VARIABLES LIKE 'collation_%';"
+mysql $PROTO -e "SHOW VARIABLES LIKE 'character_set%';"
+mysql $PROTO -e "SELECT @@sql_mode;"
 
 # Create Hubzilla database
-mysql -u root -e "CREATE DATABASE IF NOT EXISTS hubzilla;";
-mysql -u root -e "CREATE USER 'hubzilla'@'localhost' IDENTIFIED BY 'hubzilla';"
-mysql -u root -e "GRANT ALL ON hubzilla.* TO 'hubzilla'@'localhost';"
+mysql $PROTO -u root -e "CREATE DATABASE IF NOT EXISTS hubzilla;";
+mysql $PROTO -u root -e "CREATE USER 'hubzilla'@'localhost' IDENTIFIED BY 'hubzilla';"
+mysql $PROTO -u root -e "GRANT ALL ON hubzilla.* TO 'hubzilla'@'localhost';"
 
 # Import table structure
-mysql -u root hubzilla < ./install/schema_mysql.sql
+mysql $PROTO -u root hubzilla < ./install/schema_mysql.sql
 
 # Show databases and tables
-mysql -u root -e "SHOW DATABASES;"
-mysql -u root -e "USE hubzilla; SHOW TABLES;"
+mysql $PROTO -u root -e "SHOW DATABASES;"
+mysql $PROTO -u root -e "USE hubzilla; SHOW TABLES;"


### PR DESCRIPTION
Use a Docker container to add MySQL 5.7 in TravisCI.
A lot of sql_mode settings have changed with 5.7, so finnaly provide it to test against it.
Will help to test for failures like #803 