### PR TITLE
Fix 'unable to add pages with spaces' (pr 922)

### DIFF
--- a/Zotlabs/Widget/Wiki_pages.php
+++ b/Zotlabs/Widget/Wiki_pages.php
@@ -21,7 +21,7 @@ class Wiki_pages {
 		$can_create = perm_is_allowed(\App::$profile['uid'],get_observer_hash(),'write_wiki');
 
 		$can_delete = ((local_channel() && (local_channel() == \App::$profile['uid'])) ? true : false);
-		$pageName = urlencode(escape_tags(urldecode(argv(3))));
+                $pageName = addslashes(escape_tags(urldecode(argv(3))));
 
 		return replace_macros(get_markup_template('wiki_page_not_found.tpl'), array(
 				'$resource_id' => $arr['resource_id'],


### PR DESCRIPTION
Fix to display unencoded text in the input for the create page form on non-existent wiki pages.  This makes the in-page form behave the same as the widget - but both appear to suffer from an issue with certain characters in the page name (see #923).