### PR TITLE
Improve Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ addons:
 php:
   - '7.0'
   - '7.1'
+  - '7.2'
   # HHVM does not fulfil PHPUnit platform requirements as being compatible with PHP7 yet
   #- 'hhvm'
 
@@ -69,7 +70,7 @@ matrix:
         mariadb: '10.1'
     # PHP7.1, PostgreSQL 9.6
     - php: '7.1'
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
+      env: DB=pgsql POSTGRESQL_VERSION=9.6 PHPUNITFILE=phpunit-pgsql.xml
       # Use newer postgres than 9.2 default
       addons:
         postgresql: '9.6'
@@ -125,15 +126,19 @@ before_script:
   - if [[ "$DB" == "pgsql" ]]; then ./tests/travis/prepare_pgsql.sh; fi
 
 # omitting "script:" will default to phpunit
-script: ./vendor/bin/phpunit $PHPUCOV -c tests/phpunit-$DB.xml
+script:
+  - ./vendor/bin/phpunit $PHPUCOV -c tests/$PHPUNITFILE
 
 after_success:
-  # Generate API documentation and deploy it to gh-pages
+  - cat tests/results/testdox.txt
+  # Generate API documentation and prepare for deployment
   - ./tests/travis/gen_apidocs.sh
-#after_failure:
+after_failure:
+  - cat tests/results/testdox.txt
 
 # Deploying release and API documentation to GitHub
-#before_deploy:
+before_deploy:
+  - if [[ "$CODECOV" == "1" ]]; then zip -9 -r -q tests/hubzilla-testresults.zip tests/results; fi
 deploy:
   - provider: pages
     skip_cleanup: true
@@ -152,6 +157,15 @@ deploy:
       repo: redmatrix/hubzilla
       tags: true
       condition: '(-n "$GH_TOKEN") && ("$TRAVIS_JOB_NUMBER" == "${TRAVIS_BUILD_NUMBER}.1")'
+  # add code coverage and test results to release
+  - provider: releases
+    skip_cleanup: true
+    api_key: $GH_TOKEN
+    file: 'tests/hubzilla-testresults.zip'
+    on:
+      repo: redmatrix/hubzilla
+      tags: true
+      condition: '(-n "$GH_TOKEN") && ("$CODECOV" == "1")'
 #after_deploy:
 
 #after_script:

--- a/tests/infection.json.dist
+++ b/tests/infection.json.dist
@@ -1,0 +1,15 @@
+{
+    "timeout": 13,
+    "source": {
+        "directories": [
+            "include",
+            "Zotlabs"
+        ]
+    },
+    "logs": {
+        "text": "tests/results/infection-log.txt"
+    },
+    "phpUnit": {
+        "configDir": "tests"
+    }
+}

--- a/tests/phpunit-mariadb.xml
+++ b/tests/phpunit-mariadb.xml
@@ -1,1 +1,0 @@
-phpunit-mysql.xml

--- a/tests/phpunit-pgsql.xml
+++ b/tests/phpunit-pgsql.xml
@@ -30,5 +30,6 @@
         <log type="coverage-clover" target="./results/coverage-clover.xml"/>
         <log type="coverage-html" target="./results/coverage-report/" lowUpperBound="35"
         highLowerBound="70"/>
+        <log type="testdox-text" target="./results/testdox.txt"/>
     </logging>
 </phpunit>

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <directory suffix="Test.php" prefix="API">./unit/</directory>
     </testsuite>
     <testsuite name="Ex-/Import Test Suite">
-        <directory suffix="Test.php">./unit/eximport/</directory>
+        <!--<directory suffix="Test.php">./unit/eximport/</directory>-->
     </testsuite>
     <groups>
         <exclude>
@@ -33,5 +33,6 @@
         <log type="coverage-clover" target="./results/coverage-clover.xml"/>
         <log type="coverage-html" target="./results/coverage-report/" lowUpperBound="35"
         highLowerBound="70"/>
+        <log type="testdox-text" target="./results/testdox.txt"/>
     </logging>
 </phpunit>

--- a/tests/unit/AutonameTest.php
+++ b/tests/unit/AutonameTest.php
@@ -57,7 +57,7 @@ class AutonameTest extends TestCase {
 
 	// 	public function testAutonameMaxLength() {
 	// 		$autoname2=autoname(PHP_INT_MAX);
-	// 		$this->assertEquals(PHP_INT_MAX, count($autoname2));
+	// 		$this->assertEquals(PHP_INT_MAX, strlen($autoname2));
 	// 	}
 
 	/**
@@ -65,10 +65,10 @@ class AutonameTest extends TestCase {
 	 */
 	public function testAutonameLength1() {
 		$autoname1=autoname(1);
-		$this->assertEquals(1, count($autoname1));
+		$this->assertEquals(1, strlen($autoname1));
 
 		$autoname2=autoname(1);
-		$this->assertEquals(1, count($autoname2));
+		$this->assertEquals(1, strlen($autoname2));
 
 		// The following test is problematic, with only 26 possibilities
 		// generating the same thing twice happens often aka


### PR DESCRIPTION
Improve Travis CI configuration a bit and add PHP7.2 to the test matrix.
Add PHPUnit Testdox output and optionally deploy test results on release tags.
Add a configuration file for infection (Mutation Testing Framework).