### PR TITLE
Unit tests for Zotlabs\Access classes.

### DIFF
--- a/Zotlabs/Access/Permissions.php
+++ b/Zotlabs/Access/Permissions.php
@@ -127,6 +127,7 @@ class Permissions {
 	static public function FilledPerms($arr) {
 		if(is_null($arr)) {
 			btlogger('FilledPerms: null');
+			$arr = [];
 		}
 
 		$everything = self::Perms();

--- a/tests/unit/Access/PermissionLimitsTest.php
+++ b/tests/unit/Access/PermissionLimitsTest.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright (c) 2017 Hubzilla
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace Zotlabs\Tests\Unit\Access;
+
+use phpmock\phpunit\PHPMock;
+use Zotlabs\Tests\Unit\UnitTestCase;
+use Zotlabs\Access\PermissionLimits;
+
+/**
+ * @brief Unit Test case for PermissionLimits class.
+ *
+ * @covers Zotlabs\Access\PermissionLimits
+ */
+class PermissionLimitsTest extends UnitTestCase {
+
+	use PHPMock;
+
+	/**
+	 * @todo If we could replace static call to Permissions::Perms() in
+	 * Std_Limits() we could better unit test this method, now we test the
+	 * result of Permissions::Perms() mostly.
+	 *
+	 * @uses Zotlabs\Access\Permissions::Perms
+	 * @uses ::call_hooks
+	 */
+	public function testStd_Limits() {
+		// There are 18 default perms
+		$permsCount = 18;
+
+		// Create a stub for global function t() with expectation
+		$t = $this->getFunctionMock('Zotlabs\Access', 't');
+		$t->expects($this->exactly($permsCount));
+
+		$stdlimits = PermissionLimits::Std_Limits();
+		$this->assertCount($permsCount, $stdlimits, "There should be $permsCount permissions.");
+
+		$this->assertEquals(PERMS_PUBLIC,   $stdlimits['view_stream']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['send_stream']);
+		$this->assertEquals(PERMS_PUBLIC,   $stdlimits['view_profile']);
+		$this->assertEquals(PERMS_PUBLIC,   $stdlimits['view_contacts']);
+		$this->assertEquals(PERMS_PUBLIC,   $stdlimits['view_storage']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['write_storage']);
+		$this->assertEquals(PERMS_PUBLIC,   $stdlimits['view_pages']);
+		$this->assertEquals(PERMS_PUBLIC,   $stdlimits['view_wiki']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['write_pages']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['write_wiki']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['post_wall']);
+		$this->assertEquals(PERMS_PUBLIC,   $stdlimits['post_comments']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['post_mail']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['post_like']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['tag_deliver']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['chat']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['republish']);
+		$this->assertEquals(PERMS_SPECIFIC, $stdlimits['delegate']);
+	}
+
+}

--- a/tests/unit/Access/PermissionRolesTest.php
+++ b/tests/unit/Access/PermissionRolesTest.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * Copyright (c) 2017 Hubzilla
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace Zotlabs\Tests\Unit\Access;
+
+use Zotlabs\Tests\Unit\UnitTestCase;
+use Zotlabs\Access\PermissionRoles;
+use phpmock\phpunit\PHPMock;
+
+/**
+ * @brief Unit Test case for PermissionRoles class.
+ *
+ * @TODO Work around dependencies to static PermissionLimits methods.
+ *
+ * @covers Zotlabs\Access\PermissionRoles
+ */
+class PermissionRolesTest extends UnitTestCase {
+
+	use PHPMock;
+
+	public function testVersion() {
+		$expectedVersion = 2;
+
+		$this->assertEquals($expectedVersion, PermissionRoles::version());
+
+		$pr = new PermissionRoles();
+		$this->assertEquals($expectedVersion, $pr->version());
+	}
+
+
+	public function testRoles() {
+		// Create a stub for global function t() with expectation
+		$t = $this->getFunctionMock('Zotlabs\Access', 't');
+		$t->expects($this->atLeastOnce())->willReturnCallback(
+				function ($string) {
+					return $string;
+				}
+		);
+
+		$roles = PermissionRoles::roles();
+		$r = new PermissionRoles();
+		$this->assertEquals($roles, $r->roles());
+
+		$socialNetworking = [
+				'social' => 'Social - Mostly Public',
+				'social_restricted' => 'Social - Restricted',
+				'social_private' => 'Social - Private'
+		];
+
+		$this->assertArraySubset(['Social Networking' => $socialNetworking], $roles);
+		$this->assertEquals($socialNetworking, $roles['Social Networking']);
+
+		$this->assertCount(5, $roles, 'There should be 5 permission groups.');
+
+		$this->assertCount(1, $roles['Other'], "In the 'Other' group should be just one permission role");
+	}
+
+
+	/**
+	 * @uses ::call_hooks
+	 * @uses Zotlabs\Access\PermissionLimits::Std_Limits
+	 * @uses Zotlabs\Access\Permissions::Perms
+	 */
+	public function testRole_perms() {
+		// Create a stub for global function t()
+		$t = $this->getFunctionMock('Zotlabs\Access', 't');
+		$t = $this->getFunctionMock('Zotlabs\Access', 'get_config');
+
+		$rp_social = PermissionRoles::role_perms('social');
+		$this->assertEquals('social', $rp_social['role']);
+
+
+		$rp_custom = PermissionRoles::role_perms('custom');
+		$this->assertEquals(['role' => 'custom'], $rp_custom);
+
+		$rp_nonexistent = PermissionRoles::role_perms('nonexistent');
+		$this->assertEquals(['role' => 'nonexistent'], $rp_nonexistent);
+	}
+
+}

--- a/tests/unit/Access/PermissionsTest.php
+++ b/tests/unit/Access/PermissionsTest.php
@@ -23,6 +23,7 @@
 
 namespace Zotlabs\Tests\Unit\Access;
 
+use phpmock\phpunit\PHPMock;
 use Zotlabs\Tests\Unit\UnitTestCase;
 use Zotlabs\Access\Permissions;
 
@@ -33,54 +34,228 @@ use Zotlabs\Access\Permissions;
  */
 class PermissionsTest extends UnitTestCase {
 
+	use PHPMock;
+
+	public function testVersion() {
+		$expectedVersion = 2;
+
+		// static call
+		$this->assertEquals($expectedVersion, Permissions::version());
+
+		// instance call
+		$p = new Permissions();
+		$this->assertEquals($expectedVersion, $p->version());
+	}
+
 	/**
+	 * @coversNothing
+	 */
+	public function testVersionEqualsPermissionRoles() {
+		$p = new Permissions();
+		$pr = new \Zotlabs\Access\PermissionRoles();
+		$this->assertEquals($p->version(), $pr->version());
+	}
+
+	/**
+	 * @uses ::call_hooks
+	 */
+	public function testPerms() {
+		// There are 18 default perms
+		$permsCount = 18;
+
+		// Create a stub for global function t() with expectation
+		$t = $this->getFunctionMock('Zotlabs\Access', 't');
+		$t->expects($this->exactly(2*$permsCount))->willReturnCallback(
+				function ($string) {
+					return $string;
+				}
+		);
+
+		// static method Perms()
+		$perms = Permissions::Perms();
+
+		$p = new Permissions();
+		$this->assertEquals($perms, $p->Perms());
+
+		$this->assertEquals($permsCount, count($perms), "There should be $permsCount permissions.");
+
+		$this->assertEquals('Can view my channel stream and posts', $perms['view_stream']);
+
+		// non existent perm should not be set
+		$this->assertFalse(isset($perms['invalid_perm']));
+	}
+
+	/**
+	 * filter parmeter is only used in hook \b permissions_list. So the result
+	 * in this test should be the same as if there was no filter parameter.
+	 *
+	 * @todo Stub call_hooks() function and also test filter
+	 *
+	 * @uses ::call_hooks
+	 */
+	public function testPermsFilter() {
+		// There are 18 default perms
+		$permsCount = 18;
+
+		// Create a stub for global function t() with expectation
+		$t = $this->getFunctionMock('Zotlabs\Access', 't');
+		$t->expects($this->exactly(2*$permsCount))->willReturnCallback(
+				function ($string) {
+					return $string;
+				}
+		);
+
+		$perms = Permissions::Perms('view_');
+		$this->assertEquals($permsCount, count($perms));
+
+		$this->assertEquals('Can view my channel stream and posts', $perms['view_stream']);
+
+		$perms = Permissions::Perms('invalid_perm');
+		$this->assertEquals($permsCount, count($perms));
+	}
+
+	/**
+	 * Better should mock Permissions::Perms, but not possible with static methods.
+	 *
+	 * @uses ::call_hooks
+	 *
 	 * @dataProvider FilledPermsProvider
+	 *
+	 * @param array $permarr An indexed permissions array to pass
+	 * @param array $expected The expected result perms array
 	 */
 	public function testFilledPerms($permarr, $expected) {
-		$this->markTestIncomplete(
-			'Need to mock static function Permissions::Perms() ...'
-		);
-		//$this->assertEquals($expected, Permissions::FilledPerms($permarr));
+		// Create a stub for global function t()
+		$t = $this->getFunctionMock('Zotlabs\Access', 't');
 
-/*		$perms = $this->getMockBuilder(Permissions::class)
-			->setMethods(['Perms'])
-			->getMock();
-		$perms->expects($this->once())
-			->method('Perms');
-		// still calls the static self::Perms()
-		$perms->FilledPerms($permarr);
-*/
+		$this->assertEquals($expected, Permissions::FilledPerms($permarr));
 	}
+	/**
+	 * @return array An associative array with test values for FilledPerms()
+	 *   * \e array Indexed array which is passed as parameter to FilledPerms()
+	 *   * \e array Expected associative result array with filled perms
+	 */
 	public function FilledPermsProvider() {
 		return [
-				'empty' => [
+				'Empty param array' => [
 						[],
-						['perm1' => 0, 'perm2' => 0]
+						[
+								'view_stream' => 0,
+								'send_stream' => 0,
+								'view_profile' => 0,
+								'view_contacts' => 0,
+								'view_storage' => 0,
+								'write_storage' => 0,
+								'view_pages' => 0,
+								'view_wiki' => 0,
+								'write_pages' => 0,
+								'write_wiki' => 0,
+								'post_wall' => 0,
+								'post_comments' => 0,
+								'post_mail' => 0,
+								'post_like' => 0,
+								'tag_deliver' => 0,
+								'chat' => 0,
+								'republish' => 0,
+								'delegate' => 0
+						]
 				],
-				'valid' => [
-						[['perm1' => 1]],
-						['perm1' => 1, 'perm2' => 0]
+				'provide view_stream and view_pages as param' => [
+						['view_stream', 'view_pages'],
+						[
+								'view_stream' => 1,
+								'send_stream' => 0,
+								'view_profile' => 0,
+								'view_contacts' => 0,
+								'view_storage' => 0,
+								'write_storage' => 0,
+								'view_pages' => 1,
+								'view_wiki' => 0,
+								'write_pages' => 0,
+								'write_wiki' => 0,
+								'post_wall' => 0,
+								'post_comments' => 0,
+								'post_mail' => 0,
+								'post_like' => 0,
+								'tag_deliver' => 0,
+								'chat' => 0,
+								'republish' => 0,
+								'delegate' => 0
+						]
+				],
+				'provide an unknown param' => [
+						['view_stream', 'unknown_perm'],
+						[
+								'view_stream' => 1,
+								'send_stream' => 0,
+								'view_profile' => 0,
+								'view_contacts' => 0,
+								'view_storage' => 0,
+								'write_storage' => 0,
+								'view_pages' => 0,
+								'view_wiki' => 0,
+								'write_pages' => 0,
+								'write_wiki' => 0,
+								'post_wall' => 0,
+								'post_comments' => 0,
+								'post_mail' => 0,
+								'post_like' => 0,
+								'tag_deliver' => 0,
+								'chat' => 0,
+								'republish' => 0,
+								'delegate' => 0
+						]
 				]
 		];
 	}
-/*	public function testFilledPermsNull() {
-		// need to mock global function btlogger();
-		Permissions::FilledPerms(null);
+	/**
+	 * @uses ::call_hooks
+	 */
+	public function testFilledPermsNull() {
+		// Create a stub for global function t() with expectation
+		$t = $this->getFunctionMock('Zotlabs\Access', 't');
+		$t->expects($this->atLeastOnce());
+		// Create a stub for global function bt() with expectations
+		$bt = $this->getFunctionMock('Zotlabs\Access', 'btlogger');
+		$bt->expects($this->once())->with($this->equalTo('FilledPerms: null'));
+
+		$result = [
+				'view_stream' => 0,
+				'send_stream' => 0,
+				'view_profile' => 0,
+				'view_contacts' => 0,
+				'view_storage' => 0,
+				'write_storage' => 0,
+				'view_pages' => 0,
+				'view_wiki' => 0,
+				'write_pages' => 0,
+				'write_wiki' => 0,
+				'post_wall' => 0,
+				'post_comments' => 0,
+				'post_mail' => 0,
+				'post_like' => 0,
+				'tag_deliver' => 0,
+				'chat' => 0,
+				'republish' => 0,
+				'delegate' => 0
+		];
+
+		$this->assertEquals($result, Permissions::FilledPerms(null));
 	}
-*/
+
 	/**
 	 * @dataProvider OPermsProvider
 	 *
-	 * @param array $permarr
-	 * @param array $expected
+	 * @param array $permarr The params to pass to the OPerms method
+	 * @param array $expected The expected result
 	 */
 	public function testOPerms($permarr, $expected) {
 		$this->assertEquals($expected, Permissions::OPerms($permarr));
 	}
 	/**
-	 * @return Associative array with test values for OPerms()
-	 *   * \e array Array to test
-	 *   * \e array Expect array
+	 * @return array An associative array with test values for OPerms()
+	 *   * \e array Array with perms to test
+	 *   * \e array Expected result array
 	 */
 	public function OPermsProvider() {
 		return [
@@ -99,22 +274,21 @@ class PermissionsTest extends UnitTestCase {
 		];
 	}
 
-
 	/**
 	 * @dataProvider permsCompareProvider
 	 *
-	 * @param array $p1
-	 * @param array $p2
-	 * @param boolean $expectedresult
+	 * @param array $p1 The first permission
+	 * @param array $p2 The second permission
+	 * @param boolean $expectedresult The expected result of the tested method
 	 */
 	public function testPermsCompare($p1, $p2, $expectedresult) {
 		$this->assertEquals($expectedresult, Permissions::PermsCompare($p1, $p2));
 	}
 	/**
-	 * @return Associative array with test values for PermsCompare()
-	 *   * \e array 1st array
-	 *   * \e array 2nd array
-	 *   * \e boolean expected result for the test
+	 * @return array An associative array with test values for PermsCompare()
+	 *   * \e array 1st array with perms
+	 *   * \e array 2nd array with perms
+	 *   * \e boolean expected result for the perms comparison
 	 */
 	public function permsCompareProvider() {
 		return [


### PR DESCRIPTION
Fixing a PHP warning in Permissions::FilledPerms() when NULL parameter.