### PR TITLE
Adapted to Debian 9 (Stretch)

### DIFF
--- a/.homeinstall/README.md
+++ b/.homeinstall/README.md
@@ -7,7 +7,7 @@ The script is known to work with Debian 9 stable (Stretch)
 + Home-PC (Debian-9.2-amd64)
 + Raspian (Debian-9.3 on a Rapberry 3)
 
-This script is not recommended for Debian 8 (Jessie) any longer.
+This script does not work for Debian 8 (Jessie).
 
 # Step-by-Step Overwiew
 

--- a/.homeinstall/README.md
+++ b/.homeinstall/README.md
@@ -2,10 +2,12 @@
 
 Run hubzilla-setup.sh for an unattended installation of hubzilla.
 
-The script is known to work with Debian 8.3 stable (Jessie)
+The script is known to work with Debian 9 stable (Stretch)
 
-+ Home-PC (Debian-8.3.0-amd64)
-+ DigitalOcean droplet (Debian 8.3 x64 / 512 MB Memory / 20 GB Disk / NYC3)
++ Home-PC (Debian-9.2-amd64)
++ Raspian (Debian-9.3 on a Rapberry 3)
+
+This script is not recommended for Debian 8 (Jessie) any longer.
 
 # Step-by-Step Overwiew
 
@@ -14,12 +16,12 @@ The script is known to work with Debian 8.3 stable (Jessie)
 Hardware
 
 + Internet connection and router at home
-+ Mini-pc connected to your router
++ Mini-pc connected to your router (a Raspberry 3 will do it too)
 + USB drive for backups
 
 Software
 
-+ Fresh installation of Debian on your mini-pc
++ Fresh installation of Debian 9 (Stretch) on your mini-pc
 + Router with open ports 80 and 443 for your Debian
 
 ## The basic steps (quick overview)
@@ -32,7 +34,8 @@ Software
   - git clone https://github.com/redmatrix/hubzilla.git html
   - cp .homeinstall/hubzilla-config.txt.template .homeinstall/hubzilla-config.txt
   - nano .homeinstall/hubzilla-config.txt
-    - Enter your values there: db pass, domain, values for dyn DNS
+    - Read the comments carefully
+    - Enter your values: db pass, domain, values for dyn DNS
   - hubzilla-setup.sh as root
     - ... wait, wait, wait until the script is finised
   - reboot
@@ -51,18 +54,36 @@ The installation will create a daily backup.
 If the backup process does not find an external device than the backup goes to
 the internal disk.
 
-The USB drive must be compatible with an encrpyted filesystem LUKS + ext4.
+The USB drive must be compatible with the filesystems
+
+- ext4 (if you do not want to encrypt the USB) 
+- LUKS + ext4 (if you want to encrypt the USB) 
 
 ## Preparations Software
 
 ### Install Debian Linux on the Mini-PC
 
-Download the stable Debian at https://www.debian.org/
+Download the stable Debian at https://www.debian.org/  
+(Debian 8 is no longer supported.)
 
-Create bootable USB drive with Debian on it. You could use the programm
-unetbootin, https://en.wikipedia.org/wiki/UNetbootin
+Create bootable USB drive with Debian on it.You could use
 
-Switch of your mini pc, plug in your USB drive and start the mini pc from the
+- unetbootin, https://en.wikipedia.org/wiki/UNetbootin
+- or simply the linux command "dd"
+
+Example for command dd...
+
+    su -
+    dd if=2017-11-29-raspbian-stretch.img of=/dev/mmcblk0
+
+Do not forget to unmount the SD card before and check if unmounted like in this example...
+
+    su -
+    umount /dev/mmcblk0*
+    df -h
+
+
+Switch off your mini pc, plug in your USB drive and start the mini pc from the
 stick. Install Debian. Follow the instructions of the installation.
 
 ### Configure your Router
@@ -81,26 +102,21 @@ You can use subdomains as well
 
 There are two way to get a domain
 
-- buy a domain (recommended) or
+- buy a domain, or
 - register a free subdomain
 
-### Method 1: Get yourself an own Domain (recommended)
+### Method 1: Buy an own Domain 
 
-...for example at selfHOST.de
+...for example buy at selfHOST.de  
+
+The cost are around 10,- € once and 1,50 € per month (2017).
 
 ### Method 2 Register a (free) Subdomain
 
-Register a free subdomain for example at
+...for example register at freeDNS
 
-- freeDNS
-- selfHOST
+Follow the instructions in .homeinstall/hubzilla-config.txt.  
 
-WATCH THIS: A free subdomain is not the prefered way to get a domain name. Why?
-
-Let's encrpyt issues a limited number of certificates each
-day. Possibly other users of this domain will try to issue a certificate
-at the same day as you do. So make sure you choose a domain with as less subdomains as
-possible.
 
 ## Install Hubzilla on your Debian
 
@@ -135,7 +151,7 @@ Copy the template file
     
     cp hubzilla-config.txt.template hubzilla-config.txt
 
-Change the file "hubzilla-config.txt". Read the instructions there and enter your values.
+Change the file "hubzilla-config.txt". Read the instructions there carefully and enter your values.
 
     nano hubzilla-config.txt
 
@@ -146,7 +162,7 @@ Run the script
 Wait... The script should not finish with an error message.
 
 In a webbrowser open your domain.
-Expected: A test page of hubzilla is shown. All checks there shoulg be
+Expected: A test page of hubzilla is shown. All checks there should be
 successfull. Go on...
 Expected: A page for the Hubzilla server configuration shows up.
 
@@ -161,4 +177,22 @@ Enter
 Leave db type "MySQL" untouched.
 
 Follow the instructions in the next pages.
+
+## Note for the Rasperry 
+
+The script was tested with an Raspberry 3 under Raspian (Debian 9.3, 2017-11-29-raspbian-stretch.img).
+
+It is recommended to deinstall these programms to avoid endless updates. Use...
+
+    sudo apt-get purge wolfram-engine sonic-pi
+    sudo apt-get autoremove
+
+It is recommended to run the Raspi without graphical frontend (X-Server). Use...
+
+    sudo raspi-config
+
+to boot the Rapsi to the client console.
+
+DO NOT FORGET TO CHANGE THE DEFAULT PASSWORD FOR USER PI!
+
 

--- a/.homeinstall/hubzilla-config.txt.template
+++ b/.homeinstall/hubzilla-config.txt.template
@@ -70,15 +70,17 @@ selfhost_pass=
 #       freedns_key=U1Z6aGt2R0NzMFNPNWRjbWxxZGpsd093OjE1Mzg5NDE5
 #
 #
-#freedns_key=
+freedns_key=
 
 
 ###############################################
 ### OPTIONAL - Backup to external device ######
 #
 # The script can use an external device for the daily backup.
-# The file system of the device (USB stick for example) must be compatible
-# with encrypted LUKS + ext4
+# The file system of the device (USB stick for example) must be compatible with
+#
+# - encrypted LUKS + ext4, or
+# - ext4
 #
 # You should test to mount the device befor you run the script
 # (hubzilla-setup.sh).
@@ -113,25 +115,19 @@ selfhost_pass=
 #     lsof /media/hubzilla_backup
 #
 # If you leave the following parameters
+#
 # - "backup_device_name" and
 # - "backup_device_pass"
+#
 # empty the script will create daily backups on the internal disk (which could
 # save you as well).
 #
 #   Example: backup_device_name=/dev/sdc1
 #
+# Leave "backup_device_pass=" empty if the external device is not encrypted.
+#
 backup_device_name=
 backup_device_pass=
-
-
-###############################################
-### OPTIONAL - Owncloud - deprecated ##########
-#
-# To install owncloud: owncloud=y
-# Leave empty if you don't want to install owncloud
-#
-#owncloud=
-
 
 
 ###############################################
@@ -159,19 +155,4 @@ mysqlpass=$db_pass
 #   Example: phpmyadminpass=aberhallo
 #   Example: phpmyadminpass="aber hallo has blanks in it"
 phpmyadminpass=$db_pass
-
-# TODO Prepare hubzilla for programmers
-# - install eclipse and plugins
-# - install xdebug to debug the php with eclipse
-# - weaken permissions on /var/www/html
-# - manual steps after this script
-#   * in eclipse: install plugins for php git hub
-#   * in eclipse: configure firefox (chrome,...) as browser to run with the php debuger
-#   * in eclipse: switch php debugger from zend to xdebug
-#   * in eclipse: add local hubzilla github repository
-#
-# Which user will use eclipse?
-# Leave this empty if you do not want to prepare hubzilla for debugging
-#
-#developer_name=
 

--- a/.homeinstall/hubzilla-setup.sh
+++ b/.homeinstall/hubzilla-setup.sh
@@ -251,6 +251,9 @@ function install_php {
     # openssl and mbstring are included in libapache2-mod-php
     print_info "installing php..."
     nocheck_install "libapache2-mod-php php php-pear php-curl php-mcrypt php-gd"
+    print_info "increase upload file size to 100M..."
+    sed -i "s/^upload_max_filesize =.*/upload_max_filesize = 100M/g" /etc/php/7.0/apache2/php.ini
+    sed -i "s/^post_max_size =.*/post_max_size = 100M/g" /etc/php/7.0/apache2/php.ini
 }
 
 function install_mysql {


### PR DESCRIPTION
Tested 

- inside a VM for Debian 9.2
- on a Raspberrs 3, Rasbian (Debian 9.3)

Removed support for Debian 8.x (Jessie).

Tested with a free sub domain from https://freedns.afraid.org. So you can run an own small Hub literally for free on a Raspberry.