### PR TITLE
prevent 'my_address' being set with bogus info

### DIFF
--- a/Zotlabs/Web/WebServer.php
+++ b/Zotlabs/Web/WebServer.php
@@ -58,7 +58,11 @@ class WebServer {
 		if((x($_GET,'zid')) && (! \App::$install)) {
 			\App::$query_string = strip_zids(\App::$query_string);
 			if(! local_channel()) {
-				$_SESSION['my_address'] = $_GET['zid'];
+                                if ($_SESSION['my_address']!=$_GET['zid'])
+                                {
+                                        $_SESSION['my_address'] = $_GET['zid'];
+                                        $_SESSION['authenticated'] = 0;
+                                }
 				zid_init();
 			}
 		}


### PR DESCRIPTION
After a user has authenticated, it is possible to set my_address in $_SESSION to 'anything' using zid= parameter in URL - if user is authenticated then zid is never validated but the session variable is updated. This change kills the authenticated switch if a person sends a new zid through for processing, which will trigger remote authentication.