### PR TITLE
Fix the multiple table of content bug

### DIFF
--- a/Zotlabs/Widget/Helpindex.php
+++ b/Zotlabs/Widget/Helpindex.php
@@ -25,6 +25,7 @@ class Helpindex {
 
 
 		// TODO: Implement support for translations in hierarchical table of content files
+		/*
 		if(argc() > 2) {
 			$path = '';
 			for($x = 1; $x < argc(); $x ++) {
@@ -36,6 +37,7 @@ class Helpindex {
 					$levels[] = preg_replace('/\<ul(.*?)\>/','<ul class="nav nav-pills flex-column">',$y);
 			}
 		}
+		*/
 
 		if($level_0)
 			$o .= $level_0;

--- a/include/help.php
+++ b/include/help.php
@@ -28,16 +28,22 @@ function get_help_content($tocpath = false) {
 	}
 
 	if($path) {
+		
 		$title = basename($path);
 		if(! $tocpath)
 			\App::$page['title'] = t('Help:') . ' ' . ucwords(str_replace('-',' ',notags($title)));
 
+		// Check that there is a "toc" or "sitetoc" located at the specified path.
+		// If there is not, then there was not a translation of the table of contents
+		// available and so default back to the English TOC at /doc/toc.{html,bb,md}
+		// TODO: This is incompatible with the hierarchical TOC construction
+		// defined in /Zotlabs/Widget/Helpindex.php.
 		if($tocpath !== false && 
 			load_doc_file('doc/' . $path . '.md') === '' && 
 			load_doc_file('doc/' . $path . '.bb') === '' && 
 			load_doc_file('doc/' . $path . '.html') === '' 
 		  ) {
-			$path = 'toc';
+			$path = $title;
 		}
 		$text = load_doc_file('doc/' . $path . '.md');
 


### PR DESCRIPTION
Like I said on Hubzilla:

> This loads the translated TOC if present, loading the default English version if not, but it breaks hierarchical TOC loading for subfolders.
> Almost no one contributes to the doco in any meaningful way, and there are no "toc" files present in any of the subfolders currently. I would like to move forward with my proposed changes and worry about the hierarchical TOC files later if someone has a practical need for them. In the meantime just having one table of contents is challenging enough. 