### PR TITLE
Bug827

### DIFF
--- a/Zotlabs/Lib/ActivityStreams2.php
+++ b/Zotlabs/Lib/ActivityStreams2.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Zotlabs\Lib;
+
+
+class ActivityStreams2 {
+
+	public $data;
+	public $valid = false;
+	public $id    = '';
+	public $type  = '';
+	public $actor = null;
+	public $obj   = null;
+	public $tgt   = null;
+
+	function __construct($string) {
+
+		$this->data = json_decode($string,true);
+		if($this->data) {
+			$this->valid = true;
+		}
+
+		if($this->is_valid()) {
+			$this->id    = $this->get_property_obj('id');
+			$this->type  = $this->get_primary_type();
+			$this->actor = $this->get_compound_property('actor');
+			$this->obj   = $this->get_compound_property('object');
+			$this->tgt   = $this->get_compound_property('target');
+		}
+	}
+
+	function is_valid() {
+		return $this->valid;
+	}
+
+	function get_property_obj($property,$base = '') {
+		if(! $base) {
+			$base = $this->data;
+		}
+		return $base[$property];
+	}
+
+	function fetch_property($url) {
+		$redirects = 0;
+		$x = z_fetch_url($url,true,$redirects,
+			['headers' => [ 'Accept' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"']]);
+		if($x['success'])
+			return json_decode($x['body'],true);
+		return null;
+	}
+
+	function get_compound_property($property,$base = '') {
+		$x = $this->get_property_obj($property,$base);
+		if($this->is_url($x)) {
+			$x = $this->fetch_property($x); 	
+		}
+		return $x;
+	}
+
+	function is_url($url) {
+		if(($url) && (! is_array($url)) && (strpos($url,'http') === 0)) {
+			return true;
+		}
+		return false;
+	}
+
+	function get_primary_type($base = '') {
+		if(! $base)
+			$base = $this->data;
+		$x = $this->get_property_obj('type',$base);
+		if(is_array($x)) {
+			foreach($x as $y) {
+				if(strpos($y,':') === false) {
+					return $y;
+				}
+			}
+		}
+		return $x;
+	}
+
+	function debug() {
+		$x = var_export($this,true);
+		return $x;
+	}
+
+}

--- a/include/feedutils.php
+++ b/include/feedutils.php
@@ -1040,6 +1040,11 @@ function consume_feed($xml, $importer, &$contact, $pass = 0) {
 					$datarray['comment_policy'] = 'none';
 				}
 
+				// if we have everything but a photo, provide the default profile photo
+
+				if($author['author_name'] && $author['author_link'] && (! $author['author_photo']))
+					$author['author_photo'] = z_root() . '/' . get_default_profile_photo(80);
+
 				if((! x($author,'author_name')) || ($author['author_is_feed']))
 					$author['author_name'] = $contact['xchan_name'];
 				if((! x($author,'author_link')) || ($author['author_is_feed']))
@@ -1243,6 +1248,12 @@ function consume_feed($xml, $importer, &$contact, $pass = 0) {
 					$datarray['public_policy'] = 'specific';
 					$datarray['comment_policy'] = 'none';
 				}
+
+
+				// if we have everything but a photo, provide the default profile photo
+
+				if($author['author_name'] && $author['author_link'] && (! $author['author_photo']))
+					$author['author_photo'] = z_root() . '/' . get_default_profile_photo(80);
 
 				if(is_array($contact)) {
 					if((! x($author,'author_name')) || ($author['author_is_feed']))

--- a/include/feedutils.php
+++ b/include/feedutils.php
@@ -1890,17 +1890,17 @@ function i2asld($i) {
 
 	$ret = array();
 
-	$ret['@context'] = array( 'http://www.w3.org/ns/activitystreams', 'zot' => 'http://purl.org/zot/protocol');
+	$ret['@context'] = array( 'https://www.w3.org/ns/activitystreams', 'zot' => 'http://purl.org/zot/protocol');
 
 	if($i['verb']) {
 		if(strpos(dirname($i['verb'],'activitystrea.ms/schema/1.0'))) {
-			$ret['@type'] = ucfirst(basename($i['verb']));
+			$ret['type'] = ucfirst(basename($i['verb']));
 		}
 		elseif(strpos(dirname($i['verb'],'purl.org/zot'))) {
-			$ret['@type'] = 'zot:' . ucfirst(basename($i['verb']));
+			$ret['type'] = 'zot:' . ucfirst(basename($i['verb']));
 		}
 	}
-	$ret['@id'] = $i['plink'];
+	$ret['id'] = $i['plink'];
 
 	$ret['published'] = datetime_convert('UTC','UTC',$i['created'],ATOM_TIME);
 
@@ -1922,7 +1922,7 @@ function asencode_note($i) {
 	$ret = array();
 
 	$ret['@type'] = 'Note';
-	$ret['@id'] = $i['plink'];
+	$ret['id'] = $i['plink'];
 	if($i['title'])
 		$ret['title'] = bbcode($i['title']);
 
@@ -1938,16 +1938,18 @@ function asencode_note($i) {
 
 function asencode_person($p) {
 	$ret = array();
-	$ret['@type'] = 'Person';
-	$ret['@id'] = 'acct:' . $p['xchan_addr'];
-	$ret['displayName'] = $p['xchan_name'];
-	$ret['icon'] = array(
-		'@type' => 'Link',
+	$ret['type'] = 'Person';
+	$ret['id'] = $p['xchan_url'];
+	$ret['name'] = $p['xchan_name'];
+	$ret['image'] = array(
+		'type' => 'Link',
 		'mediaType' => $p['xchan_photo_mimetype'],
-		'href' => $p['xchan_photo_m']
+		'href' => $p['xchan_photo_l'],
+		'height' => 300,
+		'width' => 300
 	);
 	$ret['url'] = array(
-		'@type' => 'Link',
+		'type' => 'Link',
 		'mediaType' => 'text/html',
 		'href' => $p['xchan_url']
 	);

--- a/include/photos.php
+++ b/include/photos.php
@@ -593,6 +593,15 @@ function photos_album_exists($channel_id, $observer_hash, $album) {
 		intval($channel_id)
 	);
 
+	// partial backward compatibility with Hubzilla < 2.4 when we used the filename only 
+	// (ambiguous which would get chosen if you had two albums of the same name in different directories)
+ 
+	if(! $r) {
+		$r = q("SELECT folder, hash, is_dir, filename, os_path, display_path FROM attach WHERE filename = '%s' AND is_dir = 1 AND uid = %d $sql_extra limit 1",
+		dbesc(hex2bin($album)),
+		intval($channel_id)
+	);
+
 	return (($r) ? $r[0] : false);
 }
 

--- a/include/photos.php
+++ b/include/photos.php
@@ -598,9 +598,10 @@ function photos_album_exists($channel_id, $observer_hash, $album) {
  
 	if(! $r) {
 		$r = q("SELECT folder, hash, is_dir, filename, os_path, display_path FROM attach WHERE filename = '%s' AND is_dir = 1 AND uid = %d $sql_extra limit 1",
-		dbesc(hex2bin($album)),
-		intval($channel_id)
-	);
+			dbesc(hex2bin($album)),
+			intval($channel_id)
+		);
+	}
 
 	return (($r) ? $r[0] : false);
 }


### PR DESCRIPTION
issue #827 

provide backward compatibility for album links generated in earlier times before the ambiguity of photo album names was solved. This may provide incorrect results if two or more photo albums with the same basename exist in different directories of the file tree; but there is no easy way to solve that ambiguity - which is why the link format changed. 