### PR TITLE
Fix dup content issue when using {module}_mod_content hook.

### DIFF
--- a/Zotlabs/Web/Router.php
+++ b/Zotlabs/Web/Router.php
@@ -275,6 +275,8 @@ class Router {
 						$arr = array('content' => $func($a));
 					}
 				}
+
+				$arr = array('content' => '', 'replace' => false);
 				call_hooks(\App::$module . '_mod_aftercontent', $arr);
 				\App::$page['content'] .= $arr['content'];
 			}


### PR DESCRIPTION
Sets $arr['content'] to '' before call to $module_mod_aftercontent hook - otherwise - $arr['content'] returned by $module_mod_content hook gets duplicated in the final page.