### PR TITLE
more flexibility for relative date/time translations

### DIFF
--- a/include/js_strings.php
+++ b/include/js_strings.php
@@ -24,10 +24,16 @@ function js_strings() {
 		'$leavethispage' => t('Unsaved changes. Are you sure you wish to leave this page?'),
 		'$location'    => t('Location'),
 
-		'$t01' => ((t('timeago.prefixAgo') != 'timeago.prefixAgo') ? t('timeago.prefixAgo') : ''),
-		'$t02' => ((t('timeago.prefixFromNow') != 'timeago.prefixFromNow') ? t('timeago.prefixFromNow') : ''),
-		'$t03' => t('ago'),
-		'$t04' => t('from now'),
+		// translatable prefix and suffix strings for jquery.timeago -
+		// using the defaults set below if left untranslated, empty strings if
+		// translated to "NONE" and the corresponding language strings
+		// if translated to anything else
+		'$t01' => ((t('timeago.prefixAgo') == 'timeago.prefixAgo') ? '' : ((t('timeago.prefixAgo') == 'NONE') ? '' : t('timeago.prefixAgo'))),
+		'$t02' => ((t('timeago.prefixFromNow') == 'timeago.prefixFromNow') ? '' : ((t('timeago.prefixFromNow') == 'NONE') ? '' : t('timeago.prefixFromNow'))),
+		'$t03' => ((t('timeago.suffixAgo') == 'timeago.suffixAgo') ? 'ago' : ((t('timeago.suffixAgo') == 'NONE') ? '' : t('timeago.suffixAgo'))),
+		'$t04' => ((t('timeago.suffixFromNow') == 'timeago.suffixFromNow') ? 'from now' : ((t('timeago.suffixFromNow') == 'NONE') ? '' : t('timeago.suffixFromNow'))),
+
+		// translatable main strings for jquery.timeago
 		'$t05' => t('less than a minute'),
 		'$t06' => t('about a minute'),
 		'$t07' => t('%d minutes'),

--- a/view/de-de/hmessages.po
+++ b/view/de-de/hmessages.po
@@ -12377,27 +12377,27 @@ msgstr "Ungespeicherte Änderungen. Bist Du sicher, dass Du diese Seite verlasse
 
 #: ../../include/js_strings.php:27
 msgid "timeago.prefixAgo"
-msgstr "timeago.prefixAgo"
+msgstr "vor"
 
 #: ../../include/js_strings.php:28
 msgid "timeago.prefixFromNow"
-msgstr " "
+msgstr "in"
 
 #: ../../include/js_strings.php:29
-msgid "ago"
-msgstr "her"
+msgid "timeago.suffixAgo"
+msgstr "NONE"
 
 #: ../../include/js_strings.php:30
-msgid "from now"
-msgstr "von jetzt"
+msgid "timeago.suffixFromNow"
+msgstr "NONE"
 
 #: ../../include/js_strings.php:31
 msgid "less than a minute"
-msgstr "weniger als eine Minute"
+msgstr "weniger als einer Minute"
 
 #: ../../include/js_strings.php:32
 msgid "about a minute"
-msgstr "ungefähr eine Minute"
+msgstr "ungefähr einer Minute"
 
 #: ../../include/js_strings.php:33
 #, php-format
@@ -12406,7 +12406,7 @@ msgstr "%d Minuten"
 
 #: ../../include/js_strings.php:34
 msgid "about an hour"
-msgstr "ungefähr eine Stunde"
+msgstr "ungefähr einer Stunde"
 
 #: ../../include/js_strings.php:35
 #, php-format
@@ -12415,30 +12415,30 @@ msgstr "ungefähr %d Stunden"
 
 #: ../../include/js_strings.php:36
 msgid "a day"
-msgstr "ein Tag"
+msgstr "einem Tag"
 
 #: ../../include/js_strings.php:37
 #, php-format
 msgid "%d days"
-msgstr "%d Tage"
+msgstr "%d Tagen"
 
 #: ../../include/js_strings.php:38
 msgid "about a month"
-msgstr "ungefähr einen Monat"
+msgstr "ungefähr einem Monat"
 
 #: ../../include/js_strings.php:39
 #, php-format
 msgid "%d months"
-msgstr "%d Monate"
+msgstr "%d Monaten"
 
 #: ../../include/js_strings.php:40
 msgid "about a year"
-msgstr "ungefähr ein Jahr"
+msgstr "ungefähr einem Jahr"
 
 #: ../../include/js_strings.php:41
 #, php-format
 msgid "%d years"
-msgstr "%d Jahre"
+msgstr "%d Jahren"
 
 #: ../../include/js_strings.php:42
 msgid " "

--- a/view/de-de/hstrings.php
+++ b/view/de-de/hstrings.php
@@ -1,7 +1,7 @@
 <?php
 
-if(! function_exists("string_plural_select_de")) {
-function string_plural_select_de($n){
+if(! function_exists("string_plural_select_de_de")) {
+function string_plural_select_de_de($n){
 	return ($n != 1);;
 }}
 App::$rtl = 0;
@@ -2790,21 +2790,21 @@ App::$strings["Rate This Channel (this is public)"] = "Diesen Kanal bewerten (ö
 App::$strings["Describe (optional)"] = "Beschreibung (optional)";
 App::$strings["Please enter a link URL"] = "Gib eine URL ein:";
 App::$strings["Unsaved changes. Are you sure you wish to leave this page?"] = "Ungespeicherte Änderungen. Bist Du sicher, dass Du diese Seite verlassen möchtest?";
-App::$strings["timeago.prefixAgo"] = "timeago.prefixAgo";
-App::$strings["timeago.prefixFromNow"] = " ";
-App::$strings["ago"] = "her";
-App::$strings["from now"] = "von jetzt";
-App::$strings["less than a minute"] = "weniger als eine Minute";
-App::$strings["about a minute"] = "ungefähr eine Minute";
+App::$strings["timeago.prefixAgo"] = "vor";
+App::$strings["timeago.prefixFromNow"] = "in";
+App::$strings["timeago.suffixAgo"] = "NONE";
+App::$strings["timeago.suffixFromNow"] = "NONE";
+App::$strings["less than a minute"] = "weniger als einer Minute";
+App::$strings["about a minute"] = "ungefähr einer Minute";
 App::$strings["%d minutes"] = "%d Minuten";
-App::$strings["about an hour"] = "ungefähr eine Stunde";
+App::$strings["about an hour"] = "ungefähr einer Stunde";
 App::$strings["about %d hours"] = "ungefähr %d Stunden";
-App::$strings["a day"] = "ein Tag";
-App::$strings["%d days"] = "%d Tage";
-App::$strings["about a month"] = "ungefähr einen Monat";
-App::$strings["%d months"] = "%d Monate";
-App::$strings["about a year"] = "ungefähr ein Jahr";
-App::$strings["%d years"] = "%d Jahre";
+App::$strings["a day"] = "einem Tag";
+App::$strings["%d days"] = "%d Tagen";
+App::$strings["about a month"] = "ungefähr einem Monat";
+App::$strings["%d months"] = "%d Monaten";
+App::$strings["about a year"] = "ungefähr einem Jahr";
+App::$strings["%d years"] = "%d Jahren";
 App::$strings[" "] = " ";
 App::$strings["timeago.numbers"] = "timeago.numbers";
 App::$strings["__ctx:long__ May"] = "Mai";


### PR DESCRIPTION
small translation improvement - see commit messages and code comments for more info...

might be a bit rough - if someone knows a better way or more elegant syntax to achieve this, tips are welcome

If the non-JS method from datetime.php is still used elsewhere I might look into improving the translation flexibility for that, too.