### PR TITLE
Update translations for catalan (ca/ca_ES) from transifex

### DIFF
--- a/view/ca/hmessages.po
+++ b/view/ca/hmessages.po
@@ -1,19 +1,20 @@
-# Hubzilla Project
-# Copyright (C) 2012-2014 the Hubzilla Project
-# This file is distributed under the same license as the Red package.
+# hubzilla
+# Copyright (C) 2012-2016 hubzilla
+# This file is distributed under the same license as the hubzilla package.
 # 
 # Translators:
-# Espart <ranker72@gmail.com>, 2015
+# fadelkon <fadelkon@posteo.net>, 2015-2016
+# fadelkon <fadelkon@posteo.net>, 2018
 # Rafael, 2015
-# Rafael Garau, 2016
+# Rafael Garau, 2016-2017
 # Rafael Garau, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: Redmatrix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-10 00:02-0700\n"
-"PO-Revision-Date: 2016-06-10 09:14+0000\n"
-"Last-Translator: fabrixxm <fabrix.xm@gmail.com>\n"
+"POT-Creation-Date: 2018-03-01 08:51+0100\n"
+"PO-Revision-Date: 2018-03-17 02:23+0000\n"
+"Last-Translator: fadelkon <fadelkon@posteo.net>\n"
 "Language-Team: Catalan (Spain) (http://www.transifex.com/Friendica/red-matrix/language/ca_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,386 +22,5675 @@ msgstr ""
 "Language: ca_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../../Zotlabs/Storage/Browser.php:107 ../../Zotlabs/Storage/Browser.php:239
-msgid "parent"
-msgstr "pare"
+#: ../../Zotlabs/Access/Permissions.php:56
+msgid "Can view my channel stream and posts"
+msgstr "Pot veure el flux i entrades del meu canal"
 
-#: ../../Zotlabs/Storage/Browser.php:131 ../../include/text.php:2620
-msgid "Collection"
-msgstr "Col·lecció"
+#: ../../Zotlabs/Access/Permissions.php:57
+msgid "Can send me their channel stream and posts"
+msgstr "Pot enviar-me el flux i entrades del seu canal"
 
-#: ../../Zotlabs/Storage/Browser.php:134
-msgid "Principal"
-msgstr "Principal"
+#: ../../Zotlabs/Access/Permissions.php:58
+msgid "Can view my default channel profile"
+msgstr "Pot veure el perfil del meu canal per defecte"
 
-#: ../../Zotlabs/Storage/Browser.php:137
-msgid "Addressbook"
-msgstr "Llista d'Adreçes"
+#: ../../Zotlabs/Access/Permissions.php:59
+msgid "Can view my connections"
+msgstr "Pot veure les meves connexions"
 
-#: ../../Zotlabs/Storage/Browser.php:140
-msgid "Calendar"
-msgstr "Calendari"
+#: ../../Zotlabs/Access/Permissions.php:60
+msgid "Can view my file storage and photos"
+msgstr "Pot veure les meves fotos i arxius"
 
-#: ../../Zotlabs/Storage/Browser.php:143
-msgid "Schedule Inbox"
-msgstr "Programació de la bústia d'entrada"
+#: ../../Zotlabs/Access/Permissions.php:61
+msgid "Can upload/modify my file storage and photos"
+msgstr "Pot pujar i modificar els meus fitxers i fotos"
 
-#: ../../Zotlabs/Storage/Browser.php:146
-msgid "Schedule Outbox"
-msgstr "Programació de la bústia de sortida"
+#: ../../Zotlabs/Access/Permissions.php:62
+msgid "Can view my channel webpages"
+msgstr "Pot veure les pàgines web del meu canal"
 
-#: ../../Zotlabs/Storage/Browser.php:164 ../../Zotlabs/Module/Photos.php:798
-#: ../../Zotlabs/Module/Photos.php:1243 ../../Zotlabs/Lib/Apps.php:486
-#: ../../Zotlabs/Lib/Apps.php:561 ../../include/widgets.php:1505
-#: ../../include/conversation.php:1032
-msgid "Unknown"
-msgstr "Desconegut"
+#: ../../Zotlabs/Access/Permissions.php:63
+msgid "Can view my wiki pages"
+msgstr "Por veure les meves pàgines wiki"
 
-#: ../../Zotlabs/Storage/Browser.php:226 ../../Zotlabs/Module/Fbrowser.php:85
-#: ../../Zotlabs/Lib/Apps.php:216 ../../include/nav.php:93
-#: ../../include/conversation.php:1639
-msgid "Files"
-msgstr "Arxius"
+#: ../../Zotlabs/Access/Permissions.php:64
+msgid "Can create/edit my channel webpages"
+msgstr "Pot crear i modificar les pàgines web del meu canal"
 
-#: ../../Zotlabs/Storage/Browser.php:227
-msgid "Total"
-msgstr "Total"
+#: ../../Zotlabs/Access/Permissions.php:65
+msgid "Can write to my wiki pages"
+msgstr "Pot escriure a les meves pàgines wiki"
 
-#: ../../Zotlabs/Storage/Browser.php:229
-msgid "Shared"
-msgstr "Compartit"
+#: ../../Zotlabs/Access/Permissions.php:66
+msgid "Can post on my channel (wall) page"
+msgstr "Pot penjar entrades al mur del meu canal"
 
-#: ../../Zotlabs/Storage/Browser.php:230 ../../Zotlabs/Storage/Browser.php:306
-#: ../../Zotlabs/Module/Blocks.php:156 ../../Zotlabs/Module/Layouts.php:182
-#: ../../Zotlabs/Module/Menu.php:118 ../../Zotlabs/Module/New_channel.php:142
-#: ../../Zotlabs/Module/Webpages.php:186
+#: ../../Zotlabs/Access/Permissions.php:67
+msgid "Can comment on or like my posts"
+msgstr "Pot comentar i fer \"m'agrada\" a les meves entrades"
+
+#: ../../Zotlabs/Access/Permissions.php:68
+msgid "Can send me private mail messages"
+msgstr "Pot enviar-me missatges privats"
+
+#: ../../Zotlabs/Access/Permissions.php:69
+msgid "Can like/dislike profiles and profile things"
+msgstr "Pot fer m'agrada i no m'agrada als perfils i coses del perfil"
+
+#: ../../Zotlabs/Access/Permissions.php:70
+msgid "Can forward to all my channel connections via @+ mentions in posts"
+msgstr "Pot reenviar a totes les connexions del meu canal fent servir @+ per mencionar"
+
+#: ../../Zotlabs/Access/Permissions.php:71
+msgid "Can chat with me"
+msgstr "Pot xatejar amb mi"
+
+#: ../../Zotlabs/Access/Permissions.php:72
+msgid "Can source my public posts in derived channels"
+msgstr "Pot fer servir les meves entrades per publicar automàticament en altres canals"
+
+#: ../../Zotlabs/Access/Permissions.php:73
+msgid "Can administer my channel"
+msgstr "Pot administrar el meu canal"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:265
+msgid "Social Networking"
+msgstr "Xarxes Socials"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:266
+msgid "Social - Mostly Public"
+msgstr "Social -  Principalment públic"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:267
+msgid "Social - Restricted"
+msgstr "Social - Restingit"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:268
+msgid "Social - Private"
+msgstr "Social - Privat"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:271
+msgid "Community Forum"
+msgstr "Fòrum comunitari"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:272
+msgid "Forum - Mostly Public"
+msgstr "Fòrum - Principalment públic"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:273
+msgid "Forum - Restricted"
+msgstr "Fòrum - Restringit"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:274
+msgid "Forum - Private"
+msgstr "Fòrum - Privat"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:277
+msgid "Feed Republish"
+msgstr "Republicador"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:278
+msgid "Feed - Mostly Public"
+msgstr "Republicador - Principalment públic"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:279
+msgid "Feed - Restricted"
+msgstr "Republicador - Restringit"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:282
+msgid "Special Purpose"
+msgstr "Objectiu Especial"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:283
+msgid "Special - Celebrity/Soapbox"
+msgstr "Especial - Personatge públic / Plataforma"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:284
+msgid "Special - Group Repository"
+msgstr "Especial  - Repositori d'un Grup"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:287
+#: ../../Zotlabs/Module/Cdav.php:1182 ../../Zotlabs/Module/New_channel.php:130
+#: ../../Zotlabs/Module/Settings/Channel.php:473
+#: ../../Zotlabs/Module/Connedit.php:918 ../../Zotlabs/Module/Profiles.php:798
+#: ../../Zotlabs/Module/Register.php:224 ../../include/selectors.php:49
+#: ../../include/selectors.php:66 ../../include/selectors.php:104
+#: ../../include/selectors.php:140 ../../include/event.php:1315
+#: ../../include/event.php:1322 ../../include/connections.php:689
+#: ../../include/connections.php:696
+msgid "Other"
+msgstr "Altres"
+
+#: ../../Zotlabs/Access/PermissionRoles.php:288
+msgid "Custom/Expert Mode"
+msgstr "Personalitzat, mode expert"
+
+#: ../../Zotlabs/Module/Blocks.php:33 ../../Zotlabs/Module/Articles.php:29
+#: ../../Zotlabs/Module/Editlayout.php:31 ../../Zotlabs/Module/Connect.php:17
+#: ../../Zotlabs/Module/Achievements.php:15 ../../Zotlabs/Module/Hcard.php:12
+#: ../../Zotlabs/Module/Editblock.php:31 ../../Zotlabs/Module/Profile.php:20
+#: ../../Zotlabs/Module/Layouts.php:31 ../../Zotlabs/Module/Editwebpage.php:32
+#: ../../Zotlabs/Module/Cards.php:33 ../../Zotlabs/Module/Webpages.php:33
+#: ../../Zotlabs/Module/Filestorage.php:51 ../../include/channel.php:1198
+msgid "Requested profile is not available."
+msgstr "El perfil demanat no està disponible."
+
+#: ../../Zotlabs/Module/Blocks.php:73 ../../Zotlabs/Module/Blocks.php:80
+#: ../../Zotlabs/Module/Invite.php:17 ../../Zotlabs/Module/Invite.php:94
+#: ../../Zotlabs/Module/Articles.php:68 ../../Zotlabs/Module/Editlayout.php:67
+#: ../../Zotlabs/Module/Editlayout.php:90 ../../Zotlabs/Module/Channel.php:110
+#: ../../Zotlabs/Module/Channel.php:248 ../../Zotlabs/Module/Channel.php:288
+#: ../../Zotlabs/Module/Settings.php:59 ../../Zotlabs/Module/Locs.php:87
+#: ../../Zotlabs/Module/Mitem.php:115 ../../Zotlabs/Module/Events.php:271
+#: ../../Zotlabs/Module/Appman.php:86 ../../Zotlabs/Module/Regmod.php:21
+#: ../../Zotlabs/Module/Article_edit.php:51
+#: ../../Zotlabs/Module/New_channel.php:77
+#: ../../Zotlabs/Module/New_channel.php:102
+#: ../../Zotlabs/Module/Sharedwithme.php:16 ../../Zotlabs/Module/Setup.php:209
+#: ../../Zotlabs/Module/Moderate.php:13
+#: ../../Zotlabs/Module/Achievements.php:34 ../../Zotlabs/Module/Thing.php:275
+#: ../../Zotlabs/Module/Thing.php:295 ../../Zotlabs/Module/Thing.php:336
+#: ../../Zotlabs/Module/Api.php:24 ../../Zotlabs/Module/Editblock.php:67
+#: ../../Zotlabs/Module/Profile.php:85 ../../Zotlabs/Module/Profile.php:101
+#: ../../Zotlabs/Module/Mood.php:116 ../../Zotlabs/Module/Connections.php:29
+#: ../../Zotlabs/Module/Viewsrc.php:19 ../../Zotlabs/Module/Bookmarks.php:64
+#: ../../Zotlabs/Module/Photos.php:69 ../../Zotlabs/Module/Wiki.php:50
+#: ../../Zotlabs/Module/Wiki.php:273 ../../Zotlabs/Module/Wiki.php:400
+#: ../../Zotlabs/Module/Pdledit.php:29 ../../Zotlabs/Module/Poke.php:149
+#: ../../Zotlabs/Module/Profile_photo.php:302
+#: ../../Zotlabs/Module/Profile_photo.php:315
+#: ../../Zotlabs/Module/Authtest.php:16 ../../Zotlabs/Module/Item.php:229
+#: ../../Zotlabs/Module/Item.php:246 ../../Zotlabs/Module/Item.php:256
+#: ../../Zotlabs/Module/Item.php:1099 ../../Zotlabs/Module/Page.php:34
+#: ../../Zotlabs/Module/Page.php:133 ../../Zotlabs/Module/Connedit.php:389
+#: ../../Zotlabs/Module/Chat.php:100 ../../Zotlabs/Module/Chat.php:105
+#: ../../Zotlabs/Module/Menu.php:78 ../../Zotlabs/Module/Layouts.php:71
+#: ../../Zotlabs/Module/Layouts.php:78 ../../Zotlabs/Module/Layouts.php:89
+#: ../../Zotlabs/Module/Defperms.php:173 ../../Zotlabs/Module/Group.php:13
+#: ../../Zotlabs/Module/Profiles.php:198 ../../Zotlabs/Module/Profiles.php:635
+#: ../../Zotlabs/Module/Editwebpage.php:68
+#: ../../Zotlabs/Module/Editwebpage.php:89
+#: ../../Zotlabs/Module/Editwebpage.php:107
+#: ../../Zotlabs/Module/Editwebpage.php:121 ../../Zotlabs/Module/Manage.php:10
+#: ../../Zotlabs/Module/Cards.php:72 ../../Zotlabs/Module/Webpages.php:118
+#: ../../Zotlabs/Module/Block.php:24 ../../Zotlabs/Module/Block.php:74
+#: ../../Zotlabs/Module/Editpost.php:17 ../../Zotlabs/Module/Sources.php:74
+#: ../../Zotlabs/Module/Like.php:185 ../../Zotlabs/Module/Suggest.php:28
+#: ../../Zotlabs/Module/Message.php:18 ../../Zotlabs/Module/Mail.php:146
+#: ../../Zotlabs/Module/Register.php:77
+#: ../../Zotlabs/Module/Cover_photo.php:281
+#: ../../Zotlabs/Module/Cover_photo.php:294
+#: ../../Zotlabs/Module/Display.php:406 ../../Zotlabs/Module/Network.php:15
+#: ../../Zotlabs/Module/Filestorage.php:15
+#: ../../Zotlabs/Module/Filestorage.php:70
+#: ../../Zotlabs/Module/Filestorage.php:85
+#: ../../Zotlabs/Module/Filestorage.php:117 ../../Zotlabs/Module/Common.php:38
+#: ../../Zotlabs/Module/Viewconnections.php:28
+#: ../../Zotlabs/Module/Viewconnections.php:33
+#: ../../Zotlabs/Module/Service_limits.php:11
+#: ../../Zotlabs/Module/Rate.php:113 ../../Zotlabs/Module/Card_edit.php:51
+#: ../../Zotlabs/Module/Notifications.php:11
+#: ../../Zotlabs/Lib/Chatroom.php:133 ../../Zotlabs/Web/WebServer.php:123
+#: ../../addon/keepout/keepout.php:36 ../../addon/openid/Mod_Id.php:53
+#: ../../addon/gitwiki/Mod_Gitwiki.php:196
+#: ../../addon/gitwiki/Mod_Gitwiki.php:292 ../../addon/pumpio/pumpio.php:40
+#: ../../include/attach.php:150 ../../include/attach.php:197
+#: ../../include/attach.php:270 ../../include/attach.php:284
+#: ../../include/attach.php:293 ../../include/attach.php:366
+#: ../../include/attach.php:380 ../../include/attach.php:387
+#: ../../include/attach.php:469 ../../include/attach.php:1019
+#: ../../include/attach.php:1093 ../../include/attach.php:1258
+#: ../../include/items.php:3656 ../../include/photos.php:27
+msgid "Permission denied."
+msgstr "S'ha denegat el permís."
+
+#: ../../Zotlabs/Module/Blocks.php:97 ../../Zotlabs/Module/Blocks.php:155
+#: ../../Zotlabs/Module/Editblock.php:113
+msgid "Block Name"
+msgstr "Nom del bloc"
+
+#: ../../Zotlabs/Module/Blocks.php:154 ../../include/text.php:2402
+msgid "Blocks"
+msgstr "Blocs"
+
+#: ../../Zotlabs/Module/Blocks.php:156
+msgid "Block Title"
+msgstr "Títol del bloc"
+
+#: ../../Zotlabs/Module/Blocks.php:157 ../../Zotlabs/Module/Menu.php:114
+#: ../../Zotlabs/Module/Layouts.php:191 ../../Zotlabs/Module/Webpages.php:251
+msgid "Created"
+msgstr "Creat"
+
+#: ../../Zotlabs/Module/Blocks.php:158 ../../Zotlabs/Module/Menu.php:115
+#: ../../Zotlabs/Module/Layouts.php:192 ../../Zotlabs/Module/Webpages.php:252
+msgid "Edited"
+msgstr "Editat"
+
+#: ../../Zotlabs/Module/Blocks.php:159 ../../Zotlabs/Module/Articles.php:96
+#: ../../Zotlabs/Module/Cdav.php:1185 ../../Zotlabs/Module/New_channel.php:146
+#: ../../Zotlabs/Module/Connedit.php:921 ../../Zotlabs/Module/Menu.php:118
+#: ../../Zotlabs/Module/Layouts.php:185 ../../Zotlabs/Module/Profiles.php:801
+#: ../../Zotlabs/Module/Cards.php:100 ../../Zotlabs/Module/Webpages.php:239
+#: ../../Zotlabs/Storage/Browser.php:276 ../../Zotlabs/Storage/Browser.php:382
+#: ../../Zotlabs/Widget/Cdav.php:128 ../../Zotlabs/Widget/Cdav.php:165
 msgid "Create"
-msgstr "Crear"
+msgstr "Crea"
 
-#: ../../Zotlabs/Storage/Browser.php:231 ../../Zotlabs/Storage/Browser.php:308
-#: ../../Zotlabs/Module/Cover_photo.php:357
-#: ../../Zotlabs/Module/Photos.php:825 ../../Zotlabs/Module/Photos.php:1364
-#: ../../Zotlabs/Module/Profile_photo.php:368 ../../include/widgets.php:1518
-msgid "Upload"
-msgstr "Pujar"
-
-#: ../../Zotlabs/Storage/Browser.php:235 ../../Zotlabs/Module/Chat.php:247
-#: ../../Zotlabs/Module/Admin.php:1223 ../../Zotlabs/Module/Settings.php:592
-#: ../../Zotlabs/Module/Settings.php:618
-#: ../../Zotlabs/Module/Sharedwithme.php:99
-msgid "Name"
-msgstr "Nom"
-
-#: ../../Zotlabs/Storage/Browser.php:236
-msgid "Type"
-msgstr "Tipus"
-
-#: ../../Zotlabs/Storage/Browser.php:237
-#: ../../Zotlabs/Module/Sharedwithme.php:101 ../../include/text.php:1344
-msgid "Size"
-msgstr "Mida"
-
-#: ../../Zotlabs/Storage/Browser.php:238
-#: ../../Zotlabs/Module/Sharedwithme.php:102
-msgid "Last Modified"
-msgstr "Últim Modificat"
-
-#: ../../Zotlabs/Storage/Browser.php:240 ../../Zotlabs/Module/Blocks.php:157
-#: ../../Zotlabs/Module/Editblock.php:109
-#: ../../Zotlabs/Module/Connections.php:290
-#: ../../Zotlabs/Module/Connections.php:310
-#: ../../Zotlabs/Module/Editpost.php:84
-#: ../../Zotlabs/Module/Editlayout.php:113
-#: ../../Zotlabs/Module/Editwebpage.php:146
-#: ../../Zotlabs/Module/Layouts.php:190 ../../Zotlabs/Module/Menu.php:112
-#: ../../Zotlabs/Module/Admin.php:2113 ../../Zotlabs/Module/Settings.php:652
-#: ../../Zotlabs/Module/Thing.php:260 ../../Zotlabs/Module/Webpages.php:187
-#: ../../Zotlabs/Lib/Apps.php:337 ../../Zotlabs/Lib/ThreadItem.php:106
-#: ../../include/channel.php:937 ../../include/channel.php:941
-#: ../../include/menu.php:108 ../../include/page_widgets.php:8
-#: ../../include/page_widgets.php:36
+#: ../../Zotlabs/Module/Blocks.php:160 ../../Zotlabs/Module/Editlayout.php:114
+#: ../../Zotlabs/Module/Article_edit.php:99
+#: ../../Zotlabs/Module/Admin/Profs.php:154
+#: ../../Zotlabs/Module/Settings/Oauth.php:149
+#: ../../Zotlabs/Module/Thing.php:261 ../../Zotlabs/Module/Editblock.php:114
+#: ../../Zotlabs/Module/Connections.php:265
+#: ../../Zotlabs/Module/Connections.php:303
+#: ../../Zotlabs/Module/Connections.php:323 ../../Zotlabs/Module/Wiki.php:202
+#: ../../Zotlabs/Module/Wiki.php:358 ../../Zotlabs/Module/Menu.php:112
+#: ../../Zotlabs/Module/Layouts.php:193
+#: ../../Zotlabs/Module/Editwebpage.php:142
+#: ../../Zotlabs/Module/Webpages.php:240 ../../Zotlabs/Module/Editpost.php:85
+#: ../../Zotlabs/Module/Card_edit.php:99 ../../Zotlabs/Lib/Apps.php:409
+#: ../../Zotlabs/Lib/ThreadItem.php:121 ../../Zotlabs/Storage/Browser.php:288
+#: ../../Zotlabs/Widget/Cdav.php:126 ../../Zotlabs/Widget/Cdav.php:162
+#: ../../addon/gitwiki/Mod_Gitwiki.php:151
+#: ../../addon/gitwiki/Mod_Gitwiki.php:252 ../../include/channel.php:1297
+#: ../../include/channel.php:1301 ../../include/menu.php:113
 msgid "Edit"
 msgstr "Edita"
 
-#: ../../Zotlabs/Storage/Browser.php:241 ../../Zotlabs/Module/Blocks.php:159
-#: ../../Zotlabs/Module/Connedit.php:572
-#: ../../Zotlabs/Module/Editblock.php:134
-#: ../../Zotlabs/Module/Connections.php:263
-#: ../../Zotlabs/Module/Editlayout.php:136
-#: ../../Zotlabs/Module/Editwebpage.php:170 ../../Zotlabs/Module/Group.php:177
-#: ../../Zotlabs/Module/Photos.php:1173 ../../Zotlabs/Module/Admin.php:1039
-#: ../../Zotlabs/Module/Admin.php:1213 ../../Zotlabs/Module/Admin.php:2114
-#: ../../Zotlabs/Module/Settings.php:653 ../../Zotlabs/Module/Thing.php:261
-#: ../../Zotlabs/Module/Webpages.php:189 ../../Zotlabs/Lib/Apps.php:338
-#: ../../Zotlabs/Lib/ThreadItem.php:126 ../../include/conversation.php:657
+#: ../../Zotlabs/Module/Blocks.php:161 ../../Zotlabs/Module/Photos.php:1102
+#: ../../Zotlabs/Module/Layouts.php:194 ../../Zotlabs/Module/Webpages.php:241
+#: ../../Zotlabs/Widget/Cdav.php:124 ../../include/conversation.php:1363
+msgid "Share"
+msgstr "Compartir"
+
+#: ../../Zotlabs/Module/Blocks.php:162 ../../Zotlabs/Module/Editlayout.php:138
+#: ../../Zotlabs/Module/Cdav.php:897 ../../Zotlabs/Module/Cdav.php:1187
+#: ../../Zotlabs/Module/Article_edit.php:129
+#: ../../Zotlabs/Module/Admin/Accounts.php:174
+#: ../../Zotlabs/Module/Admin/Channels.php:149
+#: ../../Zotlabs/Module/Admin/Profs.php:155
+#: ../../Zotlabs/Module/Settings/Oauth.php:150
+#: ../../Zotlabs/Module/Thing.php:262 ../../Zotlabs/Module/Editblock.php:139
+#: ../../Zotlabs/Module/Connections.php:273
+#: ../../Zotlabs/Module/Photos.php:1203 ../../Zotlabs/Module/Connedit.php:654
+#: ../../Zotlabs/Module/Connedit.php:923 ../../Zotlabs/Module/Group.php:179
+#: ../../Zotlabs/Module/Profiles.php:803
+#: ../../Zotlabs/Module/Editwebpage.php:167
+#: ../../Zotlabs/Module/Webpages.php:242
+#: ../../Zotlabs/Module/Card_edit.php:129 ../../Zotlabs/Lib/Apps.php:410
+#: ../../Zotlabs/Lib/ThreadItem.php:141 ../../Zotlabs/Storage/Browser.php:289
+#: ../../include/conversation.php:690 ../../include/conversation.php:733
 msgid "Delete"
 msgstr "Esborra"
 
-#: ../../Zotlabs/Storage/Browser.php:285
-#, php-format
-msgid "You are using %1$s of your available file storage."
-msgstr "Estàs emprant el %1$s de l'espai d'emmagatzematge disponible"
+#: ../../Zotlabs/Module/Blocks.php:166 ../../Zotlabs/Module/Events.php:694
+#: ../../Zotlabs/Module/Wiki.php:204 ../../Zotlabs/Module/Layouts.php:198
+#: ../../Zotlabs/Module/Webpages.php:246 ../../Zotlabs/Module/Pubsites.php:60
+#: ../../addon/gitwiki/Mod_Gitwiki.php:153
+msgid "View"
+msgstr "Mostra"
 
-#: ../../Zotlabs/Storage/Browser.php:290
-#, php-format
-msgid "You are using %1$s of %2$s available file storage. (%3$s&#37;)"
-msgstr "Estàs emprant %1$s de %2$s d'emmagatzematge d'arxius disponible.\n(%3$s&#37;)"
+#: ../../Zotlabs/Module/Invite.php:29
+msgid "Total invitation limit exceeded."
+msgstr "S'ha superat el límit total d'invitacions."
 
-#: ../../Zotlabs/Storage/Browser.php:302
-msgid "WARNING:"
+#: ../../Zotlabs/Module/Invite.php:53
+#, php-format
+msgid "%s : Not a valid email address."
+msgstr "L'adreça de correu %s no és vàlida."
+
+#: ../../Zotlabs/Module/Invite.php:67
+msgid "Please join us on $Projectname"
+msgstr "Suma't a $Projectname!"
+
+#: ../../Zotlabs/Module/Invite.php:77
+msgid "Invitation limit exceeded. Please contact your site administrator."
+msgstr "S'ha superat el límit d'invitacions. Posa't en contacte amb l'administrador del lloc."
+
+#: ../../Zotlabs/Module/Invite.php:82
+#: ../../addon/notifyadmin/notifyadmin.php:40
+#, php-format
+msgid "%s : Message delivery failed."
+msgstr "No s'ha pogut lliurar la invitació a %s"
+
+#: ../../Zotlabs/Module/Invite.php:86
+#, php-format
+msgid "%d message sent."
+msgid_plural "%d messages sent."
+msgstr[0] "S'ha enviat %d invitació."
+msgstr[1] "S'han enviat %d invitacions."
+
+#: ../../Zotlabs/Module/Invite.php:107
+msgid "You have no more invitations available"
+msgstr "No pots enviar més invitacions"
+
+#: ../../Zotlabs/Module/Invite.php:138
+msgid "Send invitations"
+msgstr "Envia invitacions"
+
+#: ../../Zotlabs/Module/Invite.php:139
+msgid "Enter email addresses, one per line:"
+msgstr "Introdueix les adreces de correu electrònic, una per línia:"
+
+#: ../../Zotlabs/Module/Invite.php:140 ../../Zotlabs/Module/Mail.php:285
+msgid "Your message:"
+msgstr "El teu missatge:"
+
+#: ../../Zotlabs/Module/Invite.php:141
+msgid "Please join my community on $Projectname."
+msgstr "Vols sumar-te a la meva comunitat a $Projectname?"
+
+#: ../../Zotlabs/Module/Invite.php:143
+msgid "You will need to supply this invitation code:"
+msgstr "Hauràs de facilitar aquest codi d'invitació:"
+
+#: ../../Zotlabs/Module/Invite.php:144
+msgid ""
+"1. Register at any $Projectname location (they are all inter-connected)"
+msgstr "1. Pots registrar-te a qualsevol node de $Projectname (estan tots interconnectats)"
+
+#: ../../Zotlabs/Module/Invite.php:146
+msgid "2. Enter my $Projectname network address into the site searchbar."
+msgstr "2. Escriu a la barra de cerca la meva adreça de la xarxa $Projectname."
+
+#: ../../Zotlabs/Module/Invite.php:147
+msgid "or visit"
+msgstr "o bé visita"
+
+#: ../../Zotlabs/Module/Invite.php:149
+msgid "3. Click [Connect]"
+msgstr "3. Clica [connecta]"
+
+#: ../../Zotlabs/Module/Invite.php:151 ../../Zotlabs/Module/Locs.php:121
+#: ../../Zotlabs/Module/Mitem.php:243 ../../Zotlabs/Module/Events.php:493
+#: ../../Zotlabs/Module/Appman.php:152
+#: ../../Zotlabs/Module/Import_items.php:129
+#: ../../Zotlabs/Module/Setup.php:308 ../../Zotlabs/Module/Setup.php:349
+#: ../../Zotlabs/Module/Connect.php:98
+#: ../../Zotlabs/Module/Admin/Features.php:66
+#: ../../Zotlabs/Module/Admin/Plugins.php:438
+#: ../../Zotlabs/Module/Admin/Accounts.php:167
+#: ../../Zotlabs/Module/Admin/Logs.php:84
+#: ../../Zotlabs/Module/Admin/Channels.php:147
+#: ../../Zotlabs/Module/Admin/Themes.php:158
+#: ../../Zotlabs/Module/Admin/Site.php:289
+#: ../../Zotlabs/Module/Admin/Profs.php:157
+#: ../../Zotlabs/Module/Admin/Account_edit.php:74
+#: ../../Zotlabs/Module/Admin/Security.php:104
+#: ../../Zotlabs/Module/Settings/Permcats.php:110
+#: ../../Zotlabs/Module/Settings/Channel.php:488
+#: ../../Zotlabs/Module/Settings/Features.php:47
+#: ../../Zotlabs/Module/Settings/Tokens.php:168
+#: ../../Zotlabs/Module/Settings/Account.php:118
+#: ../../Zotlabs/Module/Settings/Featured.php:54
+#: ../../Zotlabs/Module/Settings/Display.php:192
+#: ../../Zotlabs/Module/Settings/Oauth.php:87
+#: ../../Zotlabs/Module/Thing.php:321 ../../Zotlabs/Module/Thing.php:374
+#: ../../Zotlabs/Module/Import.php:529 ../../Zotlabs/Module/Cal.php:345
+#: ../../Zotlabs/Module/Mood.php:139 ../../Zotlabs/Module/Photos.php:1082
+#: ../../Zotlabs/Module/Photos.php:1122 ../../Zotlabs/Module/Photos.php:1240
+#: ../../Zotlabs/Module/Wiki.php:206 ../../Zotlabs/Module/Pdledit.php:98
+#: ../../Zotlabs/Module/Poke.php:200 ../../Zotlabs/Module/Connedit.php:887
+#: ../../Zotlabs/Module/Chat.php:196 ../../Zotlabs/Module/Chat.php:242
+#: ../../Zotlabs/Module/Email_validation.php:40
+#: ../../Zotlabs/Module/Pconfig.php:107 ../../Zotlabs/Module/Defperms.php:249
+#: ../../Zotlabs/Module/Group.php:87 ../../Zotlabs/Module/Profiles.php:726
+#: ../../Zotlabs/Module/Sources.php:114 ../../Zotlabs/Module/Sources.php:149
+#: ../../Zotlabs/Module/Xchan.php:15 ../../Zotlabs/Module/Mail.php:431
+#: ../../Zotlabs/Module/Filestorage.php:160 ../../Zotlabs/Module/Rate.php:166
+#: ../../Zotlabs/Lib/ThreadItem.php:750
+#: ../../Zotlabs/Widget/Eventstools.php:16
+#: ../../Zotlabs/Widget/Wiki_pages.php:40
+#: ../../Zotlabs/Widget/Wiki_pages.php:97
+#: ../../view/theme/redbasic_c/php/config.php:95
+#: ../../view/theme/redbasic/php/config.php:93
+#: ../../addon/skeleton/skeleton.php:65 ../../addon/gnusoc/gnusoc.php:273
+#: ../../addon/planets/planets.php:153
+#: ../../addon/openclipatar/openclipatar.php:53
+#: ../../addon/wppost/wppost.php:113 ../../addon/nsfw/nsfw.php:92
+#: ../../addon/ijpost/ijpost.php:89 ../../addon/dwpost/dwpost.php:89
+#: ../../addon/likebanner/likebanner.php:57
+#: ../../addon/redphotos/redphotos.php:136 ../../addon/irc/irc.php:53
+#: ../../addon/ljpost/ljpost.php:86 ../../addon/startpage/startpage.php:113
+#: ../../addon/diaspora/diaspora.php:822
+#: ../../addon/gitwiki/Mod_Gitwiki.php:155
+#: ../../addon/rainbowtag/rainbowtag.php:85 ../../addon/hzfiles/hzfiles.php:84
+#: ../../addon/visage/visage.php:170 ../../addon/nsabait/nsabait.php:161
+#: ../../addon/mailtest/mailtest.php:100
+#: ../../addon/openstreetmap/openstreetmap.php:168
+#: ../../addon/rtof/rtof.php:101 ../../addon/jappixmini/jappixmini.php:371
+#: ../../addon/superblock/superblock.php:120 ../../addon/nofed/nofed.php:80
+#: ../../addon/redred/redred.php:119 ../../addon/logrot/logrot.php:35
+#: ../../addon/frphotos/frphotos.php:96 ../../addon/pubcrawl/pubcrawl.php:1053
+#: ../../addon/chords/Mod_Chords.php:60 ../../addon/libertree/libertree.php:85
+#: ../../addon/flattrwidget/flattrwidget.php:124
+#: ../../addon/statusnet/statusnet.php:322
+#: ../../addon/statusnet/statusnet.php:380
+#: ../../addon/statusnet/statusnet.php:432
+#: ../../addon/statusnet/statusnet.php:900 ../../addon/twitter/twitter.php:218
+#: ../../addon/twitter/twitter.php:265
+#: ../../addon/smileybutton/smileybutton.php:219
+#: ../../addon/piwik/piwik.php:95 ../../addon/pageheader/pageheader.php:48
+#: ../../addon/authchoose/authchoose.php:71 ../../addon/xmpp/xmpp.php:69
+#: ../../addon/pumpio/pumpio.php:237 ../../addon/redfiles/redfiles.php:124
+#: ../../addon/hubwall/hubwall.php:95 ../../include/js_strings.php:22
+msgid "Submit"
+msgstr "Envia"
+
+#: ../../Zotlabs/Module/Articles.php:38 ../../Zotlabs/Module/Articles.php:179
+#: ../../Zotlabs/Lib/Apps.php:229 ../../include/features.php:124
+#: ../../include/nav.php:469
+msgid "Articles"
+msgstr "Articles"
+
+#: ../../Zotlabs/Module/Articles.php:95
+msgid "Add Article"
+msgstr "Afegeix un article"
+
+#: ../../Zotlabs/Module/Editlayout.php:79
+#: ../../Zotlabs/Module/Article_edit.php:17
+#: ../../Zotlabs/Module/Article_edit.php:33
+#: ../../Zotlabs/Module/Editblock.php:79 ../../Zotlabs/Module/Editblock.php:95
+#: ../../Zotlabs/Module/Editwebpage.php:80
+#: ../../Zotlabs/Module/Editpost.php:24 ../../Zotlabs/Module/Card_edit.php:17
+#: ../../Zotlabs/Module/Card_edit.php:33
+msgid "Item not found"
+msgstr "No s'ha trobat l'element"
+
+#: ../../Zotlabs/Module/Editlayout.php:128
+#: ../../Zotlabs/Module/Layouts.php:129 ../../Zotlabs/Module/Layouts.php:189
+msgid "Layout Name"
+msgstr "Nom del disseny"
+
+#: ../../Zotlabs/Module/Editlayout.php:129
+#: ../../Zotlabs/Module/Layouts.php:132
+msgid "Layout Description (Optional)"
+msgstr "Descripció del disseny (opcional)"
+
+#: ../../Zotlabs/Module/Editlayout.php:137
+msgid "Edit Layout"
+msgstr "Edita el disseny"
+
+#: ../../Zotlabs/Module/Profperm.php:28 ../../Zotlabs/Module/Subthread.php:86
+#: ../../Zotlabs/Module/Import_items.php:120
+#: ../../Zotlabs/Module/Cloud.php:111 ../../Zotlabs/Module/Group.php:74
+#: ../../Zotlabs/Module/Dreport.php:10 ../../Zotlabs/Module/Dreport.php:68
+#: ../../Zotlabs/Module/Like.php:296 ../../Zotlabs/Web/WebServer.php:122
+#: ../../addon/redphotos/redphotos.php:119 ../../addon/hzfiles/hzfiles.php:73
+#: ../../addon/frphotos/frphotos.php:81 ../../addon/redfiles/redfiles.php:109
+#: ../../include/items.php:358
+msgid "Permission denied"
+msgstr "S'ha denegat el permís"
+
+#: ../../Zotlabs/Module/Profperm.php:34 ../../Zotlabs/Module/Profperm.php:63
+msgid "Invalid profile identifier."
+msgstr "L'identificador de perfil no és vàlid."
+
+#: ../../Zotlabs/Module/Profperm.php:111
+msgid "Profile Visibility Editor"
+msgstr "Editor de la visibilitat del perfil"
+
+#: ../../Zotlabs/Module/Profperm.php:113 ../../include/channel.php:1634
+msgid "Profile"
+msgstr "Perfil"
+
+#: ../../Zotlabs/Module/Profperm.php:115
+msgid "Click on a contact to add or remove."
+msgstr "Clica sobre un contacte per afegir-lo o esborrar-lo."
+
+#: ../../Zotlabs/Module/Profperm.php:124
+msgid "Visible To"
+msgstr "Visible per"
+
+#: ../../Zotlabs/Module/Profperm.php:140
+#: ../../Zotlabs/Module/Connections.php:140
+msgid "All Connections"
+msgstr "Totes les connexions"
+
+#: ../../Zotlabs/Module/Cdav.php:785
+msgid "INVALID EVENT DISMISSED!"
+msgstr "S'HA DESCARTAT UN ESDEVENIMENT INVÀLID."
+
+#: ../../Zotlabs/Module/Cdav.php:786
+msgid "Summary: "
+msgstr "Resum:"
+
+#: ../../Zotlabs/Module/Cdav.php:786 ../../Zotlabs/Module/Cdav.php:787
+#: ../../Zotlabs/Module/Cdav.php:794 ../../Zotlabs/Module/Embedphotos.php:146
+#: ../../Zotlabs/Module/Photos.php:817 ../../Zotlabs/Module/Photos.php:1273
+#: ../../Zotlabs/Lib/Apps.php:754 ../../Zotlabs/Lib/Apps.php:832
+#: ../../Zotlabs/Storage/Browser.php:164 ../../Zotlabs/Widget/Portfolio.php:95
+#: ../../Zotlabs/Widget/Album.php:84 ../../addon/pubcrawl/as.php:853
+#: ../../include/conversation.php:1160
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: ../../Zotlabs/Module/Cdav.php:787
+msgid "Date: "
+msgstr "Data:"
+
+#: ../../Zotlabs/Module/Cdav.php:788 ../../Zotlabs/Module/Cdav.php:795
+msgid "Reason: "
+msgstr "Motiu:"
+
+#: ../../Zotlabs/Module/Cdav.php:793
+msgid "INVALID CARD DISMISSED!"
+msgstr "S'HA DESCARTAT UNA TARGETA INVÀLIDA."
+
+#: ../../Zotlabs/Module/Cdav.php:794
+msgid "Name: "
+msgstr "Nom:"
+
+#: ../../Zotlabs/Module/Cdav.php:868 ../../Zotlabs/Module/Events.php:460
+msgid "Event title"
+msgstr "Títol de l'esdeveniment"
+
+#: ../../Zotlabs/Module/Cdav.php:869 ../../Zotlabs/Module/Events.php:466
+msgid "Start date and time"
+msgstr "Data i hora d'inici"
+
+#: ../../Zotlabs/Module/Cdav.php:869 ../../Zotlabs/Module/Cdav.php:870
+msgid "Example: YYYY-MM-DD HH:mm"
+msgstr "Exemple: AAAA-MM-DD HH:mm"
+
+#: ../../Zotlabs/Module/Cdav.php:870
+msgid "End date and time"
+msgstr "Data i hora de fi"
+
+#: ../../Zotlabs/Module/Cdav.php:871 ../../Zotlabs/Module/Events.php:473
+#: ../../Zotlabs/Module/Appman.php:142 ../../Zotlabs/Module/Rbmark.php:101
+#: ../../addon/rendezvous/rendezvous.php:173
+msgid "Description"
+msgstr "Descripció"
+
+#: ../../Zotlabs/Module/Cdav.php:872 ../../Zotlabs/Module/Locs.php:117
+#: ../../Zotlabs/Module/Events.php:475 ../../Zotlabs/Module/Profiles.php:509
+#: ../../Zotlabs/Module/Profiles.php:737 ../../Zotlabs/Module/Pubsites.php:52
+#: ../../include/js_strings.php:25
+msgid "Location"
+msgstr "Ubicació"
+
+#: ../../Zotlabs/Module/Cdav.php:879 ../../Zotlabs/Module/Events.php:689
+#: ../../Zotlabs/Module/Events.php:698 ../../Zotlabs/Module/Cal.php:339
+#: ../../Zotlabs/Module/Cal.php:346 ../../Zotlabs/Module/Photos.php:971
+msgid "Previous"
+msgstr "Anterior"
+
+#: ../../Zotlabs/Module/Cdav.php:880 ../../Zotlabs/Module/Events.php:690
+#: ../../Zotlabs/Module/Events.php:699 ../../Zotlabs/Module/Setup.php:263
+#: ../../Zotlabs/Module/Cal.php:340 ../../Zotlabs/Module/Cal.php:347
+#: ../../Zotlabs/Module/Photos.php:980
+msgid "Next"
+msgstr "Següent"
+
+#: ../../Zotlabs/Module/Cdav.php:881 ../../Zotlabs/Module/Events.php:700
+#: ../../Zotlabs/Module/Cal.php:348
+msgid "Today"
+msgstr "Avui"
+
+#: ../../Zotlabs/Module/Cdav.php:882 ../../Zotlabs/Module/Events.php:695
+msgid "Month"
+msgstr "mes"
+
+#: ../../Zotlabs/Module/Cdav.php:883 ../../Zotlabs/Module/Events.php:696
+msgid "Week"
+msgstr "setmana"
+
+#: ../../Zotlabs/Module/Cdav.php:884 ../../Zotlabs/Module/Events.php:697
+msgid "Day"
+msgstr "dia"
+
+#: ../../Zotlabs/Module/Cdav.php:885
+msgid "List month"
+msgstr "Mes en llista"
+
+#: ../../Zotlabs/Module/Cdav.php:886
+msgid "List week"
+msgstr "Setmana en llista"
+
+#: ../../Zotlabs/Module/Cdav.php:887
+msgid "List day"
+msgstr "Dia en llista"
+
+#: ../../Zotlabs/Module/Cdav.php:894
+msgid "More"
+msgstr "Mostra més"
+
+#: ../../Zotlabs/Module/Cdav.php:895
+msgid "Less"
+msgstr "Mostra menys"
+
+#: ../../Zotlabs/Module/Cdav.php:896
+msgid "Select calendar"
+msgstr "Tria un calendari"
+
+#: ../../Zotlabs/Module/Cdav.php:898
+msgid "Delete all"
+msgstr "Esborra'ls tots"
+
+#: ../../Zotlabs/Module/Cdav.php:899 ../../Zotlabs/Module/Cdav.php:1188
+#: ../../Zotlabs/Module/Admin/Plugins.php:423
+#: ../../Zotlabs/Module/Settings/Oauth.php:88
+#: ../../Zotlabs/Module/Settings/Oauth.php:114
+#: ../../Zotlabs/Module/Wiki.php:345 ../../Zotlabs/Module/Wiki.php:375
+#: ../../Zotlabs/Module/Profile_photo.php:464
+#: ../../Zotlabs/Module/Connedit.php:924 ../../Zotlabs/Module/Fbrowser.php:66
+#: ../../Zotlabs/Module/Fbrowser.php:88 ../../Zotlabs/Module/Profiles.php:804
+#: ../../Zotlabs/Module/Filer.php:55 ../../Zotlabs/Module/Cover_photo.php:365
+#: ../../Zotlabs/Module/Tagrm.php:15 ../../Zotlabs/Module/Tagrm.php:138
+#: ../../addon/gitwiki/Mod_Gitwiki.php:244
+#: ../../addon/gitwiki/Mod_Gitwiki.php:267 ../../include/conversation.php:1386
+#: ../../include/conversation.php:1435
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: ../../Zotlabs/Module/Cdav.php:900
+msgid "Sorry! Editing of recurrent events is not yet implemented."
+msgstr "Malauradament encara no es poden editar esdeveniments periòdics."
+
+#: ../../Zotlabs/Module/Cdav.php:1170
+#: ../../Zotlabs/Module/Sharedwithme.php:105
+#: ../../Zotlabs/Module/Admin/Channels.php:159
+#: ../../Zotlabs/Module/Settings/Oauth.php:89
+#: ../../Zotlabs/Module/Settings/Oauth.php:115
+#: ../../Zotlabs/Module/Wiki.php:209 ../../Zotlabs/Module/Connedit.php:906
+#: ../../Zotlabs/Module/Chat.php:251 ../../Zotlabs/Lib/NativeWikiPage.php:558
+#: ../../Zotlabs/Storage/Browser.php:283
+#: ../../Zotlabs/Widget/Wiki_page_history.php:22
+#: ../../addon/rendezvous/rendezvous.php:172
+#: ../../addon/gitwiki/Mod_Gitwiki.php:158
+msgid "Name"
+msgstr "Nom"
+
+#: ../../Zotlabs/Module/Cdav.php:1171 ../../Zotlabs/Module/Connedit.php:907
+msgid "Organisation"
+msgstr "Organització"
+
+#: ../../Zotlabs/Module/Cdav.php:1172 ../../Zotlabs/Module/Connedit.php:908
+msgid "Title"
+msgstr "Títol"
+
+#: ../../Zotlabs/Module/Cdav.php:1173 ../../Zotlabs/Module/Connedit.php:909
+#: ../../Zotlabs/Module/Profiles.php:789
+msgid "Phone"
+msgstr "Telèfon"
+
+#: ../../Zotlabs/Module/Cdav.php:1174
+#: ../../Zotlabs/Module/Admin/Accounts.php:170
+#: ../../Zotlabs/Module/Admin/Accounts.php:182
+#: ../../Zotlabs/Module/Connedit.php:910 ../../Zotlabs/Module/Profiles.php:790
+#: ../../addon/openid/MysqlProvider.php:56
+#: ../../addon/openid/MysqlProvider.php:57 ../../addon/rtof/rtof.php:93
+#: ../../addon/redred/redred.php:107 ../../include/network.php:1775
+msgid "Email"
+msgstr "Correu electrònic"
+
+#: ../../Zotlabs/Module/Cdav.php:1175 ../../Zotlabs/Module/Connedit.php:911
+#: ../../Zotlabs/Module/Profiles.php:791
+msgid "Instant messenger"
+msgstr "Missatgeria instantània"
+
+#: ../../Zotlabs/Module/Cdav.php:1176 ../../Zotlabs/Module/Connedit.php:912
+#: ../../Zotlabs/Module/Profiles.php:792
+msgid "Website"
+msgstr "Lloc web"
+
+#: ../../Zotlabs/Module/Cdav.php:1177 ../../Zotlabs/Module/Locs.php:118
+#: ../../Zotlabs/Module/Admin/Channels.php:160
+#: ../../Zotlabs/Module/Connedit.php:913 ../../Zotlabs/Module/Profiles.php:502
+#: ../../Zotlabs/Module/Profiles.php:793
+msgid "Address"
+msgstr "Adreça"
+
+#: ../../Zotlabs/Module/Cdav.php:1178 ../../Zotlabs/Module/Connedit.php:914
+#: ../../Zotlabs/Module/Profiles.php:794
+msgid "Note"
+msgstr "Nota"
+
+#: ../../Zotlabs/Module/Cdav.php:1179 ../../Zotlabs/Module/Connedit.php:915
+#: ../../Zotlabs/Module/Profiles.php:795 ../../include/event.php:1308
+#: ../../include/connections.php:682
+msgid "Mobile"
+msgstr "Mòbil"
+
+#: ../../Zotlabs/Module/Cdav.php:1180 ../../Zotlabs/Module/Connedit.php:916
+#: ../../Zotlabs/Module/Profiles.php:796 ../../include/event.php:1309
+#: ../../include/connections.php:683
+msgid "Home"
+msgstr "Inici"
+
+#: ../../Zotlabs/Module/Cdav.php:1181 ../../Zotlabs/Module/Connedit.php:917
+#: ../../Zotlabs/Module/Profiles.php:797 ../../include/event.php:1312
+#: ../../include/connections.php:686
+msgid "Work"
+msgstr "Feina"
+
+#: ../../Zotlabs/Module/Cdav.php:1183 ../../Zotlabs/Module/Connedit.php:919
+#: ../../Zotlabs/Module/Profiles.php:799
+#: ../../addon/jappixmini/jappixmini.php:368
+msgid "Add Contact"
+msgstr "Afegeix un contacte"
+
+#: ../../Zotlabs/Module/Cdav.php:1184 ../../Zotlabs/Module/Connedit.php:920
+#: ../../Zotlabs/Module/Profiles.php:800
+msgid "Add Field"
+msgstr "Afegeix un camp"
+
+#: ../../Zotlabs/Module/Cdav.php:1186
+#: ../../Zotlabs/Module/Admin/Plugins.php:453
+#: ../../Zotlabs/Module/Settings/Oauth.php:42
+#: ../../Zotlabs/Module/Settings/Oauth.php:113
+#: ../../Zotlabs/Module/Connedit.php:922 ../../Zotlabs/Module/Profiles.php:802
+#: ../../Zotlabs/Lib/Apps.php:393
+msgid "Update"
+msgstr "Actualitza"
+
+#: ../../Zotlabs/Module/Cdav.php:1189 ../../Zotlabs/Module/Connedit.php:925
+msgid "P.O. Box"
+msgstr "Apartat de correus"
+
+#: ../../Zotlabs/Module/Cdav.php:1190 ../../Zotlabs/Module/Connedit.php:926
+msgid "Additional"
+msgstr "Addicional"
+
+#: ../../Zotlabs/Module/Cdav.php:1191 ../../Zotlabs/Module/Connedit.php:927
+msgid "Street"
+msgstr "Carrer"
+
+#: ../../Zotlabs/Module/Cdav.php:1192 ../../Zotlabs/Module/Connedit.php:928
+msgid "Locality"
+msgstr "Localitat"
+
+#: ../../Zotlabs/Module/Cdav.php:1193 ../../Zotlabs/Module/Connedit.php:929
+msgid "Region"
+msgstr "Regió"
+
+#: ../../Zotlabs/Module/Cdav.php:1194 ../../Zotlabs/Module/Connedit.php:930
+msgid "ZIP Code"
+msgstr "Codi postal"
+
+#: ../../Zotlabs/Module/Cdav.php:1195 ../../Zotlabs/Module/Connedit.php:931
+#: ../../Zotlabs/Module/Profiles.php:760
+msgid "Country"
+msgstr "País"
+
+#: ../../Zotlabs/Module/Cdav.php:1242
+msgid "Default Calendar"
+msgstr "Calendari per defecte"
+
+#: ../../Zotlabs/Module/Cdav.php:1252
+msgid "Default Addressbook"
+msgstr "Llibreta d'adreces per defecte"
+
+#: ../../Zotlabs/Module/Regdir.php:49 ../../Zotlabs/Module/Dirsearch.php:25
+msgid "This site is not a directory server"
+msgstr "Aquest hub no és un servidor de directori"
+
+#: ../../Zotlabs/Module/Channel.php:32 ../../Zotlabs/Module/Chat.php:25
+#: ../../addon/gitwiki/Mod_Gitwiki.php:28 ../../addon/chess/chess.php:508
+msgid "You must be logged in to see this page."
+msgstr "Has de tenir una sessió iniciada per a veure aquesta pàgina."
+
+#: ../../Zotlabs/Module/Channel.php:47 ../../Zotlabs/Module/Hcard.php:37
+#: ../../Zotlabs/Module/Profile.php:45
+msgid "Posts and comments"
+msgstr "Entrades i comentaris"
+
+#: ../../Zotlabs/Module/Channel.php:54 ../../Zotlabs/Module/Hcard.php:44
+#: ../../Zotlabs/Module/Profile.php:52
+msgid "Only posts"
+msgstr "Només entrades"
+
+#: ../../Zotlabs/Module/Channel.php:107
+msgid "Insufficient permissions.  Request redirected to profile page."
+msgstr "S'ha denegat el permís. La petició s'ha redirigit a la pàgina de perfil."
+
+#: ../../Zotlabs/Module/Uexport.php:57 ../../Zotlabs/Module/Uexport.php:58
+msgid "Export Channel"
+msgstr "Exporta un canal"
+
+#: ../../Zotlabs/Module/Uexport.php:59
+msgid ""
+"Export your basic channel information to a file.  This acts as a backup of "
+"your connections, permissions, profile and basic data, which can be used to "
+"import your data to a new server hub, but does not contain your content."
+msgstr "Exporta la informació bàsica del canal a un arxiu. Això serveix com a còpia de seguretat de les teves connexions, permisos, perfil i dades bàsiques, i pots emprar-la per a importar aquestes dades des d'un altre hub. No conté el contingut del canal."
+
+#: ../../Zotlabs/Module/Uexport.php:60
+msgid "Export Content"
+msgstr "Exporta'n el contingut"
+
+#: ../../Zotlabs/Module/Uexport.php:61
+msgid ""
+"Export your channel information and recent content to a JSON backup that can"
+" be restored or imported to another server hub. This backs up all of your "
+"connections, permissions, profile data and several months of posts. This "
+"file may be VERY large.  Please be patient - it may take several minutes for"
+" this download to begin."
+msgstr "Exporta la informació del canal i tot el contingut recent a una còpia de seguretat en format JSON. Pot ser restaurada o importada des d'un altre hub. Això desa totes les teves connexions, permisos, dades de perfil i diversos mesos de publicacions. L'arxiu pot ser MOLT gran. Si et plau, sigues pacient ja que la preparació de l'arxiu pot trigar una estona, abans que el puguis començar a baixar."
+
+#: ../../Zotlabs/Module/Uexport.php:63
+msgid "Export your posts from a given year."
+msgstr "Exporta les entrades d'un any determinat."
+
+#: ../../Zotlabs/Module/Uexport.php:65
+msgid ""
+"You may also export your posts and conversations for a particular year or "
+"month. Adjust the date in your browser location bar to select other dates. "
+"If the export fails (possibly due to memory exhaustion on your server hub), "
+"please try again selecting a more limited date range."
+msgstr "Pots també exportar les entrades i converses d'un any o un mes en particular. Ajusta la data a la barra d'adreces del navegador per seleccionar altres dates. Si l'exportació falla (possiblement degut a l'esgotament de la memòria RAM del servidor), prova de nou amb un interval de dates més petit."
+
+#: ../../Zotlabs/Module/Uexport.php:66
+#, php-format
+msgid ""
+"To select all posts for a given year, such as this year, visit <a "
+"href=\"%1$s\">%2$s</a>"
+msgstr "Per exemple, per seleccionar totes les entrades d'aquest any, ves a <a href=\"%1$s\">%2$s</a>"
+
+#: ../../Zotlabs/Module/Uexport.php:67
+#, php-format
+msgid ""
+"To select all posts for a given month, such as January of this year, visit "
+"<a href=\"%1$s\">%2$s</a>"
+msgstr "Per exemple, per seleccionar totes les entrades del mes de gener d'aquest any, ves a <a href=\"%1$s\">%2$s</a>"
+
+#: ../../Zotlabs/Module/Uexport.php:68
+#, php-format
+msgid ""
+"These content files may be imported or restored by visiting <a "
+"href=\"%1$s\">%2$s</a> on any site containing your channel. For best results"
+" please import or restore these in date order (oldest first)."
+msgstr "Les còpies de seguretat amb contingut es poden importar o restaurar des d'aquesta adreça  <a href=\"%1$s\">%2$s</a>. En aquest cas és aquest servidor, però també serviria en un altre hub que allotgés un clon del teu canal. Si vols restaurar més d'un arxiu de contingut, per evitar problemes importa'ls en ordre cronològic."
+
+#: ../../Zotlabs/Module/Hq.php:140
+msgid "Welcome to Hubzilla!"
+msgstr "Benvingut/da a Hubzilla!"
+
+#: ../../Zotlabs/Module/Hq.php:140
+msgid "You have got no unseen posts..."
+msgstr "No tens entrades pendents de veure..."
+
+#: ../../Zotlabs/Module/Search.php:17 ../../Zotlabs/Module/Photos.php:540
+#: ../../Zotlabs/Module/Ratings.php:83 ../../Zotlabs/Module/Directory.php:63
+#: ../../Zotlabs/Module/Directory.php:68 ../../Zotlabs/Module/Display.php:30
+#: ../../Zotlabs/Module/Viewconnections.php:23
+msgid "Public access denied."
+msgstr "L'accés públic no està permès."
+
+#: ../../Zotlabs/Module/Search.php:44 ../../Zotlabs/Module/Connections.php:319
+#: ../../Zotlabs/Lib/Apps.php:256 ../../Zotlabs/Widget/Sitesearch.php:31
+#: ../../include/text.php:1051 ../../include/text.php:1063
+#: ../../include/acl_selectors.php:118 ../../include/nav.php:179
+msgid "Search"
+msgstr "Cerca"
+
+#: ../../Zotlabs/Module/Search.php:226
+#, php-format
+msgid "Items tagged with: %s"
+msgstr "Elements etiquetats amb: %s"
+
+#: ../../Zotlabs/Module/Search.php:228
+#, php-format
+msgid "Search results for: %s"
+msgstr "Resultats de cerca per: %s"
+
+#: ../../Zotlabs/Module/Pubstream.php:93
+#: ../../Zotlabs/Widget/Notifications.php:131
+msgid "Public Stream"
+msgstr "Flux públic"
+
+#: ../../Zotlabs/Module/Locs.php:25 ../../Zotlabs/Module/Locs.php:54
+msgid "Location not found."
+msgstr "No s'ha trobat la ubicació."
+
+#: ../../Zotlabs/Module/Locs.php:62
+msgid "Location lookup failed."
+msgstr "Ha fallat la cerca d'ubicació."
+
+#: ../../Zotlabs/Module/Locs.php:66
+msgid ""
+"Please select another location to become primary before removing the primary"
+" location."
+msgstr "Abans d'esborrar la ubicació principal actual, fes-ne principal una altra."
+
+#: ../../Zotlabs/Module/Locs.php:95
+msgid "Syncing locations"
+msgstr "S'estan sincronitzant les ubicacions"
+
+#: ../../Zotlabs/Module/Locs.php:105
+msgid "No locations found."
+msgstr "No s'ha trobat cap ubicació."
+
+#: ../../Zotlabs/Module/Locs.php:116
+msgid "Manage Channel Locations"
+msgstr "Gestiona les ubicacions del canal"
+
+#: ../../Zotlabs/Module/Locs.php:119 ../../Zotlabs/Module/Admin.php:111
+msgid "Primary"
+msgstr "Primària"
+
+#: ../../Zotlabs/Module/Locs.php:120 ../../Zotlabs/Module/Menu.php:113
+msgid "Drop"
+msgstr "Esborra"
+
+#: ../../Zotlabs/Module/Locs.php:122
+msgid "Sync Now"
+msgstr "Sincronitza ara"
+
+#: ../../Zotlabs/Module/Locs.php:123
+msgid "Please wait several minutes between consecutive operations."
+msgstr "Espera uns minuts entre operacions consecutives."
+
+#: ../../Zotlabs/Module/Locs.php:124
+msgid ""
+"When possible, drop a location by logging into that website/hub and removing"
+" your channel."
+msgstr "Si pots, és preferible esborrar la ubicació esborrant el canal des del servidor on està copiat."
+
+#: ../../Zotlabs/Module/Locs.php:125
+msgid "Use this form to drop the location if the hub is no longer operating."
+msgstr "Fes servir aquest formulari per a esborrar la ubicació del lloc si el hub ja no està operatiu."
+
+#: ../../Zotlabs/Module/Apporder.php:44
+msgid "Change Order of Pinned Navbar Apps"
+msgstr "Canvia l'ordre de les aplicacions fixades a la barra de navegació"
+
+#: ../../Zotlabs/Module/Apporder.php:44
+msgid "Change Order of App Tray Apps"
+msgstr "Canvia l'ordre de les aplicacions de la safata d'aplicacions"
+
+#: ../../Zotlabs/Module/Apporder.php:45
+msgid ""
+"Use arrows to move the corresponding app left (top) or right (bottom) in the"
+" navbar"
+msgstr "Fes servir les fletxes per moure l'aplicació cap a l'esquerra (amunt) o cap a la dreta (avall)"
+
+#: ../../Zotlabs/Module/Apporder.php:45
+msgid "Use arrows to move the corresponding app up or down in the app tray"
+msgstr "Fes servir les fletxes per moure l'aplicació amunt o avall en la safata"
+
+#: ../../Zotlabs/Module/Mitem.php:28 ../../Zotlabs/Module/Menu.php:144
+msgid "Menu not found."
+msgstr "No s'ha trobat el menú."
+
+#: ../../Zotlabs/Module/Mitem.php:52
+msgid "Unable to create element."
+msgstr "Incapaç de crear l'element."
+
+#: ../../Zotlabs/Module/Mitem.php:76
+msgid "Unable to update menu element."
+msgstr "Incapaç d'actualitzar un element del menú."
+
+#: ../../Zotlabs/Module/Mitem.php:92
+msgid "Unable to add menu element."
+msgstr "No s'ha pogut afegir l'element de menú."
+
+#: ../../Zotlabs/Module/Mitem.php:120 ../../Zotlabs/Module/Menu.php:166
+#: ../../Zotlabs/Module/Xchan.php:41
+msgid "Not found."
+msgstr "No s'ha trobat."
+
+#: ../../Zotlabs/Module/Mitem.php:153 ../../Zotlabs/Module/Mitem.php:230
+msgid "Menu Item Permissions"
+msgstr "Permisos dels ítems de menú"
+
+#: ../../Zotlabs/Module/Mitem.php:154 ../../Zotlabs/Module/Mitem.php:231
+#: ../../Zotlabs/Module/Settings/Channel.php:521
+msgid "(click to open/close)"
+msgstr "(clica per obrir/tancar)"
+
+#: ../../Zotlabs/Module/Mitem.php:160 ../../Zotlabs/Module/Mitem.php:176
+msgid "Link Name"
+msgstr "Nom de l'enllaç"
+
+#: ../../Zotlabs/Module/Mitem.php:161 ../../Zotlabs/Module/Mitem.php:239
+msgid "Link or Submenu Target"
+msgstr "Destí de l'enllaç o del submenú"
+
+#: ../../Zotlabs/Module/Mitem.php:161
+msgid "Enter URL of the link or select a menu name to create a submenu"
+msgstr "Introdueix la URL de l'enllaç o tria un nom de menú per crear un submenú"
+
+#: ../../Zotlabs/Module/Mitem.php:162 ../../Zotlabs/Module/Mitem.php:240
+msgid "Use magic-auth if available"
+msgstr "Empra la magic-auth si està disponible"
+
+#: ../../Zotlabs/Module/Mitem.php:162 ../../Zotlabs/Module/Mitem.php:163
+#: ../../Zotlabs/Module/Mitem.php:240 ../../Zotlabs/Module/Mitem.php:241
+#: ../../Zotlabs/Module/Events.php:470 ../../Zotlabs/Module/Events.php:471
+#: ../../Zotlabs/Module/Removeme.php:63
+#: ../../Zotlabs/Module/Admin/Site.php:252
+#: ../../Zotlabs/Module/Settings/Channel.php:305
+#: ../../Zotlabs/Module/Settings/Display.php:100
+#: ../../Zotlabs/Module/Api.php:99 ../../Zotlabs/Module/Photos.php:697
+#: ../../Zotlabs/Module/Wiki.php:218 ../../Zotlabs/Module/Wiki.php:219
+#: ../../Zotlabs/Module/Connedit.php:396 ../../Zotlabs/Module/Connedit.php:779
+#: ../../Zotlabs/Module/Menu.php:100 ../../Zotlabs/Module/Menu.php:157
+#: ../../Zotlabs/Module/Defperms.php:180 ../../Zotlabs/Module/Profiles.php:681
+#: ../../Zotlabs/Module/Filestorage.php:155
+#: ../../Zotlabs/Module/Filestorage.php:163
+#: ../../Zotlabs/Storage/Browser.php:397 ../../boot.php:1587
+#: ../../view/theme/redbasic_c/php/config.php:100
+#: ../../view/theme/redbasic_c/php/config.php:115
+#: ../../view/theme/redbasic/php/config.php:98
+#: ../../addon/planets/planets.php:149 ../../addon/wppost/wppost.php:82
+#: ../../addon/wppost/wppost.php:105 ../../addon/wppost/wppost.php:109
+#: ../../addon/nsfw/nsfw.php:84 ../../addon/ijpost/ijpost.php:73
+#: ../../addon/ijpost/ijpost.php:85 ../../addon/dwpost/dwpost.php:73
+#: ../../addon/dwpost/dwpost.php:85 ../../addon/ljpost/ljpost.php:70
+#: ../../addon/ljpost/ljpost.php:82 ../../addon/gitwiki/Mod_Gitwiki.php:166
+#: ../../addon/rainbowtag/rainbowtag.php:81 ../../addon/visage/visage.php:166
+#: ../../addon/nsabait/nsabait.php:157 ../../addon/rtof/rtof.php:81
+#: ../../addon/rtof/rtof.php:85 ../../addon/jappixmini/jappixmini.php:309
+#: ../../addon/jappixmini/jappixmini.php:313
+#: ../../addon/jappixmini/jappixmini.php:343
+#: ../../addon/jappixmini/jappixmini.php:351
+#: ../../addon/jappixmini/jappixmini.php:355
+#: ../../addon/jappixmini/jappixmini.php:359 ../../addon/nofed/nofed.php:72
+#: ../../addon/nofed/nofed.php:76 ../../addon/redred/redred.php:95
+#: ../../addon/redred/redred.php:99 ../../addon/libertree/libertree.php:69
+#: ../../addon/libertree/libertree.php:81
+#: ../../addon/flattrwidget/flattrwidget.php:120
+#: ../../addon/statusnet/statusnet.php:389
+#: ../../addon/statusnet/statusnet.php:411
+#: ../../addon/statusnet/statusnet.php:415
+#: ../../addon/statusnet/statusnet.php:424 ../../addon/twitter/twitter.php:243
+#: ../../addon/twitter/twitter.php:252 ../../addon/twitter/twitter.php:261
+#: ../../addon/smileybutton/smileybutton.php:211
+#: ../../addon/smileybutton/smileybutton.php:215
+#: ../../addon/authchoose/authchoose.php:67 ../../addon/xmpp/xmpp.php:53
+#: ../../addon/pumpio/pumpio.php:219 ../../addon/pumpio/pumpio.php:223
+#: ../../addon/pumpio/pumpio.php:227 ../../addon/pumpio/pumpio.php:231
+#: ../../include/dir_fns.php:143 ../../include/dir_fns.php:144
+#: ../../include/dir_fns.php:145
+msgid "No"
+msgstr "No"
+
+#: ../../Zotlabs/Module/Mitem.php:162 ../../Zotlabs/Module/Mitem.php:163
+#: ../../Zotlabs/Module/Mitem.php:240 ../../Zotlabs/Module/Mitem.php:241
+#: ../../Zotlabs/Module/Events.php:470 ../../Zotlabs/Module/Events.php:471
+#: ../../Zotlabs/Module/Removeme.php:63
+#: ../../Zotlabs/Module/Admin/Site.php:254
+#: ../../Zotlabs/Module/Settings/Channel.php:305
+#: ../../Zotlabs/Module/Settings/Display.php:100
+#: ../../Zotlabs/Module/Api.php:98 ../../Zotlabs/Module/Photos.php:697
+#: ../../Zotlabs/Module/Wiki.php:218 ../../Zotlabs/Module/Wiki.php:219
+#: ../../Zotlabs/Module/Connedit.php:396 ../../Zotlabs/Module/Menu.php:100
+#: ../../Zotlabs/Module/Menu.php:157 ../../Zotlabs/Module/Defperms.php:180
+#: ../../Zotlabs/Module/Profiles.php:681
+#: ../../Zotlabs/Module/Filestorage.php:155
+#: ../../Zotlabs/Module/Filestorage.php:163
+#: ../../Zotlabs/Storage/Browser.php:397 ../../boot.php:1587
+#: ../../view/theme/redbasic_c/php/config.php:100
+#: ../../view/theme/redbasic_c/php/config.php:115
+#: ../../view/theme/redbasic/php/config.php:98
+#: ../../addon/planets/planets.php:149 ../../addon/wppost/wppost.php:82
+#: ../../addon/wppost/wppost.php:105 ../../addon/wppost/wppost.php:109
+#: ../../addon/nsfw/nsfw.php:84 ../../addon/ijpost/ijpost.php:73
+#: ../../addon/ijpost/ijpost.php:85 ../../addon/dwpost/dwpost.php:73
+#: ../../addon/dwpost/dwpost.php:85 ../../addon/ljpost/ljpost.php:70
+#: ../../addon/ljpost/ljpost.php:82 ../../addon/gitwiki/Mod_Gitwiki.php:166
+#: ../../addon/rainbowtag/rainbowtag.php:81 ../../addon/visage/visage.php:166
+#: ../../addon/nsabait/nsabait.php:157 ../../addon/rtof/rtof.php:81
+#: ../../addon/rtof/rtof.php:85 ../../addon/jappixmini/jappixmini.php:309
+#: ../../addon/jappixmini/jappixmini.php:313
+#: ../../addon/jappixmini/jappixmini.php:343
+#: ../../addon/jappixmini/jappixmini.php:351
+#: ../../addon/jappixmini/jappixmini.php:355
+#: ../../addon/jappixmini/jappixmini.php:359 ../../addon/nofed/nofed.php:72
+#: ../../addon/nofed/nofed.php:76 ../../addon/redred/redred.php:95
+#: ../../addon/redred/redred.php:99 ../../addon/libertree/libertree.php:69
+#: ../../addon/libertree/libertree.php:81
+#: ../../addon/flattrwidget/flattrwidget.php:120
+#: ../../addon/statusnet/statusnet.php:389
+#: ../../addon/statusnet/statusnet.php:411
+#: ../../addon/statusnet/statusnet.php:415
+#: ../../addon/statusnet/statusnet.php:424 ../../addon/twitter/twitter.php:243
+#: ../../addon/twitter/twitter.php:252 ../../addon/twitter/twitter.php:261
+#: ../../addon/smileybutton/smileybutton.php:211
+#: ../../addon/smileybutton/smileybutton.php:215
+#: ../../addon/authchoose/authchoose.php:67 ../../addon/xmpp/xmpp.php:53
+#: ../../addon/pumpio/pumpio.php:219 ../../addon/pumpio/pumpio.php:223
+#: ../../addon/pumpio/pumpio.php:227 ../../addon/pumpio/pumpio.php:231
+#: ../../include/dir_fns.php:143 ../../include/dir_fns.php:144
+#: ../../include/dir_fns.php:145
+msgid "Yes"
+msgstr "Sí"
+
+#: ../../Zotlabs/Module/Mitem.php:163 ../../Zotlabs/Module/Mitem.php:241
+msgid "Open link in new window"
+msgstr "Obre l'enllaç en una nova finestra"
+
+#: ../../Zotlabs/Module/Mitem.php:164 ../../Zotlabs/Module/Mitem.php:242
+msgid "Order in list"
+msgstr "Ordre de la llista"
+
+#: ../../Zotlabs/Module/Mitem.php:164 ../../Zotlabs/Module/Mitem.php:242
+msgid "Higher numbers will sink to bottom of listing"
+msgstr "Els números més alts al final de la llista"
+
+#: ../../Zotlabs/Module/Mitem.php:165
+msgid "Submit and finish"
+msgstr "Envia i acaba"
+
+#: ../../Zotlabs/Module/Mitem.php:166
+msgid "Submit and continue"
+msgstr "Envia i continua"
+
+#: ../../Zotlabs/Module/Mitem.php:174
+msgid "Menu:"
+msgstr "Menú:"
+
+#: ../../Zotlabs/Module/Mitem.php:177
+msgid "Link Target"
+msgstr "Destí de l'enllaç"
+
+#: ../../Zotlabs/Module/Mitem.php:180
+msgid "Edit menu"
+msgstr "Edita el menú"
+
+#: ../../Zotlabs/Module/Mitem.php:183
+msgid "Edit element"
+msgstr "Edita l'element"
+
+#: ../../Zotlabs/Module/Mitem.php:184
+msgid "Drop element"
+msgstr "Esborra l'element"
+
+#: ../../Zotlabs/Module/Mitem.php:185
+msgid "New element"
+msgstr "Element nou"
+
+#: ../../Zotlabs/Module/Mitem.php:186
+msgid "Edit this menu container"
+msgstr "Edita el contenidor de menú"
+
+#: ../../Zotlabs/Module/Mitem.php:187
+msgid "Add menu element"
+msgstr "Afegeix un element de menú"
+
+#: ../../Zotlabs/Module/Mitem.php:188
+msgid "Delete this menu item"
+msgstr "Esborra aquest article del menú"
+
+#: ../../Zotlabs/Module/Mitem.php:189
+msgid "Edit this menu item"
+msgstr "Edita aquest article del menú"
+
+#: ../../Zotlabs/Module/Mitem.php:206
+msgid "Menu item not found."
+msgstr "No s'ha trobat l'element de menú."
+
+#: ../../Zotlabs/Module/Mitem.php:219
+msgid "Menu item deleted."
+msgstr "S'ha esborrat l'element de menú."
+
+#: ../../Zotlabs/Module/Mitem.php:221
+msgid "Menu item could not be deleted."
+msgstr "No s'ha pogut esborrar l'element de menú."
+
+#: ../../Zotlabs/Module/Mitem.php:228
+msgid "Edit Menu Element"
+msgstr "Editar elements del menú"
+
+#: ../../Zotlabs/Module/Mitem.php:238
+msgid "Link text"
+msgstr "Text de l'enllaç"
+
+#: ../../Zotlabs/Module/Events.php:25
+msgid "Calendar entries imported."
+msgstr "S'han importat les entrades de calendari."
+
+#: ../../Zotlabs/Module/Events.php:27
+msgid "No calendar entries found."
+msgstr "No s'ha trobat cap entrada de calendari."
+
+#: ../../Zotlabs/Module/Events.php:110
+msgid "Event can not end before it has started."
+msgstr "L'esdeveniment no pot acabar abans de començar."
+
+#: ../../Zotlabs/Module/Events.php:112 ../../Zotlabs/Module/Events.php:121
+#: ../../Zotlabs/Module/Events.php:143
+msgid "Unable to generate preview."
+msgstr "No s'ha pogut generar la vista prèvia."
+
+#: ../../Zotlabs/Module/Events.php:119
+msgid "Event title and start time are required."
+msgstr "Cal indicar l'inici i el final de l'esdeveniment."
+
+#: ../../Zotlabs/Module/Events.php:141 ../../Zotlabs/Module/Events.php:265
+msgid "Event not found."
+msgstr "No s'ha trobat l'esdeveniment."
+
+#: ../../Zotlabs/Module/Events.php:260 ../../Zotlabs/Module/Tagger.php:73
+#: ../../Zotlabs/Module/Like.php:385 ../../include/conversation.php:119
+#: ../../include/text.php:2007 ../../include/event.php:1153
+msgid "event"
+msgstr "esdeveniment"
+
+#: ../../Zotlabs/Module/Events.php:460
+msgid "Edit event title"
+msgstr "Edita el títol de l'esdeveniment"
+
+#: ../../Zotlabs/Module/Events.php:460 ../../Zotlabs/Module/Events.php:465
+#: ../../Zotlabs/Module/Appman.php:140 ../../Zotlabs/Module/Appman.php:141
+#: ../../Zotlabs/Module/Profiles.php:748 ../../Zotlabs/Module/Profiles.php:752
+#: ../../include/datetime.php:205
+msgid "Required"
+msgstr "Obligatori"
+
+#: ../../Zotlabs/Module/Events.php:462
+msgid "Categories (comma-separated list)"
+msgstr "Categories (llista separada per comes)"
+
+#: ../../Zotlabs/Module/Events.php:463
+msgid "Edit Category"
+msgstr "Edita la categoria"
+
+#: ../../Zotlabs/Module/Events.php:463
+msgid "Category"
+msgstr "Categoria"
+
+#: ../../Zotlabs/Module/Events.php:466
+msgid "Edit start date and time"
+msgstr "Edita la data i hora d'inici"
+
+#: ../../Zotlabs/Module/Events.php:467 ../../Zotlabs/Module/Events.php:470
+msgid "Finish date and time are not known or not relevant"
+msgstr "L'hora d'acabar és desconeguda o irrellevant"
+
+#: ../../Zotlabs/Module/Events.php:469
+msgid "Edit finish date and time"
+msgstr "Edita la data i hora de finalització"
+
+#: ../../Zotlabs/Module/Events.php:469
+msgid "Finish date and time"
+msgstr "Data i hora de finalització"
+
+#: ../../Zotlabs/Module/Events.php:471 ../../Zotlabs/Module/Events.php:472
+msgid "Adjust for viewer timezone"
+msgstr "Ajusta a la zona horària de l'usuari/a"
+
+#: ../../Zotlabs/Module/Events.php:471
+msgid ""
+"Important for events that happen in a particular place. Not practical for "
+"global holidays."
+msgstr "És important per esdeveniments locals, però pels globals no és pràctic."
+
+#: ../../Zotlabs/Module/Events.php:473
+msgid "Edit Description"
+msgstr "Edita la descripció"
+
+#: ../../Zotlabs/Module/Events.php:475
+msgid "Edit Location"
+msgstr "Edita la ubicació"
+
+#: ../../Zotlabs/Module/Events.php:478 ../../Zotlabs/Module/Photos.php:1123
+#: ../../Zotlabs/Module/Webpages.php:247 ../../Zotlabs/Lib/ThreadItem.php:760
+#: ../../include/conversation.php:1330
+msgid "Preview"
+msgstr "Vista prèvia"
+
+#: ../../Zotlabs/Module/Events.php:479 ../../include/conversation.php:1402
+msgid "Permission settings"
+msgstr "Configuració de permisos"
+
+#: ../../Zotlabs/Module/Events.php:489
+msgid "Timezone:"
+msgstr "Zona horària:"
+
+#: ../../Zotlabs/Module/Events.php:494
+msgid "Advanced Options"
+msgstr "Opcions avançades"
+
+#: ../../Zotlabs/Module/Events.php:605 ../../Zotlabs/Module/Cal.php:266
+msgid "l, F j"
+msgstr "l, j \\d\\e F"
+
+#: ../../Zotlabs/Module/Events.php:633
+msgid "Edit event"
+msgstr "Edita l'esdeveniment"
+
+#: ../../Zotlabs/Module/Events.php:635
+msgid "Delete event"
+msgstr "Esborra l'esdeveniment"
+
+#: ../../Zotlabs/Module/Events.php:660 ../../Zotlabs/Module/Cal.php:315
+#: ../../include/text.php:1826
+msgid "Link to Source"
+msgstr "Enllaç a la font"
+
+#: ../../Zotlabs/Module/Events.php:669
+msgid "calendar"
+msgstr "calendari"
+
+#: ../../Zotlabs/Module/Events.php:688 ../../Zotlabs/Module/Cal.php:338
+msgid "Edit Event"
+msgstr "Edita l'esdeveniment"
+
+#: ../../Zotlabs/Module/Events.php:688 ../../Zotlabs/Module/Cal.php:338
+msgid "Create Event"
+msgstr "Crear un esdeveniment nou"
+
+#: ../../Zotlabs/Module/Events.php:691 ../../Zotlabs/Module/Cal.php:341
+#: ../../include/channel.php:1637
+msgid "Export"
+msgstr "Exporta"
+
+#: ../../Zotlabs/Module/Events.php:731
+msgid "Event removed"
+msgstr "S'ha eliminat l'esdeveniment"
+
+#: ../../Zotlabs/Module/Events.php:734
+msgid "Failed to remove event"
+msgstr "No s'ha pogut esborrar l'esdeveniment"
+
+#: ../../Zotlabs/Module/Appman.php:38 ../../Zotlabs/Module/Appman.php:55
+msgid "App installed."
+msgstr "S'ha instaŀlat l'aplicació."
+
+#: ../../Zotlabs/Module/Appman.php:48
+msgid "Malformed app."
+msgstr "L'aplicació conté errors."
+
+#: ../../Zotlabs/Module/Appman.php:129
+msgid "Embed code"
+msgstr "Codi embegut"
+
+#: ../../Zotlabs/Module/Appman.php:135
+msgid "Edit App"
+msgstr "Edita una aplicació"
+
+#: ../../Zotlabs/Module/Appman.php:135
+msgid "Create App"
+msgstr "Crea una aplicació"
+
+#: ../../Zotlabs/Module/Appman.php:140
+msgid "Name of app"
+msgstr "Nom de l'aplicació"
+
+#: ../../Zotlabs/Module/Appman.php:141
+msgid "Location (URL) of app"
+msgstr "Adreça URL de l'aplicació"
+
+#: ../../Zotlabs/Module/Appman.php:143
+msgid "Photo icon URL"
+msgstr "Adreça URL de la icona de l'aplicació"
+
+#: ../../Zotlabs/Module/Appman.php:143
+msgid "80 x 80 pixels - optional"
+msgstr "80x80 píxels (opcional)"
+
+#: ../../Zotlabs/Module/Appman.php:144
+msgid "Categories (optional, comma separated list)"
+msgstr "Categories (opcional, llista separada per comes)"
+
+#: ../../Zotlabs/Module/Appman.php:145
+msgid "Version ID"
+msgstr "Identificador o número de versió"
+
+#: ../../Zotlabs/Module/Appman.php:146
+msgid "Price of app"
+msgstr "Preu de l'aplicació"
+
+#: ../../Zotlabs/Module/Appman.php:147
+msgid "Location (URL) to purchase app"
+msgstr "Adreça URL de compra de l'aplicació"
+
+#: ../../Zotlabs/Module/Regmod.php:15
+msgid "Please login."
+msgstr "Inicia sessió."
+
+#: ../../Zotlabs/Module/Magic.php:72
+msgid "Hub not found."
+msgstr "No s'ha trobat el hub."
+
+#: ../../Zotlabs/Module/Subthread.php:111 ../../Zotlabs/Module/Tagger.php:69
+#: ../../Zotlabs/Module/Like.php:383
+#: ../../addon/redphotos/redphotohelper.php:71
+#: ../../addon/diaspora/Receiver.php:1518 ../../addon/pubcrawl/as.php:1359
+#: ../../include/conversation.php:116 ../../include/text.php:2004
+msgid "photo"
+msgstr "foto"
+
+#: ../../Zotlabs/Module/Subthread.php:111 ../../Zotlabs/Module/Like.php:383
+#: ../../addon/diaspora/Receiver.php:1518 ../../addon/pubcrawl/as.php:1359
+#: ../../include/conversation.php:144 ../../include/text.php:2010
+msgid "status"
+msgstr "estat"
+
+#: ../../Zotlabs/Module/Subthread.php:142
+#, php-format
+msgid "%1$s is following %2$s's %3$s"
+msgstr "%1$s segueix %3$s de %2$s"
+
+#: ../../Zotlabs/Module/Subthread.php:144
+#, php-format
+msgid "%1$s stopped following %2$s's %3$s"
+msgstr "%1$s ha deixat de seguir %3$s de %2$s"
+
+#: ../../Zotlabs/Module/Article_edit.php:44 ../../Zotlabs/Module/Cal.php:62
+#: ../../Zotlabs/Module/Chanview.php:96 ../../Zotlabs/Module/Page.php:75
+#: ../../Zotlabs/Module/Wall_upload.php:31 ../../Zotlabs/Module/Block.php:41
+#: ../../Zotlabs/Module/Card_edit.php:44
+msgid "Channel not found."
+msgstr "No s'ha trobat el canal."
+
+#: ../../Zotlabs/Module/Article_edit.php:101
+#: ../../Zotlabs/Module/Editblock.php:116 ../../Zotlabs/Module/Chat.php:207
+#: ../../Zotlabs/Module/Editwebpage.php:143 ../../Zotlabs/Module/Mail.php:288
+#: ../../Zotlabs/Module/Mail.php:430 ../../Zotlabs/Module/Card_edit.php:101
+#: ../../include/conversation.php:1278
+msgid "Insert web link"
+msgstr "Insereix un enllaç web"
+
+#: ../../Zotlabs/Module/Article_edit.php:117
+#: ../../Zotlabs/Module/Editblock.php:129
+#: ../../Zotlabs/Module/Card_edit.php:117 ../../include/conversation.php:1398
+msgid "Title (optional)"
+msgstr "Títol (opcional)"
+
+#: ../../Zotlabs/Module/Article_edit.php:128
+msgid "Edit Article"
+msgstr "Edita l'article"
+
+#: ../../Zotlabs/Module/Import_items.php:48 ../../Zotlabs/Module/Import.php:64
+msgid "Nothing to import."
+msgstr "No s'ha trobat res per importar."
+
+#: ../../Zotlabs/Module/Import_items.php:72 ../../Zotlabs/Module/Import.php:79
+#: ../../Zotlabs/Module/Import.php:95
+msgid "Unable to download data from old server"
+msgstr "No s'han pogut descarregar les dades del servidor antic"
+
+#: ../../Zotlabs/Module/Import_items.php:77
+#: ../../Zotlabs/Module/Import.php:102
+msgid "Imported file is empty."
+msgstr "El fitxer importat està buit."
+
+#: ../../Zotlabs/Module/Import_items.php:93
+#: ../../Zotlabs/Module/Import.php:121
+#, php-format
+msgid "Warning: Database versions differ by %1$d updates."
+msgstr "Atenció: Les versions de les bases de dades difereixen de %1$d actualitzacions."
+
+#: ../../Zotlabs/Module/Import_items.php:108
+msgid "Import completed"
+msgstr "S'ha completat la importació"
+
+#: ../../Zotlabs/Module/Import_items.php:125
+msgid "Import Items"
+msgstr "Importa articles"
+
+#: ../../Zotlabs/Module/Import_items.php:126
+msgid ""
+"Use this form to import existing posts and content from an export file."
+msgstr "Empra aquest formulari per importar entrades existents i contingut d'un arxiu d'exportació."
+
+#: ../../Zotlabs/Module/Import_items.php:127
+#: ../../Zotlabs/Module/Import.php:516
+msgid "File to Upload"
+msgstr "Fitxer per pujar"
+
+#: ../../Zotlabs/Module/New_channel.php:119
+#: ../../Zotlabs/Module/Manage.php:138
+#, php-format
+msgid "You have created %1$.0f of %2$.0f allowed channels."
+msgstr "Has creat %1$.0f canals dels %2$.0f totals permesos."
+
+#: ../../Zotlabs/Module/New_channel.php:132
+#: ../../Zotlabs/Module/Register.php:254
+msgid "Name or caption"
+msgstr "Nom o llegenda"
+
+#: ../../Zotlabs/Module/New_channel.php:132
+#: ../../Zotlabs/Module/Register.php:254
+msgid "Examples: \"Bob Jameson\", \"Lisa and her Horses\", \"Soccer\", \"Aviation Group\""
+msgstr "Exemples: \"Paula Gomila\", \"Manel i els seus cavalls\", \"Assemblea de veïnes del barri\", \"Filosofia\""
+
+#: ../../Zotlabs/Module/New_channel.php:134
+#: ../../Zotlabs/Module/Register.php:256
+msgid "Choose a short nickname"
+msgstr "Tria un àlies curt"
+
+#: ../../Zotlabs/Module/New_channel.php:134
+#: ../../Zotlabs/Module/Register.php:256
+#, php-format
+msgid ""
+"Your nickname will be used to create an easy to remember channel address "
+"e.g. nickname%s"
+msgstr "El teu àlies servirà per crear un nom fàcil per recordar l'adreça del canal. Per exemple, àlies%s"
+
+#: ../../Zotlabs/Module/New_channel.php:135
+#: ../../Zotlabs/Module/Register.php:257
+msgid "Channel role and privacy"
+msgstr "Rol i privacitat del canal"
+
+#: ../../Zotlabs/Module/New_channel.php:135
+#: ../../Zotlabs/Module/Register.php:257
+msgid "Select a channel role with your privacy requirements."
+msgstr "Tria un rol pel canal segons les teves necessitats de privacitat."
+
+#: ../../Zotlabs/Module/New_channel.php:135
+#: ../../Zotlabs/Module/Register.php:257
+msgid "Read more about roles"
+msgstr "Llegix més sobre els rols"
+
+#: ../../Zotlabs/Module/New_channel.php:138
+msgid "Create Channel"
+msgstr "Crea un canal"
+
+#: ../../Zotlabs/Module/New_channel.php:139
+msgid ""
+"A channel is your identity on this network. It can represent a person, a "
+"blog, or a forum to name a few. Channels can make connections with other "
+"channels to share information with highly detailed permissions."
+msgstr "El canal és la teva identitat en aquesta xarxa. Pot representar una persona, un bloc, o un fòrum,  entre molts altres. Els canals poden connectar-se amb altres canals per compartir informació amb permisos molt detallats."
+
+#: ../../Zotlabs/Module/New_channel.php:140
+msgid ""
+"or <a href=\"import\">import an existing channel</a> from another location."
+msgstr "o bé <a href=\"import\">importa un canal existent</a> des d'una altra ubicació."
+
+#: ../../Zotlabs/Module/New_channel.php:145
+msgid "Validate"
+msgstr "Valida-ho"
+
+#: ../../Zotlabs/Module/Removeme.php:35
+msgid ""
+"Channel removals are not allowed within 48 hours of changing the account "
+"password."
+msgstr "No es permet esborrar un canal fins a 48 hores més tard d'haver canviant la contrasenya del compte al qual pertany."
+
+#: ../../Zotlabs/Module/Removeme.php:60
+msgid "Remove This Channel"
+msgstr "Esborra aquest canal"
+
+#: ../../Zotlabs/Module/Removeme.php:61
+#: ../../Zotlabs/Module/Removeaccount.php:58
+#: ../../Zotlabs/Module/Changeaddr.php:78
+msgid "WARNING: "
 msgstr "ALERTA:"
 
-#: ../../Zotlabs/Storage/Browser.php:305
-msgid "Create new folder"
-msgstr "Crea una nova carpeta"
+#: ../../Zotlabs/Module/Removeme.php:61
+msgid "This channel will be completely removed from the network. "
+msgstr "Aquest canal serà esborrat de la xarxa completament."
 
-#: ../../Zotlabs/Storage/Browser.php:307
-msgid "Upload file"
-msgstr "Puja arxiu"
+#: ../../Zotlabs/Module/Removeme.php:61
+#: ../../Zotlabs/Module/Removeaccount.php:58
+msgid "This action is permanent and can not be undone!"
+msgstr "Aquesta acció és irreversible!"
 
-#: ../../Zotlabs/Web/WebServer.php:120 ../../Zotlabs/Module/Dreport.php:10
-#: ../../Zotlabs/Module/Dreport.php:49 ../../Zotlabs/Module/Group.php:72
-#: ../../Zotlabs/Module/Like.php:284 ../../Zotlabs/Module/Import_items.php:112
-#: ../../Zotlabs/Module/Profperm.php:28 ../../Zotlabs/Module/Subthread.php:62
-#: ../../include/items.php:385
-msgid "Permission denied"
-msgstr "Permís denegat"
+#: ../../Zotlabs/Module/Removeme.php:62
+#: ../../Zotlabs/Module/Removeaccount.php:59
+#: ../../Zotlabs/Module/Changeaddr.php:79
+msgid "Please enter your password for verification:"
+msgstr "Per seguretat, torna a introduir la contrasenya per a confirmar aquesta acció:"
 
-#: ../../Zotlabs/Web/WebServer.php:121 ../../Zotlabs/Web/Router.php:65
-#: ../../Zotlabs/Module/Achievements.php:34 ../../Zotlabs/Module/Blocks.php:73
-#: ../../Zotlabs/Module/Blocks.php:80 ../../Zotlabs/Module/Channel.php:105
-#: ../../Zotlabs/Module/Channel.php:226 ../../Zotlabs/Module/Channel.php:267
-#: ../../Zotlabs/Module/Chat.php:100 ../../Zotlabs/Module/Chat.php:105
-#: ../../Zotlabs/Module/Authtest.php:16 ../../Zotlabs/Module/Block.php:26
-#: ../../Zotlabs/Module/Block.php:76 ../../Zotlabs/Module/Bookmarks.php:61
-#: ../../Zotlabs/Module/Connedit.php:366 ../../Zotlabs/Module/Editblock.php:67
-#: ../../Zotlabs/Module/Common.php:39 ../../Zotlabs/Module/Connections.php:33
-#: ../../Zotlabs/Module/Cover_photo.php:277
-#: ../../Zotlabs/Module/Cover_photo.php:290
-#: ../../Zotlabs/Module/Editpost.php:17 ../../Zotlabs/Module/Events.php:265
-#: ../../Zotlabs/Module/Editlayout.php:67
-#: ../../Zotlabs/Module/Editlayout.php:90
-#: ../../Zotlabs/Module/Editwebpage.php:69
-#: ../../Zotlabs/Module/Editwebpage.php:90
-#: ../../Zotlabs/Module/Editwebpage.php:105
-#: ../../Zotlabs/Module/Editwebpage.php:127 ../../Zotlabs/Module/Group.php:13
-#: ../../Zotlabs/Module/Api.php:13 ../../Zotlabs/Module/Api.php:18
-#: ../../Zotlabs/Module/Filestorage.php:24
-#: ../../Zotlabs/Module/Filestorage.php:79
-#: ../../Zotlabs/Module/Filestorage.php:94
-#: ../../Zotlabs/Module/Filestorage.php:121 ../../Zotlabs/Module/Item.php:210
-#: ../../Zotlabs/Module/Item.php:218 ../../Zotlabs/Module/Item.php:1070
-#: ../../Zotlabs/Module/Layouts.php:71 ../../Zotlabs/Module/Layouts.php:78
-#: ../../Zotlabs/Module/Layouts.php:89 ../../Zotlabs/Module/Id.php:76
-#: ../../Zotlabs/Module/Like.php:181 ../../Zotlabs/Module/Invite.php:17
-#: ../../Zotlabs/Module/Invite.php:91 ../../Zotlabs/Module/Locs.php:87
-#: ../../Zotlabs/Module/Mail.php:129 ../../Zotlabs/Module/Manage.php:10
-#: ../../Zotlabs/Module/Menu.php:78 ../../Zotlabs/Module/Message.php:18
-#: ../../Zotlabs/Module/Mood.php:116 ../../Zotlabs/Module/Network.php:17
-#: ../../Zotlabs/Module/Mitem.php:115 ../../Zotlabs/Module/New_channel.php:77
-#: ../../Zotlabs/Module/New_channel.php:104
-#: ../../Zotlabs/Module/Notifications.php:70
-#: ../../Zotlabs/Module/Photos.php:75 ../../Zotlabs/Module/Page.php:35
-#: ../../Zotlabs/Module/Page.php:90 ../../Zotlabs/Module/Pdledit.php:26
-#: ../../Zotlabs/Module/Poke.php:137 ../../Zotlabs/Module/Profile.php:68
-#: ../../Zotlabs/Module/Profile.php:76 ../../Zotlabs/Module/Profiles.php:203
-#: ../../Zotlabs/Module/Profiles.php:601
-#: ../../Zotlabs/Module/Profile_photo.php:256
-#: ../../Zotlabs/Module/Profile_photo.php:269
-#: ../../Zotlabs/Module/Rate.php:113 ../../Zotlabs/Module/Appman.php:75
-#: ../../Zotlabs/Module/Register.php:77 ../../Zotlabs/Module/Regmod.php:21
-#: ../../Zotlabs/Module/Service_limits.php:11
-#: ../../Zotlabs/Module/Settings.php:572 ../../Zotlabs/Module/Setup.php:215
-#: ../../Zotlabs/Module/Sharedwithme.php:11
-#: ../../Zotlabs/Module/Sources.php:74 ../../Zotlabs/Module/Suggest.php:30
-#: ../../Zotlabs/Module/Thing.php:274 ../../Zotlabs/Module/Thing.php:294
-#: ../../Zotlabs/Module/Thing.php:331
-#: ../../Zotlabs/Module/Viewconnections.php:25
-#: ../../Zotlabs/Module/Viewconnections.php:30
-#: ../../Zotlabs/Module/Viewsrc.php:18 ../../Zotlabs/Module/Webpages.php:74
-#: ../../Zotlabs/Lib/Chatroom.php:137 ../../include/items.php:3438
-#: ../../include/attach.php:141 ../../include/attach.php:189
-#: ../../include/attach.php:252 ../../include/attach.php:266
-#: ../../include/attach.php:273 ../../include/attach.php:338
-#: ../../include/attach.php:352 ../../include/attach.php:359
-#: ../../include/attach.php:437 ../../include/attach.php:895
-#: ../../include/attach.php:966 ../../include/attach.php:1118
-#: ../../include/photos.php:27
-msgid "Permission denied."
-msgstr "Permís denegat."
+#: ../../Zotlabs/Module/Removeme.php:63
+msgid "Remove this channel and all its clones from the network"
+msgstr "Elimina aquest canal i els seus clons de la xarxa"
 
-#: ../../Zotlabs/Web/Router.php:146 ../../Zotlabs/Module/Help.php:94
-msgid "Not Found"
-msgstr "No s'ha pogut trobar la pàgina"
-
-#: ../../Zotlabs/Web/Router.php:149 ../../Zotlabs/Module/Block.php:79
-#: ../../Zotlabs/Module/Display.php:117 ../../Zotlabs/Module/Help.php:97
-#: ../../Zotlabs/Module/Page.php:93
-msgid "Page not found."
-msgstr "Pàgina no trobada."
-
-#: ../../Zotlabs/Zot/Auth.php:138
+#: ../../Zotlabs/Module/Removeme.php:63
 msgid ""
-"Remote authentication blocked. You are logged into this site locally. Please"
-" logout and retry."
-msgstr "Autenticació remota bloquejada. Ha iniciat sessió en aquest lloc a nivell local. Si us plau, tanca la sessió i torna-ho a intentar."
+"By default only the instance of the channel located on this hub will be "
+"removed from the network"
+msgstr "Per defecte, només es pot esborrar la instància del canal ubicada en aquest hub."
 
-#: ../../Zotlabs/Zot/Auth.php:246 ../../Zotlabs/Module/Openid.php:76
-#: ../../Zotlabs/Module/Openid.php:183
+#: ../../Zotlabs/Module/Removeme.php:64
+#: ../../Zotlabs/Module/Settings/Channel.php:592
+msgid "Remove Channel"
+msgstr "Elimina el canal"
+
+#: ../../Zotlabs/Module/Sharedwithme.php:104
+msgid "Files: shared with me"
+msgstr "Arxius: compartits amb mi"
+
+#: ../../Zotlabs/Module/Sharedwithme.php:106
+msgid "NEW"
+msgstr "NOU"
+
+#: ../../Zotlabs/Module/Sharedwithme.php:107
+#: ../../Zotlabs/Storage/Browser.php:285 ../../include/text.php:1434
+msgid "Size"
+msgstr "Mida"
+
+#: ../../Zotlabs/Module/Sharedwithme.php:108
+#: ../../Zotlabs/Storage/Browser.php:286
+msgid "Last Modified"
+msgstr "Última modificació"
+
+#: ../../Zotlabs/Module/Sharedwithme.php:109
+msgid "Remove all files"
+msgstr "Esborra tots els arxius"
+
+#: ../../Zotlabs/Module/Sharedwithme.php:110
+msgid "Remove this file"
+msgstr "Esborra l'arxiu"
+
+#: ../../Zotlabs/Module/Setup.php:170
+msgid "$Projectname Server - Setup"
+msgstr "Servidor de $Projectname - Instaŀlació"
+
+#: ../../Zotlabs/Module/Setup.php:174
+msgid "Could not connect to database."
+msgstr "No s'ha pogut establir una connexió amb la base de dades"
+
+#: ../../Zotlabs/Module/Setup.php:178
+msgid ""
+"Could not connect to specified site URL. Possible SSL certificate or DNS "
+"issue."
+msgstr "No s'ha pogut connectar amb la URL del lloc especificat. Comprova si hi ha un problema amb el certificat TLS o amb el registre DNS."
+
+#: ../../Zotlabs/Module/Setup.php:185
+msgid "Could not create table."
+msgstr "No s'ha pogut crear la taula."
+
+#: ../../Zotlabs/Module/Setup.php:191
+msgid "Your site database has been installed."
+msgstr "S'ha instaŀlat la base de dades del teu node."
+
+#: ../../Zotlabs/Module/Setup.php:197
+msgid ""
+"You may need to import the file \"install/schema_xxx.sql\" manually using a "
+"database client."
+msgstr "Podria ser necessari importar el fitxer \"install / schema_xxx.sql\" manualment utilitzant un client de base de dades."
+
+#: ../../Zotlabs/Module/Setup.php:198 ../../Zotlabs/Module/Setup.php:262
+#: ../../Zotlabs/Module/Setup.php:745
+msgid "Please see the file \"install/INSTALL.txt\"."
+msgstr "Consulta el fitxer \"install/INSTALL.txt\"."
+
+#: ../../Zotlabs/Module/Setup.php:259
+msgid "System check"
+msgstr "Comprovació del sistema"
+
+#: ../../Zotlabs/Module/Setup.php:264
+msgid "Check again"
+msgstr "Comprova de nou"
+
+#: ../../Zotlabs/Module/Setup.php:286
+msgid "Database connection"
+msgstr "Connexió amb la base de dades"
+
+#: ../../Zotlabs/Module/Setup.php:287
+msgid ""
+"In order to install $Projectname we need to know how to connect to your "
+"database."
+msgstr "Per tal d'instaŀlar $Projectname cal configurar la connexió amb la base de dades."
+
+#: ../../Zotlabs/Module/Setup.php:288
+msgid ""
+"Please contact your hosting provider or site administrator if you have "
+"questions about these settings."
+msgstr "Si tens dubtes sobre aquests paràmetres, posa't en contacte amb la proveïdora d'allotjament web o la persona que administradora del lloc."
+
+#: ../../Zotlabs/Module/Setup.php:289
+msgid ""
+"The database you specify below should already exist. If it does not, please "
+"create it before continuing."
+msgstr "La base de dades que especifiquis a continuació ja ha d'existir. Si no és així, crea-la abans de continuar."
+
+#: ../../Zotlabs/Module/Setup.php:293
+msgid "Database Server Name"
+msgstr "Nom del servidor de base de dades"
+
+#: ../../Zotlabs/Module/Setup.php:293
+msgid "Default is 127.0.0.1"
+msgstr "Per defecte és 127.0.0.1"
+
+#: ../../Zotlabs/Module/Setup.php:294
+msgid "Database Port"
+msgstr "Port per a la base de dades"
+
+#: ../../Zotlabs/Module/Setup.php:294
+msgid "Communication port number - use 0 for default"
+msgstr "Número del port. Posa 0 per fer servir el valor predeterminat"
+
+#: ../../Zotlabs/Module/Setup.php:295
+msgid "Database Login Name"
+msgstr "Nom d'usuari/a a la base de dades"
+
+#: ../../Zotlabs/Module/Setup.php:296
+msgid "Database Login Password"
+msgstr "Contrasenya d'usuari/a a la base de dades"
+
+#: ../../Zotlabs/Module/Setup.php:297
+msgid "Database Name"
+msgstr "Nom de la base de dades"
+
+#: ../../Zotlabs/Module/Setup.php:298
+msgid "Database Type"
+msgstr "Tipus de base de dades"
+
+#: ../../Zotlabs/Module/Setup.php:300 ../../Zotlabs/Module/Setup.php:341
+msgid "Site administrator email address"
+msgstr "Adreça de correu de l'administrador/a del lloc"
+
+#: ../../Zotlabs/Module/Setup.php:300 ../../Zotlabs/Module/Setup.php:341
+msgid ""
+"Your account email address must match this in order to use the web admin "
+"panel."
+msgstr "El teu compte de correu ha de coincidir-hi per poder emprar el panell web d'administració."
+
+#: ../../Zotlabs/Module/Setup.php:301 ../../Zotlabs/Module/Setup.php:343
+msgid "Website URL"
+msgstr "Adreça URL del lloc web"
+
+#: ../../Zotlabs/Module/Setup.php:301 ../../Zotlabs/Module/Setup.php:343
+msgid "Please use SSL (https) URL if available."
+msgstr "Si us plau, fes servir l'adreça amb TLS (https) si està disponible."
+
+#: ../../Zotlabs/Module/Setup.php:302 ../../Zotlabs/Module/Setup.php:345
+msgid "Please select a default timezone for your website"
+msgstr "Escull la zona horària per defecte del teu lloc web"
+
+#: ../../Zotlabs/Module/Setup.php:330
+msgid "Site settings"
+msgstr "Configuració del lloc"
+
+#: ../../Zotlabs/Module/Setup.php:384
+msgid "PHP version 5.5 or greater is required."
+msgstr "Es necessita una versió de PHP igual o superior a la 5.5."
+
+#: ../../Zotlabs/Module/Setup.php:385
+msgid "PHP version"
+msgstr "Versió del PHP"
+
+#: ../../Zotlabs/Module/Setup.php:401
+msgid "Could not find a command line version of PHP in the web server PATH."
+msgstr "No s'ha pogut trobar una versió de consola del PHP en la ruta del servidor web."
+
+#: ../../Zotlabs/Module/Setup.php:402
+msgid ""
+"If you don't have a command line version of PHP installed on server, you "
+"will not be able to run background polling via cron."
+msgstr "Si no tens una versió de línia de comandes de PHP instaŀlada al servidor, no es podran fer sondejos periòdics en segon pla, fent servir el cron."
+
+#: ../../Zotlabs/Module/Setup.php:406
+msgid "PHP executable path"
+msgstr "Ruta al binari de PHP"
+
+#: ../../Zotlabs/Module/Setup.php:406
+msgid ""
+"Enter full path to php executable. You can leave this blank to continue the "
+"installation."
+msgstr "Introdueix la ruta al binari de php. Pots deixar-ho en blanc i continuar l'instaŀlació."
+
+#: ../../Zotlabs/Module/Setup.php:411
+msgid "Command line PHP"
+msgstr "Línia de comandes de PHP"
+
+#: ../../Zotlabs/Module/Setup.php:421
+msgid ""
+"Unable to check command line PHP, as shell_exec() is disabled. This is "
+"required."
+msgstr "No s'ha pogut fer servir PHP per línia de comandes perquè shell_exec() està deshabilitat. Cal habilitar-ho."
+
+#: ../../Zotlabs/Module/Setup.php:424
+msgid ""
+"The command line version of PHP on your system does not have "
+"\"register_argc_argv\" enabled."
+msgstr "La versió de línia de comandes de PHP al teu sistema no té el \"register_argc_argv\" activat."
+
+#: ../../Zotlabs/Module/Setup.php:425
+msgid "This is required for message delivery to work."
+msgstr "Això és necessari per poder lliurar missatges."
+
+#: ../../Zotlabs/Module/Setup.php:428
+msgid "PHP register_argc_argv"
+msgstr "register_argc_argv de PHP"
+
+#: ../../Zotlabs/Module/Setup.php:446
 #, php-format
-msgid "Welcome %s. Remote authentication successful."
-msgstr "Benvingut %s. Autenticació remota reeixida."
+msgid ""
+"Your max allowed total upload size is set to %s. Maximum size of one file to"
+" upload is set to %s. You are allowed to upload up to %d files at once."
+msgstr "El límit màxim de pujada està establerta en %s. El límit de pujada per arxiu de pujada és de %s. Es permeten pujar %d arxius alhora."
 
-#: ../../Zotlabs/Module/Achievements.php:15 ../../Zotlabs/Module/Blocks.php:33
-#: ../../Zotlabs/Module/Connect.php:17 ../../Zotlabs/Module/Editblock.php:31
-#: ../../Zotlabs/Module/Editlayout.php:31
-#: ../../Zotlabs/Module/Editwebpage.php:33
-#: ../../Zotlabs/Module/Filestorage.php:60 ../../Zotlabs/Module/Hcard.php:12
-#: ../../Zotlabs/Module/Layouts.php:31 ../../Zotlabs/Module/Profile.php:20
-#: ../../Zotlabs/Module/Webpages.php:34 ../../include/channel.php:837
-msgid "Requested profile is not available."
-msgstr "El perfil demanat no està disponible."
+#: ../../Zotlabs/Module/Setup.php:451
+msgid "You can adjust these settings in the server php.ini file."
+msgstr "Pots modificar la configuració en l'arxiu de configuració php.ini del servidor."
+
+#: ../../Zotlabs/Module/Setup.php:453
+msgid "PHP upload limits"
+msgstr "Límits de pujada de PHP"
+
+#: ../../Zotlabs/Module/Setup.php:476
+msgid ""
+"Error: the \"openssl_pkey_new\" function on this system is not able to "
+"generate encryption keys"
+msgstr "Error: la funció \"openssl_pkey_new\" en aquest sistema no és capaç de generar claus de xifratge"
+
+#: ../../Zotlabs/Module/Setup.php:477
+msgid ""
+"If running under Windows, please see "
+"\"http://www.php.net/manual/en/openssl.installation.php\"."
+msgstr "Si estàs fent servir un sistema operatiu Windows, consulta \"http://www.php.net/manual/en/openssl.installation.php\"."
+
+#: ../../Zotlabs/Module/Setup.php:480
+msgid "Generate encryption keys"
+msgstr "Generar claus de xifratge"
+
+#: ../../Zotlabs/Module/Setup.php:497
+msgid "libCurl PHP module"
+msgstr "mòdul de PHP \"libCurl\""
+
+#: ../../Zotlabs/Module/Setup.php:498
+msgid "GD graphics PHP module"
+msgstr "mòdul de PHP \"GD graphics\""
+
+#: ../../Zotlabs/Module/Setup.php:499
+msgid "OpenSSL PHP module"
+msgstr "mòdul de PHP \"OpenSSL\""
+
+#: ../../Zotlabs/Module/Setup.php:500
+msgid "PDO database PHP module"
+msgstr "Mòdul PHP per la base de dades PDO"
+
+#: ../../Zotlabs/Module/Setup.php:501
+msgid "mb_string PHP module"
+msgstr "mòdul de PHP \"mb_string\""
+
+#: ../../Zotlabs/Module/Setup.php:502
+msgid "xml PHP module"
+msgstr "mòdul de PHP \"xml\""
+
+#: ../../Zotlabs/Module/Setup.php:503
+msgid "zip PHP module"
+msgstr "Mòdul PHP per als comprimits zip"
+
+#: ../../Zotlabs/Module/Setup.php:507 ../../Zotlabs/Module/Setup.php:509
+msgid "Apache mod_rewrite module"
+msgstr "mòdul d'Apache: \"mod_rewrite\""
+
+#: ../../Zotlabs/Module/Setup.php:507
+msgid ""
+"Error: Apache webserver mod-rewrite module is required but not installed."
+msgstr "Error: es necessita el mòdul \"mod-rewrite\" del servidor web Apache, però no està instal·lat."
+
+#: ../../Zotlabs/Module/Setup.php:513 ../../Zotlabs/Module/Setup.php:516
+msgid "exec"
+msgstr "exec"
+
+#: ../../Zotlabs/Module/Setup.php:513
+msgid ""
+"Error: exec is required but is either not installed or has been disabled in "
+"php.ini"
+msgstr "Error: no s'ha pogut fer servir exec. Cal instaŀlar-lo o bé habilitar-lo al php.ini"
+
+#: ../../Zotlabs/Module/Setup.php:519 ../../Zotlabs/Module/Setup.php:522
+msgid "shell_exec"
+msgstr "shell_exec"
+
+#: ../../Zotlabs/Module/Setup.php:519
+msgid ""
+"Error: shell_exec is required but is either not installed or has been "
+"disabled in php.ini"
+msgstr "Error: no s'ha pogut fer servir shell_exec. Cal instaŀlar-lo o bé habilitar-lo al php.ini"
+
+#: ../../Zotlabs/Module/Setup.php:527
+msgid "Error: libCURL PHP module required but not installed."
+msgstr "Error: es necessita el mòdul PHP \"libCURL\", però no està instal·lat."
+
+#: ../../Zotlabs/Module/Setup.php:531
+msgid ""
+"Error: GD graphics PHP module with JPEG support required but not installed."
+msgstr "Error: es necessita el mòdul PHP \"GD graphics\" amb support JPEG, però no està instal·lat."
+
+#: ../../Zotlabs/Module/Setup.php:535
+msgid "Error: openssl PHP module required but not installed."
+msgstr "Error: es necessita el mòdul PHP \"OpenSSL\", però no està instal·lat."
+
+#: ../../Zotlabs/Module/Setup.php:539
+msgid "Error: PDO database PHP module required but not installed."
+msgstr "Error: no s'ha trobat el mòdul PHP per a la base de dades PDO. Cal instaŀlar-lo."
+
+#: ../../Zotlabs/Module/Setup.php:543
+msgid "Error: mb_string PHP module required but not installed."
+msgstr "Error: es necessita el mòdul PHP \"mb_string\", però no està instal·lat."
+
+#: ../../Zotlabs/Module/Setup.php:547
+msgid "Error: xml PHP module required for DAV but not installed."
+msgstr "Error: es necessita el mòdul PHP \"xml\" per al DAV, però no està instal·lat."
+
+#: ../../Zotlabs/Module/Setup.php:551
+msgid "Error: zip PHP module required but not installed."
+msgstr "Error: no s'ha trobat el mòdul PHP per als fitxers zip. Cal instaŀlar-lo."
+
+#: ../../Zotlabs/Module/Setup.php:569
+msgid ""
+"The web installer needs to be able to create a file called \".htconfig.php\""
+" in the top folder of your web server and it is unable to do so."
+msgstr "L'instaŀlador ha de poder crear i modificar un fitxer anomenat «.htconfig.php» a la carpeta arrel del servidor, però sembla que no ho pot fer."
+
+#: ../../Zotlabs/Module/Setup.php:570
+msgid ""
+"This is most often a permission setting, as the web server may not be able "
+"to write files in your folder - even if you can."
+msgstr "Això sol ser un problema de permisos. Per molt que el teu usuari pugui modificar-lo, és el del servidor web qui necessita els permisos de modificació."
+
+#: ../../Zotlabs/Module/Setup.php:571
+msgid ""
+"At the end of this procedure, we will give you a text to save in a file "
+"named .htconfig.php in your Red top folder."
+msgstr "Aquest procés generarà un text que hauràs de desar en un arxiu. Ha de quedar en la carpeta arrel del servidor i, amb el nom «.htconfig.php»."
+
+#: ../../Zotlabs/Module/Setup.php:572
+msgid ""
+"You can alternatively skip this procedure and perform a manual installation."
+" Please see the file \"install/INSTALL.txt\" for instructions."
+msgstr "No obstant això, aquest procés és opcional. Per a fer una instaŀlació manual consulta les instruccions a «install/INSTALL.txt\"."
+
+#: ../../Zotlabs/Module/Setup.php:575
+msgid ".htconfig.php is writable"
+msgstr "L'arxiu «.htconfig.php» es pot modificar"
+
+#: ../../Zotlabs/Module/Setup.php:589
+msgid ""
+"This software uses the Smarty3 template engine to render its web views. "
+"Smarty3 compiles templates to PHP to speed up rendering."
+msgstr "Aquest software fa servir el motor de plantilles Smarty3 per a renderitzar les vistes web. Smarty3 compila plantilles a PHP per a agilitzar-ne el renderitzat."
+
+#: ../../Zotlabs/Module/Setup.php:590
+#, php-format
+msgid ""
+"In order to store these compiled templates, the web server needs to have "
+"write access to the directory %s under the top level web folder."
+msgstr "Per tal de guardar aquestes plantilles compilades, el servidor web necessita tenir permís d'escriptura en el directori %s sota la carpeta principal."
+
+#: ../../Zotlabs/Module/Setup.php:591 ../../Zotlabs/Module/Setup.php:612
+msgid ""
+"Please ensure that the user that your web server runs as (e.g. www-data) has"
+" write access to this folder."
+msgstr "Comprova que l'usuari que executa el servidor (www-data en Apache) té permisos d'escriptura en aquesta carpeta."
+
+#: ../../Zotlabs/Module/Setup.php:592
+#, php-format
+msgid ""
+"Note: as a security measure, you should give the web server write access to "
+"%s only--not the template files (.tpl) that it contains."
+msgstr "Nota: com a mesura de seguretat, l'usuari del servidor web ha de tenir accés d'escriptura només a %s, i no a les plantilles (.tpl) que conté."
+
+#: ../../Zotlabs/Module/Setup.php:595
+#, php-format
+msgid "%s is writable"
+msgstr "Es pot escriure a %s"
+
+#: ../../Zotlabs/Module/Setup.php:611
+msgid ""
+"This software uses the store directory to save uploaded files. The web "
+"server needs to have write access to the store directory under the top level"
+" web folder"
+msgstr "Aquest software fa servir la carpeta \"store\" per a desar els arxius pujats. El servidor web necessita permís d'escriptura per a accedir-hi. Es troba a la carpeta arrel del servidor web."
+
+#: ../../Zotlabs/Module/Setup.php:615
+msgid "store is writable"
+msgstr "Es pot escriure al magatzem (store)"
+
+#: ../../Zotlabs/Module/Setup.php:647
+msgid ""
+"SSL certificate cannot be validated. Fix certificate or disable https access"
+" to this site."
+msgstr "No s'ha pogut validar el certificat TLS.  Arregla-ho o deshabilita l'accés https a aquest lloc."
+
+#: ../../Zotlabs/Module/Setup.php:648
+msgid ""
+"If you have https access to your website or allow connections to TCP port "
+"443 (the https: port), you MUST use a browser-valid certificate. You MUST "
+"NOT use self-signed certificates!"
+msgstr "Si tens accés per https al teu lloc web o permets connexions pel port TCP 443 (port https), has d'emprar un certificat VÀLID. NO es poden emprar certificats AUTO-SIGNATS!"
+
+#: ../../Zotlabs/Module/Setup.php:649
+msgid ""
+"This restriction is incorporated because public posts from you may for "
+"example contain references to images on your own hub."
+msgstr "El motiu d'aquesta restricció és que les teves entrades públiques poden contenir referències a imatges del teu propi node."
+
+#: ../../Zotlabs/Module/Setup.php:650
+msgid ""
+"If your certificate is not recognized, members of other sites (who may "
+"themselves have valid certificates) will get a warning message on their own "
+"site complaining about security issues."
+msgstr "Si el teu certificat no és vàlid, llavors el membres d'altres hubs, encara que tinguin certificats vàlids, rebran una advertència de seguretat en carregar contingut teu."
+
+#: ../../Zotlabs/Module/Setup.php:651
+msgid ""
+"This can cause usability issues elsewhere (not just on your own site) so we "
+"must insist on this requirement."
+msgstr "Per tant, com que perjudica la usabilitat més enllà del teu lloc, la restricció de tenir un certificat vàlid és molt important."
+
+#: ../../Zotlabs/Module/Setup.php:652
+msgid ""
+"Providers are available that issue free certificates which are browser-"
+"valid."
+msgstr "Hi ha autoritats de certificació reconegudes que ofereixen certificats gratuïts."
+
+#: ../../Zotlabs/Module/Setup.php:654
+msgid ""
+"If you are confident that the certificate is valid and signed by a trusted "
+"authority, check to see if you have failed to install an intermediate cert. "
+"These are not normally required by browsers, but are required for server-to-"
+"server communications."
+msgstr "Si no tens cap dubte que el certificat és vàlid i signat per una autoritat de confiança, comprova si has instaŀlat malament un certificat intermedi. Tot i que els navegadors no en demanen, són necessaris per les connexions entre servidors."
+
+#: ../../Zotlabs/Module/Setup.php:656
+msgid "SSL certificate validation"
+msgstr "Validació del certificat TLS"
+
+#: ../../Zotlabs/Module/Setup.php:662
+msgid ""
+"Url rewrite in .htaccess is not working. Check your server "
+"configuration.Test: "
+msgstr "No es poden reescriure les URL a «.htaccess». Comprova la configuració del servidor:"
+
+#: ../../Zotlabs/Module/Setup.php:665
+msgid "Url rewrite is working"
+msgstr "Es poden reescriure les URL a «.htaccess»"
+
+#: ../../Zotlabs/Module/Setup.php:679
+msgid ""
+"The database configuration file \".htconfig.php\" could not be written. "
+"Please use the enclosed text to create a configuration file in your web "
+"server root."
+msgstr "L'arxiu de configuracio de la base de dades «.htconfig.php» no s'ha pogut modificar. L'hauràs de modificar manualment amb el text de la caixa de text, i desar-lo a l'arrel del servidor web."
+
+#: ../../Zotlabs/Module/Setup.php:703
+#: ../../addon/rendezvous/rendezvous.php:401
+msgid "Errors encountered creating database tables."
+msgstr "S'han produït errors en crear taules a la base de dades."
+
+#: ../../Zotlabs/Module/Setup.php:743
+msgid "<h1>What next?</h1>"
+msgstr "<h1>I ara què</h1>"
+
+#: ../../Zotlabs/Module/Setup.php:744
+msgid ""
+"IMPORTANT: You will need to [manually] setup a scheduled task for the "
+"poller."
+msgstr "IMPORTANT! Cal que configuris manualment una execució periòdica de l'enquestador (poller en anglès)."
+
+#: ../../Zotlabs/Module/Connect.php:61 ../../Zotlabs/Module/Connect.php:109
+msgid "Continue"
+msgstr "Continua"
+
+#: ../../Zotlabs/Module/Connect.php:90
+msgid "Premium Channel Setup"
+msgstr "Configuració dels canals prèmium"
+
+#: ../../Zotlabs/Module/Connect.php:92
+msgid "Enable premium channel connection restrictions"
+msgstr "Activa l'opció de restringir les connexions dels canals prèmium"
+
+#: ../../Zotlabs/Module/Connect.php:93
+msgid ""
+"Please enter your restrictions or conditions, such as paypal receipt, usage "
+"guidelines, etc."
+msgstr "Si us plau, introdueix les restriccions o condicions, com ara el rebut de PayPal, les pautes d'ús, etc."
+
+#: ../../Zotlabs/Module/Connect.php:95 ../../Zotlabs/Module/Connect.php:115
+msgid ""
+"This channel may require additional steps or acknowledgement of the "
+"following conditions prior to connecting:"
+msgstr "Aquest canal pot requerir passos addicionals o reconeixement de les següents condicions abans de connectar:"
+
+#: ../../Zotlabs/Module/Connect.php:96
+msgid ""
+"Potential connections will then see the following text before proceeding:"
+msgstr "Les possibles connexions veuran el següent text abans de continuar:"
+
+#: ../../Zotlabs/Module/Connect.php:97 ../../Zotlabs/Module/Connect.php:118
+msgid ""
+"By continuing, I certify that I have complied with any instructions provided"
+" on this page."
+msgstr "En continuar, certifico que he complert amb totes les instruccions proporcionades en aquesta pàgina."
+
+#: ../../Zotlabs/Module/Connect.php:106
+msgid "(No specific instructions have been provided by the channel owner.)"
+msgstr "(No s'han proporcionat instruccions específiques per la persona propietària del canal.)"
+
+#: ../../Zotlabs/Module/Connect.php:114
+msgid "Restricted or Premium Channel"
+msgstr "Canal restringit o prèmium"
+
+#: ../../Zotlabs/Module/Admin/Queue.php:35
+msgid "Queue Statistics"
+msgstr "Estadístiques de la cua"
+
+#: ../../Zotlabs/Module/Admin/Queue.php:36
+msgid "Total Entries"
+msgstr "Total d'entrades"
+
+#: ../../Zotlabs/Module/Admin/Queue.php:37
+msgid "Priority"
+msgstr "Prioritat"
+
+#: ../../Zotlabs/Module/Admin/Queue.php:38
+msgid "Destination URL"
+msgstr "Adreça URL de Destí"
+
+#: ../../Zotlabs/Module/Admin/Queue.php:39
+msgid "Mark hub permanently offline"
+msgstr "Marca el node com a permanentment fora de línia"
+
+#: ../../Zotlabs/Module/Admin/Queue.php:40
+msgid "Empty queue for this hub"
+msgstr "Buida la cua per aquest node"
+
+#: ../../Zotlabs/Module/Admin/Queue.php:41
+msgid "Last known contact"
+msgstr "Últim contacte conegut"
+
+#: ../../Zotlabs/Module/Admin/Features.php:55
+#: ../../Zotlabs/Module/Admin/Features.php:56
+#: ../../Zotlabs/Module/Settings/Features.php:38
+msgid "Off"
+msgstr "No"
+
+#: ../../Zotlabs/Module/Admin/Features.php:55
+#: ../../Zotlabs/Module/Admin/Features.php:56
+#: ../../Zotlabs/Module/Settings/Features.php:38
+msgid "On"
+msgstr "Sí"
+
+#: ../../Zotlabs/Module/Admin/Features.php:56
+#, php-format
+msgid "Lock feature %s"
+msgstr "Bloqueja l'opció «%s»"
+
+#: ../../Zotlabs/Module/Admin/Features.php:64
+msgid "Manage Additional Features"
+msgstr "Gestiona les funcionalitats addicionals"
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:19
+msgid "Update has been marked successful"
+msgstr "S'ha marcat l'actualització com a exitosa"
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:31
+#, php-format
+msgid "Executing %s failed. Check system logs."
+msgstr "Ha fallat l'execució de %s. Comprova el registre del sistema."
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:34
+#, php-format
+msgid "Update %s was successfully applied."
+msgstr "S'ha aplicat amb èxit l'actualització %s."
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:38
+#, php-format
+msgid "Update %s did not return a status. Unknown if it succeeded."
+msgstr "Es desconeix si l'actualització %s s'ha aplicat amb èxit, ja que no ha retornat cap resultat."
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:41
+#, php-format
+msgid "Update function %s could not be found."
+msgstr "No s'ha pogut trobar la funció d'actualització %s."
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:59
+msgid "Failed Updates"
+msgstr "Actualitzacions fallides"
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:61
+msgid "Mark success (if update was manually applied)"
+msgstr "Marca com a exitosa. Fes-ho només si l'actualització s'ha aplicat de forma manual i saps del cert que ha estat així."
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:62
+msgid "Attempt to execute this update step automatically"
+msgstr "Prova a fer automàticament aquesta actualització"
+
+#: ../../Zotlabs/Module/Admin/Dbsync.php:67
+msgid "No failed updates."
+msgstr "No hi ha actualitzacions fallides."
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:259
+#: ../../Zotlabs/Module/Admin/Themes.php:72 ../../Zotlabs/Module/Thing.php:89
+#: ../../Zotlabs/Module/Viewsrc.php:25 ../../Zotlabs/Module/Display.php:46
+#: ../../Zotlabs/Module/Display.php:410
+#: ../../Zotlabs/Module/Filestorage.php:24 ../../Zotlabs/Module/Admin.php:62
+#: ../../include/items.php:3569
+msgid "Item not found."
+msgstr "No s'ha trobat l'element."
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:289
+#, php-format
+msgid "Plugin %s disabled."
+msgstr "S'ha desactivat l'extensió %s."
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:294
+#, php-format
+msgid "Plugin %s enabled."
+msgstr "S'ha activat l'extensió %s."
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:310
+#: ../../Zotlabs/Module/Admin/Themes.php:95
+msgid "Disable"
+msgstr "Desactiva"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:313
+#: ../../Zotlabs/Module/Admin/Themes.php:97
+msgid "Enable"
+msgstr "Activa"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:341
+#: ../../Zotlabs/Module/Admin/Plugins.php:436
+#: ../../Zotlabs/Module/Admin/Accounts.php:165
+#: ../../Zotlabs/Module/Admin/Logs.php:82
+#: ../../Zotlabs/Module/Admin/Channels.php:145
+#: ../../Zotlabs/Module/Admin/Themes.php:122
+#: ../../Zotlabs/Module/Admin/Themes.php:156
+#: ../../Zotlabs/Module/Admin/Site.php:287
+#: ../../Zotlabs/Module/Admin/Security.php:86
+#: ../../Zotlabs/Module/Admin.php:136
+msgid "Administration"
+msgstr "Administració"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:342
+#: ../../Zotlabs/Module/Admin/Plugins.php:437
+#: ../../Zotlabs/Widget/Admin.php:27
+msgid "Plugins"
+msgstr "Extensions"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:343
+#: ../../Zotlabs/Module/Admin/Themes.php:124
+msgid "Toggle"
+msgstr "Commuta'n l'estat"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:344
+#: ../../Zotlabs/Module/Admin/Themes.php:125 ../../Zotlabs/Lib/Apps.php:242
+#: ../../Zotlabs/Widget/Newmember.php:55
+#: ../../Zotlabs/Widget/Settings_menu.php:133 ../../include/nav.php:105
+#: ../../include/nav.php:192
+msgid "Settings"
+msgstr "Configuració"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:351
+#: ../../Zotlabs/Module/Admin/Themes.php:134
+msgid "Author: "
+msgstr "Autor/a:"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:352
+#: ../../Zotlabs/Module/Admin/Themes.php:135
+msgid "Maintainer: "
+msgstr "Persona mantenidora:"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:353
+msgid "Minimum project version: "
+msgstr "Versió mínima del projecte:"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:354
+msgid "Maximum project version: "
+msgstr "Versió màxima del projecte:"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:355
+msgid "Minimum PHP version: "
+msgstr "Versió mínima de PHP:"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:356
+msgid "Compatible Server Roles: "
+msgstr "Rols de servidor compatibles"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:357
+msgid "Requires: "
+msgstr "Demana:"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:358
+#: ../../Zotlabs/Module/Admin/Plugins.php:442
+msgid "Disabled - version incompatibility"
+msgstr "Desactivada - versions incompatibles"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:411
+msgid "Enter the public git repository URL of the plugin repo."
+msgstr "Introdueix la URL del repositori git d'extensions. Ha de ser un repositori públic."
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:412
+msgid "Plugin repo git URL"
+msgstr "Adreça URL del repositori d'extensions."
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:413
+msgid "Custom repo name"
+msgstr "Nom personalitzat pel repositori"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:413
+msgid "(optional)"
+msgstr "(opcional)"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:414
+msgid "Download Plugin Repo"
+msgstr "Descarrega el repositori"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:421
+msgid "Install new repo"
+msgstr "Instal·la un nou repositori"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:422 ../../Zotlabs/Lib/Apps.php:393
+msgid "Install"
+msgstr "Instal·la"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:445
+msgid "Manage Repos"
+msgstr "Gestiona els repositoris"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:446
+msgid "Installed Plugin Repositories"
+msgstr "Repositoris instaŀlats"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:447
+msgid "Install a New Plugin Repository"
+msgstr "Instal·la un nou repositori"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:454
+msgid "Switch branch"
+msgstr "Canvia de branca"
+
+#: ../../Zotlabs/Module/Admin/Plugins.php:455
+#: ../../Zotlabs/Module/Photos.php:1020 ../../Zotlabs/Module/Tagrm.php:137
+#: ../../addon/superblock/superblock.php:116
+msgid "Remove"
+msgstr "Esborra"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:37
+#, php-format
+msgid "%s account blocked/unblocked"
+msgid_plural "%s account blocked/unblocked"
+msgstr[0] "S'ha [des]bloquejat %s compte"
+msgstr[1] "S'han [des]bloquejat %s comptes"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:44
+#, php-format
+msgid "%s account deleted"
+msgid_plural "%s accounts deleted"
+msgstr[0] "S'ha esborrat el compte %s"
+msgstr[1] "S'han esborrat %s comptes"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:80
+msgid "Account not found"
+msgstr "No s'ha trobat el compte"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:91 ../../include/channel.php:2462
+#, php-format
+msgid "Account '%s' deleted"
+msgstr "S'ha esborrat el compte '%s'"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:99
+#, php-format
+msgid "Account '%s' blocked"
+msgstr "S'ha bloquejat el compte '%s'"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:107
+#, php-format
+msgid "Account '%s' unblocked"
+msgstr "S'ha desbloquejat el compte '%s'"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:166
+#: ../../Zotlabs/Module/Admin/Accounts.php:179
+#: ../../Zotlabs/Module/Admin.php:96 ../../Zotlabs/Widget/Admin.php:23
+msgid "Accounts"
+msgstr "Comptes"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:168
+#: ../../Zotlabs/Module/Admin/Channels.php:148
+msgid "select all"
+msgstr "sel·leciona-ho tot"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:169
+msgid "Registrations waiting for confirm"
+msgstr "Inscripcions esperant confirmació"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:170
+msgid "Request date"
+msgstr "Data de la petició"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:171
+msgid "No registrations."
+msgstr "Sense inscripcions."
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:172
+#: ../../Zotlabs/Module/Connections.php:287 ../../include/conversation.php:732
+msgid "Approve"
+msgstr "Aprova"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:173
+msgid "Deny"
+msgstr "Denega"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:175
+#: ../../Zotlabs/Module/Connedit.php:622
+msgid "Block"
+msgstr "Bloqueja"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:176
+#: ../../Zotlabs/Module/Connedit.php:622
+msgid "Unblock"
+msgstr "Desbloqueja"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:181
+msgid "ID"
+msgstr "Identificador"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:183 ../../include/group.php:284
+msgid "All Channels"
+msgstr "Tots els canals"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:184
+msgid "Register date"
+msgstr "Data d'inscripció"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:185
+msgid "Last login"
+msgstr "Últim inici de sessió"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:186
+msgid "Expires"
+msgstr "Caduca"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:187
+msgid "Service Class"
+msgstr "Classe de servei"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:189
+msgid ""
+"Selected accounts will be deleted!\\n\\nEverything these accounts had posted"
+" on this site will be permanently deleted!\\n\\nAre you sure?"
+msgstr "S'esborraran tots els comptes seleccionats!\\n\\nTot el que hagin publicat en aquest lloc també serà esborrat permanentment!\\n\\nN'estàs segur/a de continuar?"
+
+#: ../../Zotlabs/Module/Admin/Accounts.php:190
+msgid ""
+"The account {0} will be deleted!\\n\\nEverything this account has posted on "
+"this site will be permanently deleted!\\n\\nAre you sure?"
+msgstr "El compte {0} serà eliminat!\\n\\nTot el que hagi publicat en aquest lloc serà esborrat permanentment!\\n\\nN'estàs segur/a?"
+
+#: ../../Zotlabs/Module/Admin/Logs.php:28
+msgid "Log settings updated."
+msgstr "S'ha actualitzat la configuració del registre."
+
+#: ../../Zotlabs/Module/Admin/Logs.php:83 ../../Zotlabs/Widget/Admin.php:48
+#: ../../Zotlabs/Widget/Admin.php:58
+msgid "Logs"
+msgstr "Registre"
+
+#: ../../Zotlabs/Module/Admin/Logs.php:85
+msgid "Clear"
+msgstr "Neteja"
+
+#: ../../Zotlabs/Module/Admin/Logs.php:91
+msgid "Debugging"
+msgstr "Depuració"
+
+#: ../../Zotlabs/Module/Admin/Logs.php:92
+msgid "Log file"
+msgstr "Arxiu de registre"
+
+#: ../../Zotlabs/Module/Admin/Logs.php:92
+msgid ""
+"Must be writable by web server. Relative to your top-level webserver "
+"directory."
+msgstr "El servidor web l'ha de poder modificar. Escriu la ruta relativa respecte a la carpeta arrel del servidor web."
+
+#: ../../Zotlabs/Module/Admin/Logs.php:93
+msgid "Log level"
+msgstr "Nivell de registre"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:31
+#, php-format
+msgid "%s channel censored/uncensored"
+msgid_plural "%s channels censored/uncensored"
+msgstr[0] "%s canal censurat/no censurat"
+msgstr[1] "S'han [des]censurat %s canals"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:40
+#, php-format
+msgid "%s channel code allowed/disallowed"
+msgid_plural "%s channels code allowed/disallowed"
+msgstr[0] "%s codi permes/no permes al canal"
+msgstr[1] "S'han [des]activat %s codis de canal"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:46
+#, php-format
+msgid "%s channel deleted"
+msgid_plural "%s channels deleted"
+msgstr[0] "%s canal esborrat"
+msgstr[1] "S'han esborrat %s canals"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:65
+msgid "Channel not found"
+msgstr "No s'ha trobat el canal"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:75
+#, php-format
+msgid "Channel '%s' deleted"
+msgstr "S'ha esborrat el canal «%s»"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:87
+#, php-format
+msgid "Channel '%s' censored"
+msgstr "S'ha censurat el canal «%s»"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:87
+#, php-format
+msgid "Channel '%s' uncensored"
+msgstr "S'ha descensurat el canal «%s»"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:98
+#, php-format
+msgid "Channel '%s' code allowed"
+msgstr "S'ha activat un codi pel canal «%s»"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:98
+#, php-format
+msgid "Channel '%s' code disallowed"
+msgstr "S'ha desactivat un codi pel canal «%s»"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:146
+#: ../../Zotlabs/Module/Admin.php:110 ../../Zotlabs/Widget/Admin.php:24
+msgid "Channels"
+msgstr "Canals"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:150
+msgid "Censor"
+msgstr "Censura"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:151
+msgid "Uncensor"
+msgstr "Descensura"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:152
+msgid "Allow Code"
+msgstr "Activa el codi"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:153
+msgid "Disallow Code"
+msgstr "Desactiva el codi"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:154
+#: ../../include/conversation.php:1808 ../../include/nav.php:378
+msgid "Channel"
+msgstr "Canal"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:158
+msgid "UID"
+msgstr "Identificador"
+
+#: ../../Zotlabs/Module/Admin/Channels.php:162
+msgid ""
+"Selected channels will be deleted!\\n\\nEverything that was posted in these "
+"channels on this site will be permanently deleted!\\n\\nAre you sure?"
+msgstr "Els canals seleccionats estan a punt de ser esborrats\\n\\nTotes les seves publicacions en aquest lloc s'eliminaran de forma permanent!\\n\\nN'estàs segur/a? "
+
+#: ../../Zotlabs/Module/Admin/Channels.php:163
+msgid ""
+"The channel {0} will be deleted!\\n\\nEverything that was posted in this "
+"channel on this site will be permanently deleted!\\n\\nAre you sure?"
+msgstr "El canal {0} està a punt de ser esborrat!\\n\\nTotes les seves publicacions d'aquest en aquest lloc s'eliminaran de forma permanent!\\n\\nN'estàs segur/a?"
+
+#: ../../Zotlabs/Module/Admin/Themes.php:26
+msgid "Theme settings updated."
+msgstr "S'ha actualitzat la configuració de tema."
+
+#: ../../Zotlabs/Module/Admin/Themes.php:61
+msgid "No themes found."
+msgstr "No s'ha trobat cap tema."
+
+#: ../../Zotlabs/Module/Admin/Themes.php:116
+msgid "Screenshot"
+msgstr "Captura de pantalla"
+
+#: ../../Zotlabs/Module/Admin/Themes.php:123
+#: ../../Zotlabs/Module/Admin/Themes.php:157 ../../Zotlabs/Widget/Admin.php:28
+msgid "Themes"
+msgstr "Temes"
+
+#: ../../Zotlabs/Module/Admin/Themes.php:162
+msgid "[Experimental]"
+msgstr "[Experimental]"
+
+#: ../../Zotlabs/Module/Admin/Themes.php:163
+msgid "[Unsupported]"
+msgstr "[Incompatible]"
+
+#: ../../Zotlabs/Module/Admin/Site.php:158
+msgid "Site settings updated."
+msgstr "S'ha actualitzat la configuració del lloc"
+
+#: ../../Zotlabs/Module/Admin/Site.php:184
+#: ../../view/theme/redbasic_c/php/config.php:15
+#: ../../view/theme/redbasic/php/config.php:15 ../../include/text.php:3082
+msgid "Default"
+msgstr "Predeterminat"
+
+#: ../../Zotlabs/Module/Admin/Site.php:195
+#: ../../Zotlabs/Module/Settings/Display.php:130
+#, php-format
+msgid "%s - (Incompatible)"
+msgstr "%s - (Incompatible)"
+
+#: ../../Zotlabs/Module/Admin/Site.php:202
+msgid "mobile"
+msgstr "mòbil"
+
+#: ../../Zotlabs/Module/Admin/Site.php:204
+msgid "experimental"
+msgstr "experimental"
+
+#: ../../Zotlabs/Module/Admin/Site.php:206
+msgid "unsupported"
+msgstr "incompatible"
+
+#: ../../Zotlabs/Module/Admin/Site.php:253
+msgid "Yes - with approval"
+msgstr "Sí - amb aprovació"
+
+#: ../../Zotlabs/Module/Admin/Site.php:259
+msgid "My site is not a public server"
+msgstr "El meu node no es un servidor públic"
+
+#: ../../Zotlabs/Module/Admin/Site.php:260
+msgid "My site has paid access only"
+msgstr "El meu node només ofereix accés de pagament"
+
+#: ../../Zotlabs/Module/Admin/Site.php:261
+msgid "My site has free access only"
+msgstr "El meu node només ofereix accés gratuït"
+
+#: ../../Zotlabs/Module/Admin/Site.php:262
+msgid "My site offers free accounts with optional paid upgrades"
+msgstr "El meu node ofereix comptes gratuïts i millores de pagament"
+
+#: ../../Zotlabs/Module/Admin/Site.php:274
+msgid "Beginner/Basic"
+msgstr "Principiant/bàsica"
+
+#: ../../Zotlabs/Module/Admin/Site.php:275
+msgid "Novice - not skilled but willing to learn"
+msgstr "Aprenent - amb poca experiència però amb ganes d'aprendre"
+
+#: ../../Zotlabs/Module/Admin/Site.php:276
+msgid "Intermediate - somewhat comfortable"
+msgstr "Intermedi - còmode en entorns informàtics"
+
+#: ../../Zotlabs/Module/Admin/Site.php:277
+msgid "Advanced - very comfortable"
+msgstr "Avançat - molt còmode en entorns informàtics"
+
+#: ../../Zotlabs/Module/Admin/Site.php:278
+msgid "Expert - I can write computer code"
+msgstr "Expert - Sé programar"
+
+#: ../../Zotlabs/Module/Admin/Site.php:279
+msgid "Wizard - I probably know more than you do"
+msgstr "Bruixot - Segurament en sé més que tu"
+
+#: ../../Zotlabs/Module/Admin/Site.php:288 ../../Zotlabs/Widget/Admin.php:22
+msgid "Site"
+msgstr "Node"
+
+#: ../../Zotlabs/Module/Admin/Site.php:290
+#: ../../Zotlabs/Module/Register.php:269
+msgid "Registration"
+msgstr "Inscripcions"
+
+#: ../../Zotlabs/Module/Admin/Site.php:291
+msgid "File upload"
+msgstr "Pujada d'arxius"
+
+#: ../../Zotlabs/Module/Admin/Site.php:292
+msgid "Policies"
+msgstr "Polítiques"
+
+#: ../../Zotlabs/Module/Admin/Site.php:293
+#: ../../include/contact_widgets.php:16
+msgid "Advanced"
+msgstr "Avançat"
+
+#: ../../Zotlabs/Module/Admin/Site.php:297
+#: ../../addon/statusnet/statusnet.php:891
+msgid "Site name"
+msgstr "Nom del node"
+
+#: ../../Zotlabs/Module/Admin/Site.php:299
+msgid "Site default technical skill level"
+msgstr "Nivell per defecte del lloc de competències tècniques"
+
+#: ../../Zotlabs/Module/Admin/Site.php:299
+msgid "Used to provide a member experience matched to technical comfort level"
+msgstr "Es fa servir per oferir una experiència ajustada al nivell tècnic de cadascú"
+
+#: ../../Zotlabs/Module/Admin/Site.php:301
+msgid "Lock the technical skill level setting"
+msgstr "Bloqueja el paràmetre de nivell tècnic"
+
+#: ../../Zotlabs/Module/Admin/Site.php:301
+msgid "Members can set their own technical comfort level by default"
+msgstr "Per defecte, els/les membres poden modificar el paràmetre de nivell tècnic"
+
+#: ../../Zotlabs/Module/Admin/Site.php:303
+msgid "Banner/Logo"
+msgstr "Cartell i logotip"
+
+#: ../../Zotlabs/Module/Admin/Site.php:303
+msgid "Unfiltered HTML/CSS/JS is allowed"
+msgstr "Es permet contingut HTML, CSS i JS, sense filtrar"
+
+#: ../../Zotlabs/Module/Admin/Site.php:304
+msgid "Administrator Information"
+msgstr "Informació de l'administració"
+
+#: ../../Zotlabs/Module/Admin/Site.php:304
+msgid ""
+"Contact information for site administrators.  Displayed on siteinfo page.  "
+"BBCode can be used here"
+msgstr "Informació per contactar amb les persones administradores del node. Es mostra a la pàgina d'informació del node. S'hi pot emprar BBCode."
+
+#: ../../Zotlabs/Module/Admin/Site.php:305
+#: ../../Zotlabs/Module/Siteinfo.php:21
+msgid "Site Information"
+msgstr "Informació del node"
+
+#: ../../Zotlabs/Module/Admin/Site.php:305
+msgid ""
+"Publicly visible description of this site.  Displayed on siteinfo page.  "
+"BBCode can be used here"
+msgstr "Descripció del node visible públicament. Es mostra a la pàgina d'informació del node. S'hi pot emprar BBCode."
+
+#: ../../Zotlabs/Module/Admin/Site.php:306
+msgid "System language"
+msgstr "Llengua del sistema"
+
+#: ../../Zotlabs/Module/Admin/Site.php:307
+msgid "System theme"
+msgstr "Tema del sistema"
+
+#: ../../Zotlabs/Module/Admin/Site.php:307
+msgid ""
+"Default system theme - may be over-ridden by user profiles - <a href='#' "
+"id='cnftheme'>change theme settings</a>"
+msgstr "Tema del sistema per defecte. Les persones usuàries poden sobreescriure'l a la configuració de perfil: <a href='#' id='cnftheme'>canvia la configuració de tema</a>"
+
+#: ../../Zotlabs/Module/Admin/Site.php:308
+msgid "Mobile system theme"
+msgstr "Tema del sistema per a mòbils"
+
+#: ../../Zotlabs/Module/Admin/Site.php:308
+msgid "Theme for mobile devices"
+msgstr "Tema per a aparells mòbils"
+
+#: ../../Zotlabs/Module/Admin/Site.php:310
+msgid "Allow Feeds as Connections"
+msgstr "Permet connectar-se a fluxos RSS"
+
+#: ../../Zotlabs/Module/Admin/Site.php:310
+msgid "(Heavy system resource usage)"
+msgstr "(Demana molts recursos de sistema)"
+
+#: ../../Zotlabs/Module/Admin/Site.php:311
+msgid "Maximum image size"
+msgstr "Mida màxima d'imatge"
+
+#: ../../Zotlabs/Module/Admin/Site.php:311
+msgid ""
+"Maximum size in bytes of uploaded images. Default is 0, which means no "
+"limits."
+msgstr "Mida màxima total per les imatges pujades, en bytes. Per defecte és 0, que vol dir iŀlimitada."
+
+#: ../../Zotlabs/Module/Admin/Site.php:312
+msgid "Does this site allow new member registration?"
+msgstr "Aquest node està obert a la inscripció de nous membres?"
+
+#: ../../Zotlabs/Module/Admin/Site.php:313
+msgid "Invitation only"
+msgstr "Només per invitació"
+
+#: ../../Zotlabs/Module/Admin/Site.php:313
+msgid ""
+"Only allow new member registrations with an invitation code. Above register "
+"policy must be set to Yes."
+msgstr "Només permet nous membres només a través d'invitacions. Perquè tingui efecte, les inscripcions han d'estar obertes a nous membres."
+
+#: ../../Zotlabs/Module/Admin/Site.php:314
+msgid "Minimum age"
+msgstr "Edat mínima"
+
+#: ../../Zotlabs/Module/Admin/Site.php:314
+msgid "Minimum age (in years) for who may register on this site."
+msgstr "Edat mínima en anys per a poder crear un compte en aquest lloc."
+
+#: ../../Zotlabs/Module/Admin/Site.php:315
+msgid "Which best describes the types of account offered by this hub?"
+msgstr "Quina descripció s'acosta més al tipus de comptes oferts en aquest node?"
+
+#: ../../Zotlabs/Module/Admin/Site.php:316
+msgid "Register text"
+msgstr "Text d'inscripció"
+
+#: ../../Zotlabs/Module/Admin/Site.php:316
+msgid "Will be displayed prominently on the registration page."
+msgstr "Es mostrarà en gran a la pàgina d'inscripció"
+
+#: ../../Zotlabs/Module/Admin/Site.php:317
+msgid "Site homepage to show visitors (default: login box)"
+msgstr "Pàgina d'inici a mostrar als visitants (per defecte: la pàgina d'inici de sessió)"
+
+#: ../../Zotlabs/Module/Admin/Site.php:317
+msgid ""
+"example: 'public' to show public stream, 'page/sys/home' to show a system "
+"webpage called 'home' or 'include:home.html' to include a file."
+msgstr "exemple: 'public' per a mostrar el flux públic, 'page/sys/home' per a mostrar una pàgina web de sistema de nom 'home', o 'include:home.html' per a incloure un arxiu."
+
+#: ../../Zotlabs/Module/Admin/Site.php:318
+msgid "Preserve site homepage URL"
+msgstr "Preserva l'adreça URL de la pàgina d'inici"
+
+#: ../../Zotlabs/Module/Admin/Site.php:318
+msgid ""
+"Present the site homepage in a frame at the original location instead of "
+"redirecting"
+msgstr "Presenta la pàgina d'inici del node en un marc en el lloc original enlloc de redirigir-hi"
+
+#: ../../Zotlabs/Module/Admin/Site.php:319
+msgid "Accounts abandoned after x days"
+msgstr "Els comptes es consideren abandonats després de X dies"
+
+#: ../../Zotlabs/Module/Admin/Site.php:319
+msgid ""
+"Will not waste system resources polling external sites for abandonded "
+"accounts. Enter 0 for no time limit."
+msgstr "Estalviarà recursos del sistema en no sondejar nodes externs per a comptes abandonats. Un 0 vol dir \"mai\"."
+
+#: ../../Zotlabs/Module/Admin/Site.php:320
+msgid "Allowed friend domains"
+msgstr "Dominis amb permisos de connexió"
+
+#: ../../Zotlabs/Module/Admin/Site.php:320
+msgid ""
+"Comma separated list of domains which are allowed to establish friendships "
+"with this site. Wildcards are accepted. Empty to allow any domains"
+msgstr "Llista separada per comes de dominis en els quals està permès establir relacions d'amistat amb aquest node. S'accepten comodins (*). Deixa-ho buit per a acceptar qualsevol domini"
+
+#: ../../Zotlabs/Module/Admin/Site.php:321
+msgid "Verify Email Addresses"
+msgstr "Verifica les adreces de correu electrònic"
+
+#: ../../Zotlabs/Module/Admin/Site.php:321
+msgid ""
+"Check to verify email addresses used in account registration (recommended)."
+msgstr "Activa per a comprovar l'adreça de correu emprada durant la inscripció d'un nou compte (recomanat)."
+
+#: ../../Zotlabs/Module/Admin/Site.php:322
+msgid "Force publish"
+msgstr "Força la publicació"
+
+#: ../../Zotlabs/Module/Admin/Site.php:322
+msgid ""
+"Check to force all profiles on this site to be listed in the site directory."
+msgstr "Activa per a forçar que tots el perfils en aquest node siguin llistats en el directori del lloc."
+
+#: ../../Zotlabs/Module/Admin/Site.php:323
+msgid "Import Public Streams"
+msgstr "Importar fluxos públics"
+
+#: ../../Zotlabs/Module/Admin/Site.php:323
+msgid ""
+"Import and allow access to public content pulled from other sites. Warning: "
+"this content is unmoderated."
+msgstr "Importa i permet l'accés a contingut públic sondejat d'altres llocs. Avís: aquest contingut no estarà moderat."
+
+#: ../../Zotlabs/Module/Admin/Site.php:324
+msgid "Site only Public Streams"
+msgstr "Fluxos públics només locals"
+
+#: ../../Zotlabs/Module/Admin/Site.php:324
+msgid ""
+"Allow access to public content originating only from this site if Imported "
+"Public Streams are disabled."
+msgstr "Permet accedir a aquell contingut públic que s'hagi originat en aquest lloc, suposant que no s'estan important fluxos públics d'altres nodes."
+
+#: ../../Zotlabs/Module/Admin/Site.php:325
+msgid "Allow anybody on the internet to access the Public streams"
+msgstr "Permet a qualsevol persona d'internet d'accedir els fluxos públics"
+
+#: ../../Zotlabs/Module/Admin/Site.php:325
+msgid ""
+"Disable to require authentication before viewing. Warning: this content is "
+"unmoderated."
+msgstr "Desabilita-ho per a demanar iniciar sessió per poder-ho veure. Alerta: el contingut no estarà moderat."
+
+#: ../../Zotlabs/Module/Admin/Site.php:326
+msgid "Login on Homepage"
+msgstr "Accés a la Pàgina d'inici"
+
+#: ../../Zotlabs/Module/Admin/Site.php:326
+msgid ""
+"Present a login box to visitors on the home page if no other content has "
+"been configured."
+msgstr "Presenta una casella d'identificació a la pàgina d'inici als visitants si no s'ha configurat altre contingut."
+
+#: ../../Zotlabs/Module/Admin/Site.php:327
+msgid "Enable context help"
+msgstr "Activar l'ajuda contextual"
+
+#: ../../Zotlabs/Module/Admin/Site.php:327
+msgid ""
+"Display contextual help for the current page when the help button is "
+"pressed."
+msgstr "Mostra l'ajuda contextual per la pàgina actual quan el botó d'ajuda es pressionat."
+
+#: ../../Zotlabs/Module/Admin/Site.php:329
+msgid "Reply-to email address for system generated email."
+msgstr "Adreça de correu de resposta per als correus generats."
+
+#: ../../Zotlabs/Module/Admin/Site.php:330
+msgid "Sender (From) email address for system generated email."
+msgstr "Adreça de correu de remitent per als correus generats."
+
+#: ../../Zotlabs/Module/Admin/Site.php:331
+msgid "Name of email sender for system generated email."
+msgstr "Nom visible de remitent per als correus generats."
+
+#: ../../Zotlabs/Module/Admin/Site.php:333
+msgid "Directory Server URL"
+msgstr "URL del Servidor de Directoris"
+
+#: ../../Zotlabs/Module/Admin/Site.php:333
+msgid "Default directory server"
+msgstr "Servidor de directori per defecte"
+
+#: ../../Zotlabs/Module/Admin/Site.php:335
+msgid "Proxy user"
+msgstr "Usuari Proxy"
+
+#: ../../Zotlabs/Module/Admin/Site.php:336
+msgid "Proxy URL"
+msgstr "URL del Proxy"
+
+#: ../../Zotlabs/Module/Admin/Site.php:337
+msgid "Network timeout"
+msgstr "Temps d'espera de la xarxa"
+
+#: ../../Zotlabs/Module/Admin/Site.php:337
+msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
+msgstr "Valor en segons. Ajusta a 0 per a sense límits (no recomanat)"
+
+#: ../../Zotlabs/Module/Admin/Site.php:338
+msgid "Delivery interval"
+msgstr "Interval de lliurament"
+
+#: ../../Zotlabs/Module/Admin/Site.php:338
+msgid ""
+"Delay background delivery processes by this many seconds to reduce system "
+"load. Recommend: 4-5 for shared hosts, 2-3 for virtual private servers. 0-1 "
+"for large dedicated servers."
+msgstr "Retarda en segon plà l'interval de lliurament per aquests segons per reduir la càrrega del sistema. Recomanat:  4-5 per a hostes compartits, 2-3 per a servidors privats virtuals. 0-1 per a servidors dedicats."
+
+#: ../../Zotlabs/Module/Admin/Site.php:339
+msgid "Deliveries per process"
+msgstr "Entregues per processar"
+
+#: ../../Zotlabs/Module/Admin/Site.php:339
+msgid ""
+"Number of deliveries to attempt in a single operating system process. Adjust"
+" if necessary to tune system performance. Recommend: 1-5."
+msgstr "Nombre de entregues a intentar processar en un únic procèss del sistema operatiu. Ajustar si es necessari per millorar el rendiment. Es recomana: 1-5."
+
+#: ../../Zotlabs/Module/Admin/Site.php:340
+msgid "Queue Threshold"
+msgstr "Llindar de la cua"
+
+#: ../../Zotlabs/Module/Admin/Site.php:340
+msgid ""
+"Always defer immediate delivery if queue contains more than this number of "
+"entries."
+msgstr "Posposa el lliurament immediat si la cua conté més d'aquest nombre d'entrades."
+
+#: ../../Zotlabs/Module/Admin/Site.php:341
+msgid "Poll interval"
+msgstr "interval de sondeig"
+
+#: ../../Zotlabs/Module/Admin/Site.php:341
+msgid ""
+"Delay background polling processes by this many seconds to reduce system "
+"load. If 0, use delivery interval."
+msgstr "Retarda en segon pla el sondeig en aquesta quantitat de segons per a reduir la càrrega dels sistema. Si es 0 , empra l'interval de lliurament."
+
+#: ../../Zotlabs/Module/Admin/Site.php:342
+msgid "Path to ImageMagick convert program"
+msgstr "Ruta al programa de conversió d'imatges ImageMagick"
+
+#: ../../Zotlabs/Module/Admin/Site.php:342
+msgid ""
+"If set, use this program to generate photo thumbnails for huge images ( > "
+"4000 pixels in either dimension), otherwise memory exhaustion may occur. "
+"Example: /usr/bin/convert"
+msgstr "Si se n'indica la ruta, es farà servir aquest programa per a generar miniatures per a imatges enormes (més de 4000 píxels d'ample o alt). En cas contrari es pot esgotar la memòria del servidor. Ruta d'exemple: /usr/bin/convert"
+
+#: ../../Zotlabs/Module/Admin/Site.php:343
+msgid "Allow SVG thumbnails in file browser"
+msgstr "Permet miniatures en SVG a l'explorador de fitxers"
+
+#: ../../Zotlabs/Module/Admin/Site.php:343
+msgid "WARNING: SVG images may contain malicious code."
+msgstr "Alerta: Les imatges SVG poden contenir codi maliciós."
+
+#: ../../Zotlabs/Module/Admin/Site.php:344
+msgid "Maximum Load Average"
+msgstr "Càrrega Mitja Màxima"
+
+#: ../../Zotlabs/Module/Admin/Site.php:344
+msgid ""
+"Maximum system load before delivery and poll processes are deferred - "
+"default 50."
+msgstr "Càrrega màxima del sistema, abans que els processos de lliurament i sondeig es difereixin - 50 per defecte."
+
+#: ../../Zotlabs/Module/Admin/Site.php:345
+msgid "Expiration period in days for imported (grid/network) content"
+msgstr "Període d'expiració en dies per contingut importat (malla/xarxa)"
+
+#: ../../Zotlabs/Module/Admin/Site.php:345
+msgid "0 for no expiration of imported content"
+msgstr "0 vol dir sense temps d'expiració pel contingut importat"
+
+#: ../../Zotlabs/Module/Admin/Site.php:347
+msgid ""
+"Public servers: Optional landing (marketing) webpage for new registrants"
+msgstr "Servidors públics: Pàgina d'arribada promocional per a nous usuaris o usuàries."
+
+#: ../../Zotlabs/Module/Admin/Site.php:347
+#, php-format
+msgid "Create this page first. Default is %s/register"
+msgstr "Crea primer aquesta pàgina. Per defecte és %s/register"
+
+#: ../../Zotlabs/Module/Admin/Site.php:348
+msgid "Page to display after creating a new channel"
+msgstr "Pàgina que es mostrarà després d'haver creat un canal nou"
+
+#: ../../Zotlabs/Module/Admin/Site.php:348
+msgid "Recommend: profiles, go, or settings"
+msgstr "Recomanat: profiles (perfils), go (mostra diverses opcions), settings (configuració)"
+
+#: ../../Zotlabs/Module/Admin/Site.php:350
+msgid "Optional: site location"
+msgstr "Opcional: ubicació del node"
+
+#: ../../Zotlabs/Module/Admin/Site.php:350
+msgid "Region or country"
+msgstr "Regió o país"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:69
+msgid "New Profile Field"
+msgstr "Camp de Perfil Nou"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:70
+#: ../../Zotlabs/Module/Admin/Profs.php:90
+msgid "Field nickname"
+msgstr "Àlies de Camp"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:70
+#: ../../Zotlabs/Module/Admin/Profs.php:90
+msgid "System name of field"
+msgstr "nOM DEL SISTEMA DEL CAMP"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:71
+#: ../../Zotlabs/Module/Admin/Profs.php:91
+msgid "Input type"
+msgstr "Tipus d'entrada"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:72
+#: ../../Zotlabs/Module/Admin/Profs.php:92
+msgid "Field Name"
+msgstr "Nom de Camp"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:72
+#: ../../Zotlabs/Module/Admin/Profs.php:92
+msgid "Label on profile pages"
+msgstr "Etiqueta a les pàgines de perfil"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:73
+#: ../../Zotlabs/Module/Admin/Profs.php:93
+msgid "Help text"
+msgstr "Text d'ajuda"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:73
+#: ../../Zotlabs/Module/Admin/Profs.php:93
+msgid "Additional info (optional)"
+msgstr "Informació adicional (opcional)"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:74
+#: ../../Zotlabs/Module/Admin/Profs.php:94 ../../Zotlabs/Module/Rbmark.php:32
+#: ../../Zotlabs/Module/Rbmark.php:104 ../../Zotlabs/Module/Filer.php:53
+#: ../../Zotlabs/Widget/Notes.php:18 ../../include/text.php:1052
+#: ../../include/text.php:1064
+msgid "Save"
+msgstr "Guardar"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:83
+msgid "Field definition not found"
+msgstr "No es troba la definició del camp"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:89
+msgid "Edit Profile Field"
+msgstr "Camp d'Edició del Perfil"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:147 ../../Zotlabs/Widget/Admin.php:30
+msgid "Profile Fields"
+msgstr "Camps del Perfil"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:148
+msgid "Basic Profile Fields"
+msgstr "Camps Bàsics del Perfil"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:149
+msgid "Advanced Profile Fields"
+msgstr "Camps Avançats del Perfil"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:149
+msgid "(In addition to basic fields)"
+msgstr "( addicionalment als camps bàsics)"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:151
+msgid "All available fields"
+msgstr "Tots els camps disponibles"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:152
+msgid "Custom Fields"
+msgstr "Camps Personalitzats"
+
+#: ../../Zotlabs/Module/Admin/Profs.php:156
+msgid "Create Custom Field"
+msgstr "Crear un Camp Personalitzat"
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:29
+#, php-format
+msgid "Password changed for account %d."
+msgstr "S'ha modificat la contrasenya pel compte %d."
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:46
+msgid "Account settings updated."
+msgstr "S'han actualitzat els paràmetres del compte."
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:61
+msgid "Account not found."
+msgstr "No s'ha trobat el compte."
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:68
+msgid "Account Edit"
+msgstr "Edita el compte"
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:69
+msgid "New Password"
+msgstr "Introdueix la nova contrasenya"
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:70
+msgid "New Password again"
+msgstr "Repeteix la nova contrasenya"
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:71
+msgid "Technical skill level"
+msgstr "Nivell de competències tècniques"
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:72
+msgid "Account language (for emails)"
+msgstr "Idioma pel compte (pels correus)"
+
+#: ../../Zotlabs/Module/Admin/Account_edit.php:73
+msgid "Service class"
+msgstr "Classe de servei"
+
+#: ../../Zotlabs/Module/Admin/Security.php:77
+msgid ""
+"By default, unfiltered HTML is allowed in embedded media. This is inherently"
+" insecure."
+msgstr "Per defecte, HTML no filtrat està permés als media embeguts. Això es inherentment no segur."
+
+#: ../../Zotlabs/Module/Admin/Security.php:80
+msgid ""
+"The recommended setting is to only allow unfiltered HTML from the following "
+"sites:"
+msgstr "L'ajust recomanat és només permetre HTML sense filtrar dels següents llocs:"
+
+#: ../../Zotlabs/Module/Admin/Security.php:81
+msgid ""
+"https://youtube.com/<br />https://www.youtube.com/<br />https://youtu.be/<br"
+" />https://vimeo.com/<br />https://soundcloud.com/<br />"
+msgstr "https://youtube.com/<br />https://www.youtube.com/<br />https://youtu.be/<br />https://vimeo.com/<br />https://soundcloud.com/<br />"
+
+#: ../../Zotlabs/Module/Admin/Security.php:82
+msgid ""
+"All other embedded content will be filtered, <strong>unless</strong> "
+"embedded content from that site is explicitly blocked."
+msgstr "Tota la resta de contingut embegut seà filtrat, <strong>excepte</strong> contingut embegut d'aquest lloc que està blocat explícitament."
+
+#: ../../Zotlabs/Module/Admin/Security.php:87
+#: ../../Zotlabs/Widget/Admin.php:25
+msgid "Security"
+msgstr "Seguretat"
+
+#: ../../Zotlabs/Module/Admin/Security.php:89
+msgid "Block public"
+msgstr "Bloca que sigui públic"
+
+#: ../../Zotlabs/Module/Admin/Security.php:89
+msgid ""
+"Check to block public access to all otherwise public personal pages on this "
+"site unless you are currently authenticated."
+msgstr "activa per blocar l'accés a les pàgines personals públiques a tothom excepte aquells/es que s'hagin autenticat en aquest node."
+
+#: ../../Zotlabs/Module/Admin/Security.php:90
+msgid "Set \"Transport Security\" HTTP header"
+msgstr "Set \"Transport Security\" HTTP header"
+
+#: ../../Zotlabs/Module/Admin/Security.php:91
+msgid "Set \"Content Security Policy\" HTTP header"
+msgstr "Set \"Content Security Policy\" HTTP header"
+
+#: ../../Zotlabs/Module/Admin/Security.php:92
+msgid "Allowed email domains"
+msgstr "Dominis de correu electonic acceptats"
+
+#: ../../Zotlabs/Module/Admin/Security.php:92
+msgid ""
+"Comma separated list of domains which are allowed in email addresses for "
+"registrations to this site. Wildcards are accepted. Empty to allow any "
+"domains"
+msgstr "llista separada per comes de dominis d'adreces de correu electrònic permeses en aquest lloc. S'accepten comodins. Deixar buit per acceptar qualsevol domini"
+
+#: ../../Zotlabs/Module/Admin/Security.php:93
+msgid "Not allowed email domains"
+msgstr "Dominis de correu electrònic no acceptats"
+
+#: ../../Zotlabs/Module/Admin/Security.php:93
+msgid ""
+"Comma separated list of domains which are not allowed in email addresses for"
+" registrations to this site. Wildcards are accepted. Empty to allow any "
+"domains, unless allowed domains have been defined."
+msgstr "llista separada per comes de dominis d'adreces de correu electrònic no permeses en aquest lloc. S'accepten comodins. Deixar buit per no acceptar cap domini, excepte els que s'hagin definits com acceptats."
+
+#: ../../Zotlabs/Module/Admin/Security.php:94
+msgid "Allow communications only from these sites"
+msgstr "Permetre comunicacions únicament des de aquests llocs"
+
+#: ../../Zotlabs/Module/Admin/Security.php:94
+msgid ""
+"One site per line. Leave empty to allow communication from anywhere by "
+"default"
+msgstr "Un lloc per línia. Deixar en blanc per permetre, per defecte,  la comunicació amb tothom."
+
+#: ../../Zotlabs/Module/Admin/Security.php:95
+msgid "Block communications from these sites"
+msgstr "Bloca comunicacions que venen d'aquests llocs"
+
+#: ../../Zotlabs/Module/Admin/Security.php:96
+msgid "Allow communications only from these channels"
+msgstr "Permet la comunicació només per aquests canals"
+
+#: ../../Zotlabs/Module/Admin/Security.php:96
+msgid ""
+"One channel (hash) per line. Leave empty to allow from any channel by "
+"default"
+msgstr "Un canal (hash) per línia. Deixa en blanc per permetre, per defecte,  la comunicació qualsevol canal."
+
+#: ../../Zotlabs/Module/Admin/Security.php:97
+msgid "Block communications from these channels"
+msgstr "Bloca les comunicacions que venen d'aquests canals"
+
+#: ../../Zotlabs/Module/Admin/Security.php:98
+msgid "Only allow embeds from secure (SSL) websites and links."
+msgstr "Permetre embeguts només de llocs web i enllaços segurs (SSL)."
+
+#: ../../Zotlabs/Module/Admin/Security.php:99
+msgid "Allow unfiltered embedded HTML content only from these domains"
+msgstr "Permetre HTML embegut sense filtrar només d'aquests dominis."
+
+#: ../../Zotlabs/Module/Admin/Security.php:99
+msgid "One site per line. By default embedded content is filtered."
+msgstr "Un lloc per línia. Per defecte el contingut embegut es filtrat."
+
+#: ../../Zotlabs/Module/Admin/Security.php:100
+msgid "Block embedded HTML from these domains"
+msgstr "Bloca HTML embegut d'aquests dominis"
+
+#: ../../Zotlabs/Module/Lockview.php:75
+msgid "Remote privacy information not available."
+msgstr "informació privada remota no disponible."
+
+#: ../../Zotlabs/Module/Lockview.php:96
+msgid "Visible to:"
+msgstr "Visible per:"
+
+#: ../../Zotlabs/Module/Lockview.php:117 ../../Zotlabs/Module/Lockview.php:153
+#: ../../Zotlabs/Module/Acl.php:121 ../../include/acl_selectors.php:88
+msgctxt "acl"
+msgid "Profile"
+msgstr "Perfil"
+
+#: ../../Zotlabs/Module/Moderate.php:55
+msgid "Comment approved"
+msgstr "S'ha aprovat el comentari"
+
+#: ../../Zotlabs/Module/Moderate.php:59
+msgid "Comment deleted"
+msgstr "S'ha esborrat el comentari"
+
+#: ../../Zotlabs/Module/Settings/Permcats.php:37
+msgid "Permission category saved."
+msgstr "S'ha desat la categoria de permisos."
+
+#: ../../Zotlabs/Module/Settings/Permcats.php:61
+msgid ""
+"Use this form to create permission rules for various classes of people or "
+"connections."
+msgstr "Pots crear regles de permisos segons classe de persona o de connexió."
+
+#: ../../Zotlabs/Module/Settings/Permcats.php:94
+msgid "Permission Categories"
+msgstr "Categories de permisos"
+
+#: ../../Zotlabs/Module/Settings/Permcats.php:102
+msgid "Permission Name"
+msgstr "Nom de permís"
+
+#: ../../Zotlabs/Module/Settings/Permcats.php:103
+#: ../../Zotlabs/Module/Settings/Tokens.php:161
+#: ../../Zotlabs/Module/Connedit.php:891 ../../Zotlabs/Module/Defperms.php:250
+msgid "My Settings"
+msgstr "Els Meus Ajustos"
+
+#: ../../Zotlabs/Module/Settings/Permcats.php:105
+#: ../../Zotlabs/Module/Settings/Tokens.php:163
+#: ../../Zotlabs/Module/Connedit.php:886 ../../Zotlabs/Module/Defperms.php:248
+msgid "inherited"
+msgstr "heretat"
+
+#: ../../Zotlabs/Module/Settings/Permcats.php:108
+#: ../../Zotlabs/Module/Settings/Tokens.php:166
+#: ../../Zotlabs/Module/Connedit.php:893 ../../Zotlabs/Module/Defperms.php:253
+msgid "Individual Permissions"
+msgstr "Permisos Individuals"
+
+#: ../../Zotlabs/Module/Settings/Permcats.php:109
+#: ../../Zotlabs/Module/Settings/Tokens.php:167
+#: ../../Zotlabs/Module/Connedit.php:894
+msgid ""
+"Some permissions may be inherited from your channel's <a "
+"href=\"settings\"><strong>privacy settings</strong></a>, which have higher "
+"priority than individual settings. You can <strong>not</strong> change those"
+" settings here."
+msgstr "Alguns permisos poden ser heretats dels teus canals <a href=\"settings\"><strong>ajustos de privacitat</strong></a>, Els quals tenen més prioritat que els ajustos individuals. <strong>No</strong> pots canviar aquests ajustos aquí."
+
+#: ../../Zotlabs/Module/Settings/Channel.php:64
+#: ../../Zotlabs/Module/Settings/Channel.php:68
+#: ../../Zotlabs/Module/Settings/Channel.php:69
+#: ../../Zotlabs/Module/Settings/Channel.php:72
+#: ../../Zotlabs/Module/Settings/Channel.php:83
+#: ../../Zotlabs/Module/Connedit.php:711 ../../Zotlabs/Widget/Affinity.php:24
+#: ../../include/selectors.php:123 ../../include/channel.php:437
+#: ../../include/channel.php:438 ../../include/channel.php:445
+msgid "Friends"
+msgstr "Amics"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:262
+#: ../../Zotlabs/Module/Defperms.php:103
+#: ../../addon/rendezvous/rendezvous.php:82
+#: ../../addon/openstreetmap/openstreetmap.php:184
+#: ../../addon/msgfooter/msgfooter.php:54 ../../addon/logrot/logrot.php:54
+#: ../../addon/twitter/twitter.php:772 ../../addon/piwik/piwik.php:116
+#: ../../addon/xmpp/xmpp.php:102
+msgid "Settings updated."
+msgstr "Ajustes actualizados."
+
+#: ../../Zotlabs/Module/Settings/Channel.php:323
+msgid "Nobody except yourself"
+msgstr "Ningú excepte tú"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:324
+msgid "Only those you specifically allow"
+msgstr "Només allò que específicament permetis"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:325
+msgid "Approved connections"
+msgstr "Connexions aprovades"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:326
+msgid "Any connections"
+msgstr "Qualsevol connexió"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:327
+msgid "Anybody on this website"
+msgstr "Qualsevol en aquest lloc"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:328
+msgid "Anybody in this network"
+msgstr "Qualsevol en aquesta xarxa"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:329
+msgid "Anybody authenticated"
+msgstr "Qualsevol autenticat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:330
+msgid "Anybody on the internet"
+msgstr "Qualsevol a internet"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:405
+msgid "Publish your default profile in the network directory"
+msgstr "Publica el teu perfil per defecte al directori de la xarxa"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:410
+msgid "Allow us to suggest you as a potential friend to new members?"
+msgstr "Ens permets suggerir-te com a potencial amic als nous membres?"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:414
+msgid "or"
+msgstr "o"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:419
+msgid "Your channel address is"
+msgstr "La teva adreça del canal es"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:422
+msgid "Your files/photos are accessible via WebDAV at"
+msgstr "Les teves fotos i arxius estan disponibles mitjançant WebDAV a"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:486
+msgid "Channel Settings"
+msgstr "Ajustos del Canal"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:493
+msgid "Basic Settings"
+msgstr "Ajustos Bàsics"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:494
+#: ../../include/channel.php:1522
+msgid "Full Name:"
+msgstr "Nom Complet:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:495
+#: ../../Zotlabs/Module/Settings/Account.php:119
+msgid "Email Address:"
+msgstr "Adreça de E-Correu:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:496
+msgid "Your Timezone:"
+msgstr "La teva Franja Horària"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:497
+msgid "Default Post Location:"
+msgstr "Localització Predeterminada de les Entrades:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:497
+msgid "Geographical location to display on your posts"
+msgstr "Posició geogràfica a mostrar a les teves entrades"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:498
+msgid "Use Browser Location:"
+msgstr "Empra la Localització del Navegador:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:500
+msgid "Adult Content"
+msgstr "Contingut per a Adults"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:500
+msgid ""
+"This channel frequently or regularly publishes adult content. (Please tag "
+"any adult material and/or nudity with #NSFW)"
+msgstr "Aquest canal publica freqúentment o amb regularitat contingut per a adults. (Si us plau, etiqueti qualsevol material per a adults amb #NSFW)"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:502
+msgid "Security and Privacy Settings"
+msgstr "Ajustos de Seguretat i Privacitat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:504
+msgid "Your permissions are already configured. Click to view/adjust"
+msgstr "Els teus permisos estan configurats. Clic per veure/ajustar"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:506
+msgid "Hide my online presence"
+msgstr "Amaga la meva presencia en línia"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:506
+msgid "Prevents displaying in your profile that you are online"
+msgstr "Evita mostrar en el teu perfil, que estàs en línia"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:508
+msgid "Simple Privacy Settings:"
+msgstr "Ajustos simples de privacitat:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:509
+msgid ""
+"Very Public - <em>extremely permissive (should be used with caution)</em>"
+msgstr "Molt públic - <em>extremadament permissiu (s'ha d'anar en compte)</em>"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:510
+msgid ""
+"Typical - <em>default public, privacy when desired (similar to social "
+"network permissions but with improved privacy)</em>"
+msgstr "Normal - <em>públic per defecte, privat quan es desitgi (similar als permisos de xarxa social, però amb millor privacitat)"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:511
+msgid "Private - <em>default private, never open or public</em>"
+msgstr "Privat - <em>privat per defecte, mai públic o obert</em>"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:512
+msgid "Blocked - <em>default blocked to/from everybody</em>"
+msgstr "Bloquejat - <em>tothom bloquejat per defecte</em>"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:514
+msgid "Allow others to tag your posts"
+msgstr "Permet a altres etiquetar les teves entrades"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:514
+msgid ""
+"Often used by the community to retro-actively flag inappropriate content"
+msgstr "Sovint emprat per la comunitat per marcar retroactivament contingut inapropiat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:516
+msgid "Channel Permission Limits"
+msgstr "Límits dels permisos del canal"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:518
+msgid "Expire other channel content after this many days"
+msgstr "El contingut d'altes canals caduca després d'aquests dies"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:518
+msgid "0 or blank to use the website limit."
+msgstr "0 o en blanc per emprar el limit del lloc web."
+
+#: ../../Zotlabs/Module/Settings/Channel.php:518
+#, php-format
+msgid "This website expires after %d days."
+msgstr "Aquest lloc web expira després de %d dies."
+
+#: ../../Zotlabs/Module/Settings/Channel.php:518
+msgid "This website does not expire imported content."
+msgstr "A aquest lloc web no expira el contingut importat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:518
+msgid "The website limit takes precedence if lower than your limit."
+msgstr "El límit del lloc web pren la preferència si es inferior al teu límit."
+
+#: ../../Zotlabs/Module/Settings/Channel.php:519
+msgid "Maximum Friend Requests/Day:"
+msgstr "Nombre màxim de peticions d'amistat per dia"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:519
+msgid "May reduce spam activity"
+msgstr "Pot reduir l'SPAM"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:520
+msgid "Default Privacy Group"
+msgstr "Grup de privacitat per defecte"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:522
+msgid "Use my default audience setting for the type of object published"
+msgstr "Empra els meus ajustos per defecte segons el tipus de entrada publicada"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:523
+msgid "Profile to assign new connections"
+msgstr "Perfil al qual assignar les connexions noves"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:532
+msgid "Channel permissions category:"
+msgstr "Categoria de permisos de canal:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:533
+msgid "Default Permissions Group"
+msgstr "Grup de permisos per defecte"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:539
+msgid "Maximum private messages per day from unknown people:"
+msgstr "Nombre màxim de missatges privats de desconeguts al dia:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:539
+msgid "Useful to reduce spamming"
+msgstr "Útil per a reduir l'spam"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:542
+#: ../../Zotlabs/Lib/Enotify.php:68
+msgid "Notification Settings"
+msgstr "Ajustos de notificacions"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:543
+msgid "By default post a status message when:"
+msgstr "Per defecte envia un missatge d'estat quan:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:544
+msgid "accepting a friend request"
+msgstr "S'accepta una sol·licitud d'amistat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:545
+msgid "joining a forum/community"
+msgstr "Apuntar-se a un fòrum o comunitat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:546
+msgid "making an <em>interesting</em> profile change"
+msgstr "Faci un canvi  <em>interesant</em> al perfil"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:547
+msgid "Send a notification email when:"
+msgstr "Notifica per correu quan:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:548
+msgid "You receive a connection request"
+msgstr "Rebi una petició de connexió"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:549
+msgid "Your connections are confirmed"
+msgstr "Es confirma una connexió"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:550
+msgid "Someone writes on your profile wall"
+msgstr "Algú ha escrit al mur del teu perfil"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:551
+msgid "Someone writes a followup comment"
+msgstr "Algú ha escrit un comentari de resposta"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:552
+msgid "You receive a private message"
+msgstr "Rebi un missatge privat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:553
+msgid "You receive a friend suggestion"
+msgstr "Rebi una suggerència d'amistat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:554
+msgid "You are tagged in a post"
+msgstr "Estàs etiquetat a l'entrada"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:555
+msgid "You are poked/prodded/etc. in a post"
+msgstr "S'enfoten/te piquen/etc. en una entrada"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:557
+msgid "Someone likes your post/comment"
+msgstr "A algú li ha agradat la teva entrada o comentari"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:560
+msgid "Show visual notifications including:"
+msgstr "Mostra notificacion visuals, com ara:"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:562
+msgid "Unseen grid activity"
+msgstr "Activitat de malla no vista"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:563
+msgid "Unseen channel activity"
+msgstr "Activitat no vista del canal"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:564
+msgid "Unseen private messages"
+msgstr "Missatges privats no llegits"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:564
+#: ../../Zotlabs/Module/Settings/Channel.php:569
+#: ../../Zotlabs/Module/Settings/Channel.php:570
+#: ../../Zotlabs/Module/Settings/Channel.php:571
+#: ../../addon/jappixmini/jappixmini.php:343
+msgid "Recommended"
+msgstr "Recomanat"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:565
+msgid "Upcoming events"
+msgstr "Esdeveniments propers"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:566
+msgid "Events today"
+msgstr "Esdeveniments d'avui"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:567
+msgid "Upcoming birthdays"
+msgstr "Aniversaris propers"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:567
+msgid "Not available in all themes"
+msgstr "No està disponible en tots els temes"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:568
+msgid "System (personal) notifications"
+msgstr "Notificacions (personals) del sistema"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:569
+msgid "System info messages"
+msgstr "Missatges d'informació del sistema"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:570
+msgid "System critical alerts"
+msgstr "Alertes crítiques del sistema"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:571
+msgid "New connections"
+msgstr "Noves connexions"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:572
+msgid "System Registrations"
+msgstr "Inscripcions del Sistema"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:573
+msgid "Unseen shared files"
+msgstr "Fitxers compartits nous"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:574
+msgid "Unseen public activity"
+msgstr "Activitat pública nova"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:575
+msgid "Email notification hub (hostname)"
+msgstr "Hub per a notificacions per correu (nom de domini)"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:575
+#, php-format
+msgid ""
+"If your channel is mirrored to multiple hubs, set this to your preferred "
+"location. This will prevent duplicate email notifications. Example: %s"
+msgstr "En cas que el teu canal estigui repicat en diversos hubs, habilita aquesta opció al teu hub preferit. Això evita notificacions duplicades. Exemple: %s"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:576
+msgid ""
+"Also show new wall posts, private messages and connections under Notices"
+msgstr "Mostra també les entrades de mur noves, les entrades privades i les connexions a \"Notícies\""
+
+#: ../../Zotlabs/Module/Settings/Channel.php:578
+msgid "Notify me of events this many days in advance"
+msgstr "Notifica'm dels esdeveniments amb aquests dies d'antelació"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:578
+msgid "Must be greater than 0"
+msgstr "Ha de ser més gran que 0"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:584
+msgid "Advanced Account/Page Type Settings"
+msgstr "Ajustos avançats de compte i tipus de pàgina"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:585
+msgid "Change the behaviour of this account for special situations"
+msgstr "Modifica el comportament d'aquest compte en situacions especials"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:587
+msgid "Miscellaneous Settings"
+msgstr "Ajustos diversos"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:588
+msgid "Default photo upload folder"
+msgstr "Carpeta per defecte de fotos pujades"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:588
+#: ../../Zotlabs/Module/Settings/Channel.php:589
+msgid "%Y - current year, %m -  current month"
+msgstr "%Y - any en curs, %m -  mes corrent"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:589
+msgid "Default file upload folder"
+msgstr "Carpeta per defecte d'arxius pujats"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:591
+msgid "Personal menu to display in your channel pages"
+msgstr "Menú personal per mostrar en les teves pàgines de canal"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:593
+msgid "Remove this channel."
+msgstr "Elimina aquest canal."
+
+#: ../../Zotlabs/Module/Settings/Channel.php:594
+msgid "Firefox Share $Projectname provider"
+msgstr "Firefox Share $Projectname provider"
+
+#: ../../Zotlabs/Module/Settings/Channel.php:595
+msgid "Start calendar week on Monday"
+msgstr "Comença la setmana en dilluns"
+
+#: ../../Zotlabs/Module/Settings/Features.php:45
+msgid "Additional Features"
+msgstr "Característiques Addicionals"
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:31
+#, php-format
+msgid "This channel is limited to %d tokens"
+msgstr "Aquest canal té un límit de %d tokens"
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:37
+msgid "Name and Password are required."
+msgstr "El nom i la contrasenya són necessaris."
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:77
+msgid "Token saved."
+msgstr "S'ha desat el token."
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:113
+msgid ""
+"Use this form to create temporary access identifiers to share things with "
+"non-members. These identities may be used in Access Control Lists and "
+"visitors may login using these credentials to access private content."
+msgstr "Fes servir aquest formulari per a crear identificadors d'accés temporal per tal de compartir coses amb persones no membres. Aquestes identitats són reconegudes a \"Control d'accés\" i poden ser usades per iniciar sessió i accedir a contingut privat."
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:115
+msgid ""
+"You may also provide <em>dropbox</em> style access links to friends and "
+"associates by adding the Login Password to any specific site URL as shown. "
+"Examples:"
+msgstr "Si vols donar enllaços que no requereixin dos passos, pots afegir la contrasenya d'accés a la URL per compartir. Per exemple:"
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:150
+#: ../../Zotlabs/Widget/Settings_menu.php:92
+msgid "Guest Access Tokens"
+msgstr "Tokens d'accés de convidat"
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:157
+msgid "Login Name"
+msgstr "Nom d'usuari"
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:158
+msgid "Login Password"
+msgstr "Contrasenya d'usuari"
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:159
+msgid "Expires (yyyy-mm-dd)"
+msgstr "Data de caducitat (aaaa-mm-dd)"
+
+#: ../../Zotlabs/Module/Settings/Tokens.php:160
+#: ../../Zotlabs/Module/Connedit.php:890
+msgid "Their Settings"
+msgstr "Els seus Ajustos"
+
+#: ../../Zotlabs/Module/Settings/Account.php:20
+msgid "Not valid email."
+msgstr "E-correu no vàlid."
+
+#: ../../Zotlabs/Module/Settings/Account.php:23
+msgid "Protected email address. Cannot change to that email."
+msgstr "Adreça d'e-correu protegida. No es pot canviar a aquest e-correu."
+
+#: ../../Zotlabs/Module/Settings/Account.php:32
+msgid "System failure storing new email. Please try again."
+msgstr "Fallada del sistema al guardar un nou correu. Si us plau, proba de nou."
+
+#: ../../Zotlabs/Module/Settings/Account.php:40
+msgid "Technical skill level updated"
+msgstr "S'ha actualitzat el nivell de competències tècniques"
+
+#: ../../Zotlabs/Module/Settings/Account.php:56
+msgid "Password verification failed."
+msgstr "La verificació de la contrasenya ha fallat."
+
+#: ../../Zotlabs/Module/Settings/Account.php:63
+msgid "Passwords do not match. Password unchanged."
+msgstr "Les contrasenyes no coincideixen. Contrasenya sense canvis."
+
+#: ../../Zotlabs/Module/Settings/Account.php:67
+msgid "Empty passwords are not allowed. Password unchanged."
+msgstr "Les contrasenyes en blanc no estan permesas. Contrasenya sense canvis."
+
+#: ../../Zotlabs/Module/Settings/Account.php:81
+msgid "Password changed."
+msgstr "Contrasenya canviada."
+
+#: ../../Zotlabs/Module/Settings/Account.php:83
+msgid "Password update failed. Please try again."
+msgstr "L'actualització de la contrasenya va fallar. Si us plau, torneu a intentar-ho."
+
+#: ../../Zotlabs/Module/Settings/Account.php:112
+msgid "Account Settings"
+msgstr "Ajustos de Compte"
+
+#: ../../Zotlabs/Module/Settings/Account.php:113
+msgid "Current Password"
+msgstr "Contrasenya Actual"
+
+#: ../../Zotlabs/Module/Settings/Account.php:114
+msgid "Enter New Password"
+msgstr "Entra la Nova Contrasenya"
+
+#: ../../Zotlabs/Module/Settings/Account.php:115
+msgid "Confirm New Password"
+msgstr "Confirma la Nova Contrasenya"
+
+#: ../../Zotlabs/Module/Settings/Account.php:115
+msgid "Leave password fields blank unless changing"
+msgstr "Deixa els camps de contrasenya en blanc llevat que la vulguis canviar"
+
+#: ../../Zotlabs/Module/Settings/Account.php:116
+msgid "Your technical skill level"
+msgstr "El teu nivell tècnic"
+
+#: ../../Zotlabs/Module/Settings/Account.php:116
+msgid ""
+"Used to provide a member experience and additional features consistent with "
+"your comfort level"
+msgstr "Es fa servir per a oferir-te una experiència i un seguit de funcionalitats addicionals d'acord amb la complexitat que desitgis."
+
+#: ../../Zotlabs/Module/Settings/Account.php:120
+#: ../../Zotlabs/Module/Removeaccount.php:61
+msgid "Remove Account"
+msgstr "Esborra el Compte"
+
+#: ../../Zotlabs/Module/Settings/Account.php:121
+msgid "Remove this account including all its channels"
+msgstr "Esborra aquest compte inclosos tots els seus canals"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:23
+msgid "Affinity Slider settings updated."
+msgstr "S'ha actualitzat la configuració de la barra d'afinitat"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:38
+msgid "No feature settings configured"
+msgstr "No hi ha opcions de les funcions configurades"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:45
+msgid "Default maximum affinity level"
+msgstr "Nivell màxim d'afinitat predeterminat"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:45
+msgid "0-99 default 99"
+msgstr "0-99 (per defecte 99)"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:50
+msgid "Default minimum affinity level"
+msgstr "Nivell mínim d'afinitat predeterminat"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:50
+msgid "0-99 - default 0"
+msgstr "0-99 (per defecte 0)"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:54
+msgid "Affinity Slider Settings"
+msgstr "Configuració de la barra d'afinitat"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:64
+msgid "Addon Settings"
+msgstr "Configuració de les extensions"
+
+#: ../../Zotlabs/Module/Settings/Featured.php:65
+msgid "Please save/submit changes to any panel before opening another."
+msgstr "Desa els canvis en un panell abans d'obrir-ne un altre."
+
+#: ../../Zotlabs/Module/Settings/Display.php:139
+#, php-format
+msgid "%s - (Experimental)"
+msgstr "%s - (Experimental)"
+
+#: ../../Zotlabs/Module/Settings/Display.php:187
+msgid "Display Settings"
+msgstr "Ajustos de Pantalla"
+
+#: ../../Zotlabs/Module/Settings/Display.php:188
+msgid "Theme Settings"
+msgstr "Ajustos de Tema"
+
+#: ../../Zotlabs/Module/Settings/Display.php:189
+msgid "Custom Theme Settings"
+msgstr "Ajustos Personals de Tema"
+
+#: ../../Zotlabs/Module/Settings/Display.php:190
+msgid "Content Settings"
+msgstr "Ajustos de Contingut"
+
+#: ../../Zotlabs/Module/Settings/Display.php:196
+msgid "Display Theme:"
+msgstr "Ajustos de Tema:"
+
+#: ../../Zotlabs/Module/Settings/Display.php:197
+msgid "Select scheme"
+msgstr "Tria esquema"
+
+#: ../../Zotlabs/Module/Settings/Display.php:199
+msgid "Preload images before rendering the page"
+msgstr "Precarrega les imatges abans de dibuixar la pàgina"
+
+#: ../../Zotlabs/Module/Settings/Display.php:199
+msgid ""
+"The subjective page load time will be longer but the page will be ready when"
+" displayed"
+msgstr "El temps subjectiu per carregar la pàgina pot ser llarg però la pàgina estarà preparada quan es mostri"
+
+#: ../../Zotlabs/Module/Settings/Display.php:200
+msgid "Enable user zoom on mobile devices"
+msgstr "Zoom d'usuari en dispositius mòbils"
+
+#: ../../Zotlabs/Module/Settings/Display.php:201
+msgid "Update browser every xx seconds"
+msgstr "Actualitza el navegador cada xx segons"
+
+#: ../../Zotlabs/Module/Settings/Display.php:201
+msgid "Minimum of 10 seconds, no maximum"
+msgstr "Mínim de 10 segons, sense màxim"
+
+#: ../../Zotlabs/Module/Settings/Display.php:202
+msgid "Maximum number of conversations to load at any time:"
+msgstr "Nombre màxim de conversacions a càrregar cada vegada"
+
+#: ../../Zotlabs/Module/Settings/Display.php:202
+msgid "Maximum of 100 items"
+msgstr "Màxim de 100 elements"
+
+#: ../../Zotlabs/Module/Settings/Display.php:203
+msgid "Show emoticons (smilies) as images"
+msgstr "Mostra emoticons (smilies) com a imatges"
+
+#: ../../Zotlabs/Module/Settings/Display.php:204
+msgid "Provide channel menu in navigation bar"
+msgstr "Mostra el menú de canal a la barra de navegació"
+
+#: ../../Zotlabs/Module/Settings/Display.php:204
+msgid "Default: channel menu located in app menu"
+msgstr "Per defecte, el menú de canal es troba al menú d'aplicacions"
+
+#: ../../Zotlabs/Module/Settings/Display.php:205
+msgid "Manual conversation updates"
+msgstr "Actualitza les converses manualment"
+
+#: ../../Zotlabs/Module/Settings/Display.php:205
+msgid "Default is on, turning this off may increase screen jumping"
+msgstr "Per defecte està habilitada perquè evita que la pàgina salti cap avall en actualitzar-se."
+
+#: ../../Zotlabs/Module/Settings/Display.php:206
+msgid "Link post titles to source"
+msgstr "Enllaça a l'origen els títols de l'entrada"
+
+#: ../../Zotlabs/Module/Settings/Display.php:207
+msgid "System Page Layout Editor - (advanced)"
+msgstr "Editor de dissenys de pàgines de sistema (avançat)"
+
+#: ../../Zotlabs/Module/Settings/Display.php:210
+msgid "Use blog/list mode on channel page"
+msgstr "Empra el mode blog/llista a la pàgina del canal"
+
+#: ../../Zotlabs/Module/Settings/Display.php:210
+#: ../../Zotlabs/Module/Settings/Display.php:211
+msgid "(comments displayed separately)"
+msgstr "(Observacions es mostren per separat)"
+
+#: ../../Zotlabs/Module/Settings/Display.php:211
+msgid "Use blog/list mode on grid page"
+msgstr "Empra el mode de blog/llista a la pàgina de la malla"
+
+#: ../../Zotlabs/Module/Settings/Display.php:212
+msgid "Channel page max height of content (in pixels)"
+msgstr "Alçada màxima de contingut (en píxels) de la pàgina de Canal"
+
+#: ../../Zotlabs/Module/Settings/Display.php:212
+#: ../../Zotlabs/Module/Settings/Display.php:213
+msgid "click to expand content exceeding this height"
+msgstr "Clic per expandir el contingut que excedeixi aquesta alçada"
+
+#: ../../Zotlabs/Module/Settings/Display.php:213
+msgid "Grid page max height of content (in pixels)"
+msgstr "Alçada màxima dels continguts (en píxels) de la Pàgina de Malla "
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:34
+msgid "Name is required"
+msgstr "Es requereix un Nom"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:38
+msgid "Key and Secret are required"
+msgstr "Es requereix Clau (Key) i el Secret (Secret)"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:86
+#: ../../Zotlabs/Module/Settings/Oauth.php:112
+#: ../../Zotlabs/Module/Settings/Oauth.php:148
+msgid "Add application"
+msgstr "Afegir aplicatiu"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:89
+msgid "Name of application"
+msgstr "Nom de l'aplicatiu"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:90
+#: ../../Zotlabs/Module/Settings/Oauth.php:116
+#: ../../addon/statusnet/statusnet.php:894 ../../addon/twitter/twitter.php:781
+msgid "Consumer Key"
+msgstr "Consumer Key"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:90
+#: ../../Zotlabs/Module/Settings/Oauth.php:91
+msgid "Automatically generated - change if desired. Max length 20"
+msgstr "Generat automàticament- Canvia-ho si ho vols. Max. longitud 20"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:91
+#: ../../Zotlabs/Module/Settings/Oauth.php:117
+#: ../../addon/statusnet/statusnet.php:893 ../../addon/twitter/twitter.php:782
+msgid "Consumer Secret"
+msgstr "Consumer Secret"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:92
+#: ../../Zotlabs/Module/Settings/Oauth.php:118
+msgid "Redirect"
+msgstr "Redirecciona"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:92
+msgid ""
+"Redirect URI - leave blank unless your application specifically requires "
+"this"
+msgstr "URI redirigida - No canviar excepte perquè el teu aplicatiu ho requereixi."
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:93
+#: ../../Zotlabs/Module/Settings/Oauth.php:119
+msgid "Icon url"
+msgstr "Icona de url"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:93
+#: ../../Zotlabs/Module/Sources.php:112 ../../Zotlabs/Module/Sources.php:147
+msgid "Optional"
+msgstr "Opcional"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:104
+msgid "Application not found."
+msgstr "Aplicatiu no trobat."
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:147
+msgid "Connected Apps"
+msgstr "Aplicatius Conectats"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:151
+msgid "Client key starts with"
+msgstr "La clau del client comença amb"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:152
+msgid "No name"
+msgstr "Sin nombre"
+
+#: ../../Zotlabs/Module/Settings/Oauth.php:153
+msgid "Remove authorization"
+msgstr "Elimina autorització"
+
+#: ../../Zotlabs/Module/Embedphotos.php:140
+#: ../../Zotlabs/Module/Photos.php:811 ../../Zotlabs/Module/Photos.php:1350
+#: ../../Zotlabs/Widget/Portfolio.php:87 ../../Zotlabs/Widget/Album.php:78
+msgid "View Photo"
+msgstr "Mostra la imatge"
+
+#: ../../Zotlabs/Module/Embedphotos.php:156
+#: ../../Zotlabs/Module/Photos.php:842 ../../Zotlabs/Widget/Portfolio.php:108
+#: ../../Zotlabs/Widget/Album.php:95
+msgid "Edit Album"
+msgstr "Modifica l'àlbum"
+
+#: ../../Zotlabs/Module/Embedphotos.php:158
+#: ../../Zotlabs/Module/Photos.php:712 ../../Zotlabs/Module/Photos.php:844
+#: ../../Zotlabs/Module/Photos.php:1381
+#: ../../Zotlabs/Module/Profile_photo.php:458
+#: ../../Zotlabs/Module/Cover_photo.php:361
+#: ../../Zotlabs/Storage/Browser.php:277 ../../Zotlabs/Storage/Browser.php:384
+#: ../../Zotlabs/Widget/Cdav.php:133 ../../Zotlabs/Widget/Cdav.php:169
+#: ../../Zotlabs/Widget/Portfolio.php:110 ../../Zotlabs/Widget/Album.php:97
+msgid "Upload"
+msgstr "Pujar"
 
 #: ../../Zotlabs/Module/Achievements.php:38
 msgid "Some blurb about what to do when you're new here"
 msgstr "Algunes propostes sobre el que cal fer quan ets nou aquí"
 
-#: ../../Zotlabs/Module/Blocks.php:97 ../../Zotlabs/Module/Blocks.php:152
-#: ../../Zotlabs/Module/Editblock.php:108
-msgid "Block Name"
-msgstr "Nom del Bloc"
+#: ../../Zotlabs/Module/Thing.php:115
+msgid "Thing updated"
+msgstr "S'ha actualitzat la cosa"
 
-#: ../../Zotlabs/Module/Blocks.php:151 ../../include/text.php:2265
-msgid "Blocks"
-msgstr "Bloc"
+#: ../../Zotlabs/Module/Thing.php:167
+msgid "Object store: failed"
+msgstr "No s'ha pogut emmagatzemar l'objecte"
 
-#: ../../Zotlabs/Module/Blocks.php:153
-msgid "Block Title"
-msgstr "Títol del bloc"
+#: ../../Zotlabs/Module/Thing.php:171
+msgid "Thing added"
+msgstr "S'ha afegit la cosa"
 
-#: ../../Zotlabs/Module/Blocks.php:154 ../../Zotlabs/Module/Layouts.php:188
-#: ../../Zotlabs/Module/Menu.php:114 ../../Zotlabs/Module/Webpages.php:198
-#: ../../include/page_widgets.php:44
-msgid "Created"
-msgstr "Creat"
+#: ../../Zotlabs/Module/Thing.php:197
+#, php-format
+msgid "OBJ: %1$s %2$s %3$s"
+msgstr "OBJ: %1$s %2$s %3$s"
 
-#: ../../Zotlabs/Module/Blocks.php:155 ../../Zotlabs/Module/Layouts.php:189
-#: ../../Zotlabs/Module/Menu.php:115 ../../Zotlabs/Module/Webpages.php:199
-#: ../../include/page_widgets.php:45
-msgid "Edited"
-msgstr "Editat"
+#: ../../Zotlabs/Module/Thing.php:260
+msgid "Show Thing"
+msgstr "Mostra la cosa"
 
-#: ../../Zotlabs/Module/Blocks.php:158 ../../Zotlabs/Module/Layouts.php:191
-#: ../../Zotlabs/Module/Photos.php:1072 ../../Zotlabs/Module/Webpages.php:188
-#: ../../include/conversation.php:1208
-msgid "Share"
-msgstr "Compartir"
+#: ../../Zotlabs/Module/Thing.php:267
+msgid "item not found."
+msgstr "no s'ha trobat l'element."
 
-#: ../../Zotlabs/Module/Blocks.php:163 ../../Zotlabs/Module/Layouts.php:195
-#: ../../Zotlabs/Module/Pubsites.php:47 ../../Zotlabs/Module/Webpages.php:193
-#: ../../include/page_widgets.php:39
-msgid "View"
-msgstr "Mostra"
+#: ../../Zotlabs/Module/Thing.php:300
+msgid "Edit Thing"
+msgstr "Edita la cosa"
 
-#: ../../Zotlabs/Module/Cal.php:62 ../../Zotlabs/Module/Block.php:43
-#: ../../Zotlabs/Module/Page.php:56 ../../Zotlabs/Module/Wall_upload.php:33
-msgid "Channel not found."
-msgstr "Canal no trobat."
+#: ../../Zotlabs/Module/Thing.php:302 ../../Zotlabs/Module/Thing.php:359
+msgid "Select a profile"
+msgstr "Tria un perfil"
+
+#: ../../Zotlabs/Module/Thing.php:306 ../../Zotlabs/Module/Thing.php:362
+msgid "Post an activity"
+msgstr "Publica una activitat"
+
+#: ../../Zotlabs/Module/Thing.php:306 ../../Zotlabs/Module/Thing.php:362
+msgid "Only sends to viewers of the applicable profile"
+msgstr "S'envia només a visitants del perfil corresponent"
+
+#: ../../Zotlabs/Module/Thing.php:308 ../../Zotlabs/Module/Thing.php:364
+msgid "Name of thing e.g. something"
+msgstr "Nom de la cosa. Exemple: patata"
+
+#: ../../Zotlabs/Module/Thing.php:310 ../../Zotlabs/Module/Thing.php:365
+msgid "URL of thing (optional)"
+msgstr "Adreça URL de la cosa (opcional)"
+
+#: ../../Zotlabs/Module/Thing.php:312 ../../Zotlabs/Module/Thing.php:366
+msgid "URL for photo of thing (optional)"
+msgstr "Adreça URL de la foto d'una cosa (opcional)"
+
+#: ../../Zotlabs/Module/Thing.php:314 ../../Zotlabs/Module/Thing.php:367
+#: ../../Zotlabs/Module/Photos.php:702 ../../Zotlabs/Module/Photos.php:1071
+#: ../../Zotlabs/Module/Connedit.php:676 ../../Zotlabs/Module/Chat.php:235
+#: ../../Zotlabs/Module/Filestorage.php:147
+#: ../../include/acl_selectors.php:123
+msgid "Permissions"
+msgstr "Permisos "
+
+#: ../../Zotlabs/Module/Thing.php:357
+msgid "Add Thing to your Profile"
+msgstr "Afegeix una cosa al teu perfil"
+
+#: ../../Zotlabs/Module/Notify.php:61
+#: ../../Zotlabs/Module/Notifications.php:57
+msgid "No more system notifications."
+msgstr "No hi ha més notificacions del sistema."
+
+#: ../../Zotlabs/Module/Notify.php:65
+#: ../../Zotlabs/Module/Notifications.php:61
+msgid "System Notifications"
+msgstr "Notificacions del sistema"
+
+#: ../../Zotlabs/Module/Follow.php:31
+msgid "Channel added."
+msgstr "S'ha afegit el canal."
+
+#: ../../Zotlabs/Module/Import.php:143
+#, php-format
+msgid "Your service plan only allows %d channels."
+msgstr "El teu paquet de serveis només admet %d canals."
+
+#: ../../Zotlabs/Module/Import.php:157
+msgid "No channel. Import failed."
+msgstr "Sense canal. No s'ha pogut importar."
+
+#: ../../Zotlabs/Module/Import.php:481
+#: ../../addon/diaspora/import_diaspora.php:139
+msgid "Import completed."
+msgstr "S'ha completat la importació."
+
+#: ../../Zotlabs/Module/Import.php:509
+msgid "You must be logged in to use this feature."
+msgstr "Has d'estar registrat per fer servir aquesta funcionalitat."
+
+#: ../../Zotlabs/Module/Import.php:514
+msgid "Import Channel"
+msgstr "Importa un canal"
+
+#: ../../Zotlabs/Module/Import.php:515
+msgid ""
+"Use this form to import an existing channel from a different server/hub. You"
+" may retrieve the channel identity from the old server/hub via the network "
+"or provide an export file."
+msgstr "Empra aquest formulari per importar un canal existent en un altre servidor/concentrador. Pots recuperar el canal  des de l'antic servidor/concentrador via la xarxa o mitjançant un fitxer d'exportació"
+
+#: ../../Zotlabs/Module/Import.php:517
+msgid "Or provide the old server/hub details"
+msgstr "O proveeix els detalls de l'antic servidor/node"
+
+#: ../../Zotlabs/Module/Import.php:518
+msgid "Your old identity address (xyz@example.com)"
+msgstr "La teva adreça de canal antiga. El format és canal@exemple.org"
+
+#: ../../Zotlabs/Module/Import.php:519
+msgid "Your old login email address"
+msgstr "La teva adreça de correu electrònic antiga"
+
+#: ../../Zotlabs/Module/Import.php:520
+msgid "Your old login password"
+msgstr "La teva contrasenya antiga"
+
+#: ../../Zotlabs/Module/Import.php:521
+msgid ""
+"For either option, please choose whether to make this hub your new primary "
+"address, or whether your old location should continue this role. You will be"
+" able to post from either location, but only one can be marked as the "
+"primary location for files, photos, and media."
+msgstr "Per a qualsevol de les opcions, escull si vols fer primària l'adreça d'aquest node o mantenir l'anterior com a primària. Podràs penjar entrades des de totes dues adreces, però per als fitxers, imatges i altres en cal una de primària."
+
+#: ../../Zotlabs/Module/Import.php:522
+msgid "Make this hub my primary location"
+msgstr "Fes d'aquest node la meva ubicació primària"
+
+#: ../../Zotlabs/Module/Import.php:523
+msgid "Move this channel (disable all previous locations)"
+msgstr "Moure aquest canal (desactiva totes les prèvies localitzacions)"
+
+#: ../../Zotlabs/Module/Import.php:524
+msgid "Import a few months of posts if possible (limited by available memory"
+msgstr "Importa, si es possible, missatges de fa uns quants mesos (limitat per la memòria disponible) "
+
+#: ../../Zotlabs/Module/Import.php:525
+msgid ""
+"This process may take several minutes to complete. Please submit the form "
+"only once and leave this page open until finished."
+msgstr "Aquest procès pot trigar minuts en completar. Si et plau envia el formulari només una vegada i manté aquesta pàgina oberta fins que finalitzi."
+
+#: ../../Zotlabs/Module/Rmagic.php:35
+msgid "Authentication failed."
+msgstr "Ha fallat l'autentificació."
+
+#: ../../Zotlabs/Module/Rmagic.php:75 ../../boot.php:1583
+#: ../../include/channel.php:2307
+msgid "Remote Authentication"
+msgstr "Autentificació Remota"
+
+#: ../../Zotlabs/Module/Rmagic.php:76 ../../include/channel.php:2308
+msgid "Enter your channel address (e.g. channel@example.com)"
+msgstr "Introdueix la teva adreça del canal (eg canal@exemple.com)"
+
+#: ../../Zotlabs/Module/Rmagic.php:77 ../../include/channel.php:2309
+msgid "Authenticate"
+msgstr "Autentica't"
 
 #: ../../Zotlabs/Module/Cal.php:69
 msgid "Permissions denied."
 msgstr "Permís denegat."
 
-#: ../../Zotlabs/Module/Cal.php:259 ../../Zotlabs/Module/Events.php:588
-msgid "l, F j"
-msgstr "l, F j"
-
-#: ../../Zotlabs/Module/Cal.php:308 ../../Zotlabs/Module/Events.php:637
-#: ../../include/text.php:1732
-msgid "Link to Source"
-msgstr "Enllaç a la Font"
-
-#: ../../Zotlabs/Module/Cal.php:331 ../../Zotlabs/Module/Events.php:665
-msgid "Edit Event"
-msgstr "Editar l'Esdeveniment"
-
-#: ../../Zotlabs/Module/Cal.php:331 ../../Zotlabs/Module/Events.php:665
-msgid "Create Event"
-msgstr "Crear Esdeveniment"
-
-#: ../../Zotlabs/Module/Cal.php:332 ../../Zotlabs/Module/Cal.php:339
-#: ../../Zotlabs/Module/Events.php:666 ../../Zotlabs/Module/Events.php:673
-#: ../../Zotlabs/Module/Photos.php:949
-msgid "Previous"
-msgstr "Anterior"
-
-#: ../../Zotlabs/Module/Cal.php:333 ../../Zotlabs/Module/Cal.php:340
-#: ../../Zotlabs/Module/Events.php:667 ../../Zotlabs/Module/Events.php:674
-#: ../../Zotlabs/Module/Photos.php:958 ../../Zotlabs/Module/Setup.php:267
-msgid "Next"
-msgstr "Pròxim"
-
-#: ../../Zotlabs/Module/Cal.php:334 ../../Zotlabs/Module/Events.php:668
-#: ../../include/widgets.php:755
-msgid "Export"
-msgstr "Exporta"
-
-#: ../../Zotlabs/Module/Cal.php:337 ../../Zotlabs/Module/Events.php:671
-#: ../../include/widgets.php:756
+#: ../../Zotlabs/Module/Cal.php:344 ../../include/text.php:2426
 msgid "Import"
 msgstr "Importar"
 
-#: ../../Zotlabs/Module/Cal.php:338 ../../Zotlabs/Module/Chat.php:196
-#: ../../Zotlabs/Module/Chat.php:238 ../../Zotlabs/Module/Connect.php:98
-#: ../../Zotlabs/Module/Connedit.php:731 ../../Zotlabs/Module/Events.php:475
-#: ../../Zotlabs/Module/Events.php:672 ../../Zotlabs/Module/Group.php:85
-#: ../../Zotlabs/Module/Filestorage.php:162
-#: ../../Zotlabs/Module/Import.php:550
-#: ../../Zotlabs/Module/Import_items.php:120
-#: ../../Zotlabs/Module/Invite.php:146 ../../Zotlabs/Module/Locs.php:121
-#: ../../Zotlabs/Module/Mail.php:378 ../../Zotlabs/Module/Mood.php:139
-#: ../../Zotlabs/Module/Mitem.php:235 ../../Zotlabs/Module/Photos.php:677
-#: ../../Zotlabs/Module/Photos.php:1052 ../../Zotlabs/Module/Photos.php:1092
-#: ../../Zotlabs/Module/Photos.php:1210 ../../Zotlabs/Module/Pconfig.php:107
-#: ../../Zotlabs/Module/Pdledit.php:66 ../../Zotlabs/Module/Poke.php:186
-#: ../../Zotlabs/Module/Profiles.php:687 ../../Zotlabs/Module/Rate.php:170
-#: ../../Zotlabs/Module/Admin.php:492 ../../Zotlabs/Module/Admin.php:688
-#: ../../Zotlabs/Module/Admin.php:771 ../../Zotlabs/Module/Admin.php:1032
-#: ../../Zotlabs/Module/Admin.php:1211 ../../Zotlabs/Module/Admin.php:1421
-#: ../../Zotlabs/Module/Admin.php:1648 ../../Zotlabs/Module/Admin.php:1733
-#: ../../Zotlabs/Module/Admin.php:2116 ../../Zotlabs/Module/Appman.php:126
-#: ../../Zotlabs/Module/Settings.php:590 ../../Zotlabs/Module/Settings.php:703
-#: ../../Zotlabs/Module/Settings.php:731 ../../Zotlabs/Module/Settings.php:754
-#: ../../Zotlabs/Module/Settings.php:842
-#: ../../Zotlabs/Module/Settings.php:1034 ../../Zotlabs/Module/Setup.php:312
-#: ../../Zotlabs/Module/Setup.php:353 ../../Zotlabs/Module/Sources.php:114
-#: ../../Zotlabs/Module/Sources.php:149 ../../Zotlabs/Module/Thing.php:316
-#: ../../Zotlabs/Module/Thing.php:362 ../../Zotlabs/Module/Xchan.php:15
-#: ../../Zotlabs/Lib/ThreadItem.php:710 ../../include/widgets.php:757
-#: ../../include/widgets.php:769 ../../include/js_strings.php:22
-#: ../../view/theme/redbasic/php/config.php:99
-msgid "Submit"
-msgstr "Enviar"
+#: ../../Zotlabs/Module/Api.php:74 ../../Zotlabs/Module/Api.php:95
+msgid "Authorize application connection"
+msgstr "Autoritza la connexió de l'aplicació"
 
-#: ../../Zotlabs/Module/Cal.php:341 ../../Zotlabs/Module/Events.php:675
-msgid "Today"
-msgstr "Avui"
+#: ../../Zotlabs/Module/Api.php:75
+msgid "Return to your app and insert this Security Code:"
+msgstr "Torna a la teva aplicació i introdueix aquest codi de seguertat"
 
-#: ../../Zotlabs/Module/Channel.php:29 ../../Zotlabs/Module/Chat.php:25
-msgid "You must be logged in to see this page."
-msgstr "Has d'estar identificat per a veure aquesta pàgina."
+#: ../../Zotlabs/Module/Api.php:85
+msgid "Please login to continue."
+msgstr "Si et plau, identifica't per continuar."
 
-#: ../../Zotlabs/Module/Channel.php:41
-msgid "Posts and comments"
-msgstr "Entrades i comentaris"
+#: ../../Zotlabs/Module/Api.php:97
+msgid ""
+"Do you want to authorize this application to access your posts and contacts,"
+" and/or create new posts for you?"
+msgstr "Vols autoritzar a aquesta aplicació l'accés a les teves entrades i contactes i/o a crear noves entrades com si fos tu mateix."
 
-#: ../../Zotlabs/Module/Channel.php:42
-msgid "Only posts"
-msgstr "Només entrades"
+#: ../../Zotlabs/Module/Attach.php:13
+msgid "Item not available."
+msgstr "Article no disponible."
 
-#: ../../Zotlabs/Module/Channel.php:102
-msgid "Insufficient permissions.  Request redirected to profile page."
-msgstr "Permisos insuficients. Petició redirigida a la pàgina del perfil."
+#: ../../Zotlabs/Module/Editblock.php:138
+msgid "Edit Block"
+msgstr "Editar Bloc"
+
+#: ../../Zotlabs/Module/Profile.php:93
+msgid "vcard"
+msgstr "vcard (targeta estàndard de contacte)"
+
+#: ../../Zotlabs/Module/Apps.php:48 ../../Zotlabs/Lib/Apps.php:228
+msgid "Apps"
+msgstr "Aplicatius"
+
+#: ../../Zotlabs/Module/Apps.php:51
+msgid "Manage apps"
+msgstr "Gestiona apps"
+
+#: ../../Zotlabs/Module/Apps.php:52
+msgid "Create new app"
+msgstr "Crear una nova app"
+
+#: ../../Zotlabs/Module/Mood.php:67 ../../include/conversation.php:268
+#, php-format
+msgctxt "mood"
+msgid "%1$s is %2$s"
+msgstr "%1$s es %2$s"
+
+#: ../../Zotlabs/Module/Mood.php:135 ../../Zotlabs/Lib/Apps.php:253
+msgid "Mood"
+msgstr "Ànim"
+
+#: ../../Zotlabs/Module/Mood.php:136
+msgid "Set your current mood and tell your friends"
+msgstr "Estableix el teu estat d'ànim actual i digues-li als teus amics"
+
+#: ../../Zotlabs/Module/Connections.php:54
+#: ../../Zotlabs/Module/Connections.php:156
+#: ../../Zotlabs/Module/Connections.php:245
+msgid "Blocked"
+msgstr "Bloquejades"
+
+#: ../../Zotlabs/Module/Connections.php:59
+#: ../../Zotlabs/Module/Connections.php:163
+#: ../../Zotlabs/Module/Connections.php:244
+msgid "Ignored"
+msgstr "Ignorades"
+
+#: ../../Zotlabs/Module/Connections.php:64
+#: ../../Zotlabs/Module/Connections.php:177
+#: ../../Zotlabs/Module/Connections.php:243
+msgid "Hidden"
+msgstr "Amagades"
+
+#: ../../Zotlabs/Module/Connections.php:69
+#: ../../Zotlabs/Module/Connections.php:170
+msgid "Archived/Unreachable"
+msgstr "Arxivades o inaccessibles"
+
+#: ../../Zotlabs/Module/Connections.php:74
+#: ../../Zotlabs/Module/Connections.php:83 ../../Zotlabs/Module/Menu.php:116
+#: ../../Zotlabs/Module/Notifications.php:52
+#: ../../include/conversation.php:1714
+msgid "New"
+msgstr "Nou"
+
+#: ../../Zotlabs/Module/Connections.php:88
+#: ../../Zotlabs/Module/Connections.php:102
+#: ../../Zotlabs/Module/Connedit.php:713 ../../Zotlabs/Widget/Affinity.php:26
+msgid "All"
+msgstr "Tots"
+
+#: ../../Zotlabs/Module/Connections.php:133
+#: ../../Zotlabs/Widget/Notifications.php:84
+msgid "New Connections"
+msgstr "Noves Connexions"
+
+#: ../../Zotlabs/Module/Connections.php:136
+msgid "Show pending (new) connections"
+msgstr "Mostra les connexions pendents (noves)"
+
+#: ../../Zotlabs/Module/Connections.php:143
+msgid "Show all connections"
+msgstr "Mostra totes les connexions"
+
+#: ../../Zotlabs/Module/Connections.php:159
+msgid "Only show blocked connections"
+msgstr "Mostra només les connexions bloquejades"
+
+#: ../../Zotlabs/Module/Connections.php:166
+msgid "Only show ignored connections"
+msgstr "Mostra només les connexions ignorades"
+
+#: ../../Zotlabs/Module/Connections.php:173
+msgid "Only show archived/unreachable connections"
+msgstr "Mostra només les connexions arxivades o inaccessibles"
+
+#: ../../Zotlabs/Module/Connections.php:180
+msgid "Only show hidden connections"
+msgstr "Mostra només les connexions amagades"
+
+#: ../../Zotlabs/Module/Connections.php:241
+msgid "Pending approval"
+msgstr "Pendent d'aprovació"
+
+#: ../../Zotlabs/Module/Connections.php:242
+msgid "Archived"
+msgstr "Arxivades"
+
+#: ../../Zotlabs/Module/Connections.php:246
+msgid "Not connected at this location"
+msgstr "No està connectada des d'aquest aquest hub"
+
+#: ../../Zotlabs/Module/Connections.php:263
+#, php-format
+msgid "%1$s [%2$s]"
+msgstr "%1$s [%2$s]"
+
+#: ../../Zotlabs/Module/Connections.php:264
+msgid "Edit connection"
+msgstr "Modifica la connexió"
+
+#: ../../Zotlabs/Module/Connections.php:266
+msgid "Delete connection"
+msgstr "Elimina la connexió"
+
+#: ../../Zotlabs/Module/Connections.php:275
+msgid "Channel address"
+msgstr "Adreça del canal"
+
+#: ../../Zotlabs/Module/Connections.php:277
+msgid "Network"
+msgstr "Xarxa"
+
+#: ../../Zotlabs/Module/Connections.php:280
+msgid "Call"
+msgstr "Crida"
+
+#: ../../Zotlabs/Module/Connections.php:282
+msgid "Status"
+msgstr "Estat"
+
+#: ../../Zotlabs/Module/Connections.php:284
+msgid "Connected"
+msgstr "Connectat"
+
+#: ../../Zotlabs/Module/Connections.php:286
+msgid "Approve connection"
+msgstr "Aprovar la Connexió "
+
+#: ../../Zotlabs/Module/Connections.php:288
+msgid "Ignore connection"
+msgstr "Ignorar connexió"
+
+#: ../../Zotlabs/Module/Connections.php:289
+#: ../../Zotlabs/Module/Connedit.php:630
+msgid "Ignore"
+msgstr "Ignora"
+
+#: ../../Zotlabs/Module/Connections.php:290
+msgid "Recent activity"
+msgstr "Activitat recent"
+
+#: ../../Zotlabs/Module/Connections.php:315 ../../Zotlabs/Lib/Apps.php:235
+#: ../../include/text.php:973
+msgid "Connections"
+msgstr "Connexions"
+
+#: ../../Zotlabs/Module/Connections.php:320
+msgid "Search your connections"
+msgstr "Cerca entre les teves connexions"
+
+#: ../../Zotlabs/Module/Connections.php:321
+msgid "Connections search"
+msgstr "Cerca connexions"
+
+#: ../../Zotlabs/Module/Connections.php:322
+#: ../../Zotlabs/Module/Directory.php:396
+#: ../../Zotlabs/Module/Directory.php:401 ../../include/contact_widgets.php:23
+msgid "Find"
+msgstr "Troba"
+
+#: ../../Zotlabs/Module/Viewsrc.php:43
+msgid "item"
+msgstr "element"
+
+#: ../../Zotlabs/Module/Viewsrc.php:55
+msgid "Source of Item"
+msgstr "Origen de l'article"
+
+#: ../../Zotlabs/Module/Bookmarks.php:56
+msgid "Bookmark added"
+msgstr "Favorit afegit"
+
+#: ../../Zotlabs/Module/Bookmarks.php:79
+msgid "My Bookmarks"
+msgstr "Els Meus Favorits"
+
+#: ../../Zotlabs/Module/Bookmarks.php:90
+msgid "My Connections Bookmarks"
+msgstr "Les connexions dels meus Favorits"
+
+#: ../../Zotlabs/Module/Removeaccount.php:35
+msgid ""
+"Account removals are not allowed within 48 hours of changing the account "
+"password."
+msgstr "L'esborrat de comptes no està permès fins que transcorren 48 hores des de l'últim canvi de contrasenya."
+
+#: ../../Zotlabs/Module/Removeaccount.php:57
+msgid "Remove This Account"
+msgstr "Esborra el compte"
+
+#: ../../Zotlabs/Module/Removeaccount.php:58
+msgid ""
+"This account and all its channels will be completely removed from the "
+"network. "
+msgstr "Aquest compte i tots els seus canals s'estan apunt d'esborrar totalment de la xarxa."
+
+#: ../../Zotlabs/Module/Removeaccount.php:60
+msgid ""
+"Remove this account, all its channels and all its channel clones from the "
+"network"
+msgstr "Esborra de la xarxa aquest compte, tots els seus canals, i tots els seus canals clons."
+
+#: ../../Zotlabs/Module/Removeaccount.php:60
+msgid ""
+"By default only the instances of the channels located on this hub will be "
+"removed from the network"
+msgstr "Per defecte, només les instancies dels canal ubicats en aquest node poden esser esborrades  de la xarxa"
+
+#: ../../Zotlabs/Module/Photos.php:78
+msgid "Page owner information could not be retrieved."
+msgstr "La informació del propietari de la pàgina no va poder ser recuperada"
+
+#: ../../Zotlabs/Module/Photos.php:94 ../../Zotlabs/Module/Photos.php:120
+msgid "Album not found."
+msgstr "Àlbum no trobat"
+
+#: ../../Zotlabs/Module/Photos.php:103
+msgid "Delete Album"
+msgstr "Esborra Àlbum"
+
+#: ../../Zotlabs/Module/Photos.php:174 ../../Zotlabs/Module/Photos.php:1083
+msgid "Delete Photo"
+msgstr "Esborra Foto"
+
+#: ../../Zotlabs/Module/Photos.php:551
+msgid "No photos selected"
+msgstr "No has seleccionat fotos"
+
+#: ../../Zotlabs/Module/Photos.php:600
+msgid "Access to this item is restricted."
+msgstr "L'accés a aquest element esta restringit."
+
+#: ../../Zotlabs/Module/Photos.php:646
+#, php-format
+msgid "%1$.2f MB of %2$.2f MB photo storage used."
+msgstr "S'estan fent servir %1$.2f MB de %2$.2f MB de l'espai per a imatges."
+
+#: ../../Zotlabs/Module/Photos.php:649
+#, php-format
+msgid "%1$.2f MB photo storage used."
+msgstr "S'estan fent servir %1$.2f MB de l'espai per a imatges."
+
+#: ../../Zotlabs/Module/Photos.php:691
+msgid "Upload Photos"
+msgstr "Puja imatges"
+
+#: ../../Zotlabs/Module/Photos.php:695
+msgid "Enter an album name"
+msgstr "Escriu el nom del àlbum"
+
+#: ../../Zotlabs/Module/Photos.php:696
+msgid "or select an existing album (doubleclick)"
+msgstr "o bé fes doble clic a un d'existent"
+
+#: ../../Zotlabs/Module/Photos.php:697
+msgid "Create a status post for this upload"
+msgstr "Genera una entrada a partir de la pujada"
+
+#: ../../Zotlabs/Module/Photos.php:698
+msgid "Caption (optional):"
+msgstr "Subtítol (opcional):"
+
+#: ../../Zotlabs/Module/Photos.php:699
+msgid "Description (optional):"
+msgstr "Descripció (opcional):"
+
+#: ../../Zotlabs/Module/Photos.php:785
+msgid "Show Newest First"
+msgstr "Ordena de més nou a més antic"
+
+#: ../../Zotlabs/Module/Photos.php:787
+msgid "Show Oldest First"
+msgstr "Ordena de més antic a més nou"
+
+#: ../../Zotlabs/Module/Photos.php:892
+msgid "Permission denied. Access to this item may be restricted."
+msgstr "S'ha denegat el permís. Pot ser que l'accés estigui restringit."
+
+#: ../../Zotlabs/Module/Photos.php:894
+msgid "Photo not available"
+msgstr "La imatge no està disponible"
+
+#: ../../Zotlabs/Module/Photos.php:952
+msgid "Use as profile photo"
+msgstr "Fes-la imatge de perfil"
+
+#: ../../Zotlabs/Module/Photos.php:953
+msgid "Use as cover photo"
+msgstr "Emprar com a foto de portada"
+
+#: ../../Zotlabs/Module/Photos.php:960
+msgid "Private Photo"
+msgstr "Imatge privada"
+
+#: ../../Zotlabs/Module/Photos.php:975
+msgid "View Full Size"
+msgstr "Mostra a mida completa"
+
+#: ../../Zotlabs/Module/Photos.php:1057
+msgid "Edit photo"
+msgstr "Modifica la imatge"
+
+#: ../../Zotlabs/Module/Photos.php:1059
+msgid "Rotate CW (right)"
+msgstr "Tomba cap a la dreta"
+
+#: ../../Zotlabs/Module/Photos.php:1060
+msgid "Rotate CCW (left)"
+msgstr "Tomba cap a l'esquerra"
+
+#: ../../Zotlabs/Module/Photos.php:1063
+msgid "Move photo to album"
+msgstr "Mou la foto a un àlbum"
+
+#: ../../Zotlabs/Module/Photos.php:1064
+msgid "Enter a new album name"
+msgstr "Escriu el nom del nou àlbum"
+
+#: ../../Zotlabs/Module/Photos.php:1065
+msgid "or select an existing one (doubleclick)"
+msgstr "o bé fes doble clic a un d'existent"
+
+#: ../../Zotlabs/Module/Photos.php:1068
+msgid "Caption"
+msgstr "Llegenda"
+
+#: ../../Zotlabs/Module/Photos.php:1070
+msgid "Add a Tag"
+msgstr "Afegeix una etiqueta"
+
+#: ../../Zotlabs/Module/Photos.php:1078
+msgid "Example: @bob, @Barbara_Jensen, @jim@example.com"
+msgstr "Exemple: @joan, @Paula_Peris, @mar@exemple.org"
+
+#: ../../Zotlabs/Module/Photos.php:1081
+msgid "Flag as adult in album view"
+msgstr "Marca com a contingut adult"
+
+#: ../../Zotlabs/Module/Photos.php:1100 ../../Zotlabs/Lib/ThreadItem.php:281
+msgid "I like this (toggle)"
+msgstr "M'agrada això (canvia)"
+
+#: ../../Zotlabs/Module/Photos.php:1101 ../../Zotlabs/Lib/ThreadItem.php:282
+msgid "I don't like this (toggle)"
+msgstr "No m'agrada això (canvia)"
+
+#: ../../Zotlabs/Module/Photos.php:1103 ../../Zotlabs/Lib/ThreadItem.php:427
+#: ../../include/conversation.php:785
+msgid "Please wait"
+msgstr "Si us plau, espera"
+
+#: ../../Zotlabs/Module/Photos.php:1119 ../../Zotlabs/Module/Photos.php:1237
+#: ../../Zotlabs/Lib/ThreadItem.php:747
+msgid "This is you"
+msgstr "Ets tú"
+
+#: ../../Zotlabs/Module/Photos.php:1121 ../../Zotlabs/Module/Photos.php:1239
+#: ../../Zotlabs/Lib/ThreadItem.php:749 ../../include/js_strings.php:6
+msgid "Comment"
+msgstr "Comentari"
+
+#: ../../Zotlabs/Module/Photos.php:1137 ../../include/conversation.php:618
+msgctxt "title"
+msgid "Likes"
+msgstr "Agrada"
+
+#: ../../Zotlabs/Module/Photos.php:1137 ../../include/conversation.php:618
+msgctxt "title"
+msgid "Dislikes"
+msgstr "Desagrada"
+
+#: ../../Zotlabs/Module/Photos.php:1138 ../../include/conversation.php:619
+msgctxt "title"
+msgid "Agree"
+msgstr "Acord"
+
+#: ../../Zotlabs/Module/Photos.php:1138 ../../include/conversation.php:619
+msgctxt "title"
+msgid "Disagree"
+msgstr "Desacord"
+
+#: ../../Zotlabs/Module/Photos.php:1138 ../../include/conversation.php:619
+msgctxt "title"
+msgid "Abstain"
+msgstr "Abstenirse"
+
+#: ../../Zotlabs/Module/Photos.php:1139 ../../include/conversation.php:620
+msgctxt "title"
+msgid "Attending"
+msgstr "Assistint"
+
+#: ../../Zotlabs/Module/Photos.php:1139 ../../include/conversation.php:620
+msgctxt "title"
+msgid "Not attending"
+msgstr "Desassistint"
+
+#: ../../Zotlabs/Module/Photos.php:1139 ../../include/conversation.php:620
+msgctxt "title"
+msgid "Might attend"
+msgstr "Podrien assistir"
+
+#: ../../Zotlabs/Module/Photos.php:1156 ../../Zotlabs/Module/Photos.php:1168
+#: ../../Zotlabs/Lib/ThreadItem.php:201 ../../Zotlabs/Lib/ThreadItem.php:213
+msgid "View all"
+msgstr "Veure tot"
+
+#: ../../Zotlabs/Module/Photos.php:1160 ../../Zotlabs/Lib/ThreadItem.php:205
+#: ../../include/conversation.php:1978 ../../include/channel.php:1540
+#: ../../include/taxonomy.php:597
+msgctxt "noun"
+msgid "Like"
+msgid_plural "Likes"
+msgstr[0] "Agrada"
+msgstr[1] "Agraden"
+
+#: ../../Zotlabs/Module/Photos.php:1165 ../../Zotlabs/Lib/ThreadItem.php:210
+#: ../../include/conversation.php:1981
+msgctxt "noun"
+msgid "Dislike"
+msgid_plural "Dislikes"
+msgstr[0] "Desagrada"
+msgstr[1] "Desagrada"
+
+#: ../../Zotlabs/Module/Photos.php:1265
+msgid "Photo Tools"
+msgstr "Eines per Fotos"
+
+#: ../../Zotlabs/Module/Photos.php:1274
+msgid "In This Photo:"
+msgstr "Hi apareixen:"
+
+#: ../../Zotlabs/Module/Photos.php:1279
+msgid "Map"
+msgstr "Mapa"
+
+#: ../../Zotlabs/Module/Photos.php:1287 ../../Zotlabs/Lib/ThreadItem.php:415
+msgctxt "noun"
+msgid "Likes"
+msgstr "Agrada"
+
+#: ../../Zotlabs/Module/Photos.php:1288 ../../Zotlabs/Lib/ThreadItem.php:416
+msgctxt "noun"
+msgid "Dislikes"
+msgstr "Desagrada"
+
+#: ../../Zotlabs/Module/Photos.php:1293 ../../Zotlabs/Lib/ThreadItem.php:421
+#: ../../include/acl_selectors.php:125
+msgid "Close"
+msgstr "Tanca"
+
+#: ../../Zotlabs/Module/Photos.php:1365 ../../Zotlabs/Module/Photos.php:1378
+#: ../../Zotlabs/Module/Photos.php:1379 ../../include/photos.php:656
+msgid "Recent Photos"
+msgstr "Imatges recents"
+
+#: ../../Zotlabs/Module/Wiki.php:30
+msgid "Profile Unavailable."
+msgstr "El perfil no està disponible."
+
+#: ../../Zotlabs/Module/Wiki.php:44 ../../Zotlabs/Module/Cloud.php:108
+#: ../../addon/gitwiki/Mod_Gitwiki.php:42
+msgid "Not found"
+msgstr "No s'ha trobat"
+
+#: ../../Zotlabs/Module/Wiki.php:68 ../../addon/gitwiki/Mod_Gitwiki.php:62
+msgid "Invalid channel"
+msgstr "El canal és invàlid"
+
+#: ../../Zotlabs/Module/Wiki.php:124 ../../addon/gitwiki/Mod_Gitwiki.php:107
+msgid "Error retrieving wiki"
+msgstr "S'ha produït un error en carregar la wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:131 ../../addon/gitwiki/Mod_Gitwiki.php:114
+msgid "Error creating zip file export folder"
+msgstr "S'ha produït un error en crear la carpeta per al fitxer comprimit d'exportació"
+
+#: ../../Zotlabs/Module/Wiki.php:182 ../../addon/gitwiki/Mod_Gitwiki.php:132
+msgid "Error downloading wiki: "
+msgstr "S'ha produït un error en descarregar la wiki:"
+
+#: ../../Zotlabs/Module/Wiki.php:197 ../../addon/gitwiki/Mod_Gitwiki.php:146
+#: ../../include/conversation.php:1925 ../../include/nav.php:494
+msgid "Wikis"
+msgstr "Wikis"
+
+#: ../../Zotlabs/Module/Wiki.php:203 ../../addon/gitwiki/Mod_Gitwiki.php:152
+msgid "Download"
+msgstr "Descarrega"
+
+#: ../../Zotlabs/Module/Wiki.php:205 ../../Zotlabs/Module/Chat.php:256
+#: ../../Zotlabs/Module/Profiles.php:834 ../../Zotlabs/Module/Manage.php:145
+#: ../../addon/gitwiki/Mod_Gitwiki.php:154
+msgid "Create New"
+msgstr "Crear Nou"
+
+#: ../../Zotlabs/Module/Wiki.php:207 ../../addon/gitwiki/Mod_Gitwiki.php:156
+msgid "Wiki name"
+msgstr "Nom de la wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:208 ../../addon/gitwiki/Mod_Gitwiki.php:157
+msgid "Content type"
+msgstr "Llenguatge de formatació"
+
+#: ../../Zotlabs/Module/Wiki.php:208 ../../Zotlabs/Module/Wiki.php:348
+#: ../../Zotlabs/Widget/Wiki_pages.php:36
+#: ../../Zotlabs/Widget/Wiki_pages.php:93 ../../addon/mdpost/mdpost.php:40
+#: ../../include/text.php:1868
+msgid "Markdown"
+msgstr "Markdown"
+
+#: ../../Zotlabs/Module/Wiki.php:208 ../../Zotlabs/Module/Wiki.php:348
+#: ../../Zotlabs/Widget/Wiki_pages.php:36
+#: ../../Zotlabs/Widget/Wiki_pages.php:93 ../../include/text.php:1866
+msgid "BBcode"
+msgstr "BBCode"
+
+#: ../../Zotlabs/Module/Wiki.php:208 ../../Zotlabs/Widget/Wiki_pages.php:36
+#: ../../Zotlabs/Widget/Wiki_pages.php:93 ../../include/text.php:1869
+msgid "Text"
+msgstr "Cap (text pla)"
+
+#: ../../Zotlabs/Module/Wiki.php:210 ../../Zotlabs/Storage/Browser.php:284
+#: ../../addon/gitwiki/Mod_Gitwiki.php:159
+msgid "Type"
+msgstr "Tipus"
+
+#: ../../Zotlabs/Module/Wiki.php:211
+msgid "Any&nbsp;type"
+msgstr "Qualsevol"
+
+#: ../../Zotlabs/Module/Wiki.php:218
+msgid "Lock content type"
+msgstr "Bloca el llenguatge de formatació"
+
+#: ../../Zotlabs/Module/Wiki.php:219 ../../addon/gitwiki/Mod_Gitwiki.php:166
+msgid "Create a status post for this wiki"
+msgstr "Crea una entrada d'estat per aquesta wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:220
+msgid "Edit Wiki Name"
+msgstr "Canvia el nom de la wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:262 ../../addon/gitwiki/Mod_Gitwiki.php:185
+msgid "Wiki not found"
+msgstr "No s'ha trobat la wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:286 ../../addon/gitwiki/Mod_Gitwiki.php:210
+msgid "Rename page"
+msgstr "Canvia el nom de la pàgina"
+
+#: ../../Zotlabs/Module/Wiki.php:305 ../../addon/gitwiki/Mod_Gitwiki.php:214
+msgid "Error retrieving page content"
+msgstr "S'ha produït un error en carregar el contingut de la pàgina"
+
+#: ../../Zotlabs/Module/Wiki.php:313 ../../Zotlabs/Module/Wiki.php:315
+msgid "New page"
+msgstr "Crea una pàgina nova"
+
+#: ../../Zotlabs/Module/Wiki.php:343 ../../addon/gitwiki/Mod_Gitwiki.php:242
+msgid "Revision Comparison"
+msgstr "Comparació de revisió"
+
+#: ../../Zotlabs/Module/Wiki.php:344 ../../addon/gitwiki/Mod_Gitwiki.php:243
+msgid "Revert"
+msgstr "Reverteix"
+
+#: ../../Zotlabs/Module/Wiki.php:351
+msgid "Short description of your changes (optional)"
+msgstr "Descripció curta dels canvis (opcional)"
+
+#: ../../Zotlabs/Module/Wiki.php:358 ../../addon/gitwiki/Mod_Gitwiki.php:252
+msgid "Source"
+msgstr "Font"
+
+#: ../../Zotlabs/Module/Wiki.php:368 ../../addon/gitwiki/Mod_Gitwiki.php:260
+msgid "New page name"
+msgstr "Nou nom de pàgina"
+
+#: ../../Zotlabs/Module/Wiki.php:373 ../../addon/gitwiki/Mod_Gitwiki.php:265
+#: ../../include/conversation.php:1282
+msgid "Embed image from photo albums"
+msgstr "Embeu una imatge dels àlbums de fotos"
+
+#: ../../Zotlabs/Module/Wiki.php:374 ../../addon/gitwiki/Mod_Gitwiki.php:266
+#: ../../include/conversation.php:1385
+msgid "Embed an image from your albums"
+msgstr "Embeu una imatge dels teus àlbums"
+
+#: ../../Zotlabs/Module/Wiki.php:376
+#: ../../Zotlabs/Module/Profile_photo.php:465
+#: ../../Zotlabs/Module/Cover_photo.php:366
+#: ../../addon/gitwiki/Mod_Gitwiki.php:268 ../../include/conversation.php:1387
+#: ../../include/conversation.php:1434
+msgid "OK"
+msgstr "OK"
+
+#: ../../Zotlabs/Module/Wiki.php:377 ../../addon/gitwiki/Mod_Gitwiki.php:269
+#: ../../include/conversation.php:1318
+msgid "Choose images to embed"
+msgstr "Tria una imatge per a embeure-la"
+
+#: ../../Zotlabs/Module/Wiki.php:378 ../../addon/gitwiki/Mod_Gitwiki.php:270
+#: ../../include/conversation.php:1319
+msgid "Choose an album"
+msgstr "Tria un àlbum"
+
+#: ../../Zotlabs/Module/Wiki.php:379 ../../addon/gitwiki/Mod_Gitwiki.php:271
+msgid "Choose a different album"
+msgstr "Escull un àlbum diferent"
+
+#: ../../Zotlabs/Module/Wiki.php:380 ../../addon/gitwiki/Mod_Gitwiki.php:272
+#: ../../include/conversation.php:1321
+msgid "Error getting album list"
+msgstr "Ha ocorregut un error quan treia la llista de àlbums"
+
+#: ../../Zotlabs/Module/Wiki.php:381 ../../addon/gitwiki/Mod_Gitwiki.php:273
+#: ../../include/conversation.php:1322
+msgid "Error getting photo link"
+msgstr "Ha ocorregut un error quan treia l'enllaç a la foto"
+
+#: ../../Zotlabs/Module/Wiki.php:382 ../../addon/gitwiki/Mod_Gitwiki.php:274
+#: ../../include/conversation.php:1323
+msgid "Error getting album"
+msgstr "Ha ocorregut un error treient l'àlbum"
+
+#: ../../Zotlabs/Module/Wiki.php:458 ../../addon/gitwiki/Mod_Gitwiki.php:337
+msgid "Error creating wiki. Invalid name."
+msgstr "S'ha produït un error en crear la wiki. El nom no és vàlid."
+
+#: ../../Zotlabs/Module/Wiki.php:465
+msgid "A wiki with this name already exists."
+msgstr "Ja existeix una wiki amb aquest nom."
+
+#: ../../Zotlabs/Module/Wiki.php:478 ../../addon/gitwiki/Mod_Gitwiki.php:348
+msgid "Wiki created, but error creating Home page."
+msgstr "S'ha creat la wiki, però s'ha produït un error en crear-ne la pàgina principal."
+
+#: ../../Zotlabs/Module/Wiki.php:485 ../../addon/gitwiki/Mod_Gitwiki.php:353
+msgid "Error creating wiki"
+msgstr "S'ha produït un error en crear la wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:508
+msgid "Error updating wiki. Invalid name."
+msgstr "S'ha produït un error en actualitzar la wiki. El nom no és vàlid."
+
+#: ../../Zotlabs/Module/Wiki.php:528
+msgid "Error updating wiki"
+msgstr "S'ha produït un error en actualitzar la wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:543
+msgid "Wiki delete permission denied."
+msgstr "No tens permís per a eliminar la wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:553
+msgid "Error deleting wiki"
+msgstr "S'ha produït un error en eliminar la wiki"
+
+#: ../../Zotlabs/Module/Wiki.php:586 ../../addon/gitwiki/Mod_Gitwiki.php:400
+msgid "New page created"
+msgstr "S'ha desat la nova pàgina"
+
+#: ../../Zotlabs/Module/Wiki.php:707
+msgid "Cannot delete Home"
+msgstr "No es pot esborrar la pàgina principal"
+
+#: ../../Zotlabs/Module/Wiki.php:771
+msgid "Current Revision"
+msgstr "Revisió actual"
+
+#: ../../Zotlabs/Module/Wiki.php:771
+msgid "Selected Revision"
+msgstr "Revisió seleccionada"
+
+#: ../../Zotlabs/Module/Wiki.php:821
+msgid "You must be authenticated."
+msgstr "Has d'estar autenticat."
+
+#: ../../Zotlabs/Module/Chanview.php:139
+msgid "toggle full screen mode"
+msgstr "commuta el mode de pantalla completa"
+
+#: ../../Zotlabs/Module/Pdledit.php:21
+msgid "Layout updated."
+msgstr "S'ha actualitzat el disseny."
+
+#: ../../Zotlabs/Module/Pdledit.php:34 ../../Zotlabs/Module/Chat.php:219
+msgid "Feature disabled."
+msgstr "Funcionalitat desactivada."
+
+#: ../../Zotlabs/Module/Pdledit.php:47 ../../Zotlabs/Module/Pdledit.php:90
+msgid "Edit System Page Description"
+msgstr "Editor del Sistema de Descripció de Pàgines"
+
+#: ../../Zotlabs/Module/Pdledit.php:68
+msgid "(modified)"
+msgstr "(modificat)"
+
+#: ../../Zotlabs/Module/Pdledit.php:68 ../../Zotlabs/Module/Lostpass.php:133
+msgid "Reset"
+msgstr "Reajustar"
+
+#: ../../Zotlabs/Module/Pdledit.php:85
+msgid "Layout not found."
+msgstr "No s'ha trobat cap disseny de pàgina."
+
+#: ../../Zotlabs/Module/Pdledit.php:91
+msgid "Module Name:"
+msgstr "Nom del mòdul:"
+
+#: ../../Zotlabs/Module/Pdledit.php:92
+msgid "Layout Help"
+msgstr "Ajuda per al disseny de pàgina"
+
+#: ../../Zotlabs/Module/Pdledit.php:93
+msgid "Edit another layout"
+msgstr "Modifica un altre disseny"
+
+#: ../../Zotlabs/Module/Pdledit.php:94
+msgid "System layout"
+msgstr "Disseny del sistema"
+
+#: ../../Zotlabs/Module/Poke.php:182 ../../Zotlabs/Lib/Apps.php:254
+#: ../../include/conversation.php:1092
+msgid "Poke"
+msgstr "Esperonar"
+
+#: ../../Zotlabs/Module/Poke.php:183
+msgid "Poke somebody"
+msgstr "Emprenyar algú"
+
+#: ../../Zotlabs/Module/Poke.php:186
+msgid "Poke/Prod"
+msgstr "Esperonat/Picat"
+
+#: ../../Zotlabs/Module/Poke.php:187
+msgid "Poke, prod or do other things to somebody"
+msgstr "emprenyar, picar o fer altres coses a algú"
+
+#: ../../Zotlabs/Module/Poke.php:194
+msgid "Recipient"
+msgstr "Destinatari"
+
+#: ../../Zotlabs/Module/Poke.php:195
+msgid "Choose what you wish to do to recipient"
+msgstr "Tria que vols fer amb el destinatari"
+
+#: ../../Zotlabs/Module/Poke.php:198 ../../Zotlabs/Module/Poke.php:199
+msgid "Make this post private"
+msgstr "Fer aquesta entrada privada"
+
+#: ../../Zotlabs/Module/Profile_photo.php:66
+#: ../../Zotlabs/Module/Cover_photo.php:56
+msgid "Image uploaded but image cropping failed."
+msgstr "S'ha pujat la imatge però no s'ha pogut retallar."
+
+#: ../../Zotlabs/Module/Profile_photo.php:120
+#: ../../Zotlabs/Module/Profile_photo.php:248
+#: ../../include/photo/photo_driver.php:740
+msgid "Profile Photos"
+msgstr "Fotos del Perfil"
+
+#: ../../Zotlabs/Module/Profile_photo.php:142
+#: ../../Zotlabs/Module/Cover_photo.php:159
+msgid "Image resize failed."
+msgstr "No s'ha pogut escalar la imatge."
+
+#: ../../Zotlabs/Module/Profile_photo.php:218
+#: ../../addon/openclipatar/openclipatar.php:298
+msgid ""
+"Shift-reload the page or clear browser cache if the new photo does not "
+"display immediately."
+msgstr "Refresca la memòria cau del navegador si la foto no s'actualitza immediatament. Dreceres: «Ctrl+F5» i «Ctrl+Maj+R»"
+
+#: ../../Zotlabs/Module/Profile_photo.php:225
+#: ../../Zotlabs/Module/Cover_photo.php:173 ../../include/photos.php:195
+msgid "Unable to process image"
+msgstr "incapaç de processar la imatge"
+
+#: ../../Zotlabs/Module/Profile_photo.php:260
+#: ../../Zotlabs/Module/Cover_photo.php:197
+msgid "Image upload failed."
+msgstr "La pujada de la imatge va fracassar."
+
+#: ../../Zotlabs/Module/Profile_photo.php:279
+#: ../../Zotlabs/Module/Cover_photo.php:214
+msgid "Unable to process image."
+msgstr "Incapaç de processar l'imatge."
+
+#: ../../Zotlabs/Module/Profile_photo.php:343
+#: ../../Zotlabs/Module/Profile_photo.php:390
+#: ../../Zotlabs/Module/Cover_photo.php:307
+#: ../../Zotlabs/Module/Cover_photo.php:322
+msgid "Photo not available."
+msgstr "Foto no disponible."
+
+#: ../../Zotlabs/Module/Profile_photo.php:455
+#: ../../Zotlabs/Module/Cover_photo.php:358
+msgid "Upload File:"
+msgstr "Puja Arxiu:"
+
+#: ../../Zotlabs/Module/Profile_photo.php:456
+#: ../../Zotlabs/Module/Cover_photo.php:359
+msgid "Select a profile:"
+msgstr "Tria un perfil:"
+
+#: ../../Zotlabs/Module/Profile_photo.php:457
+msgid "Use Photo for Profile"
+msgstr "Fes servir la foto per al perfil"
+
+#: ../../Zotlabs/Module/Profile_photo.php:457
+msgid "Change Profile Photo"
+msgstr "Canvia la imatge de perfil"
+
+#: ../../Zotlabs/Module/Profile_photo.php:458
+msgid "Use"
+msgstr "Aplica"
+
+#: ../../Zotlabs/Module/Profile_photo.php:462
+#: ../../Zotlabs/Module/Profile_photo.php:463
+#: ../../Zotlabs/Module/Cover_photo.php:363
+#: ../../Zotlabs/Module/Cover_photo.php:364
+msgid "Use a photo from your albums"
+msgstr "Agafa una foto dels àlbums"
+
+#: ../../Zotlabs/Module/Profile_photo.php:467
+#: ../../Zotlabs/Module/Cover_photo.php:369
+msgid "Select existing photo"
+msgstr "Tria una foto existent"
+
+#: ../../Zotlabs/Module/Profile_photo.php:486
+#: ../../Zotlabs/Module/Cover_photo.php:386
+msgid "Crop Image"
+msgstr "Retalla Imatge"
+
+#: ../../Zotlabs/Module/Profile_photo.php:487
+#: ../../Zotlabs/Module/Cover_photo.php:387
+msgid "Please adjust the image cropping for optimum viewing."
+msgstr "Si us plau, retalla la imatge per a una optima visualització"
+
+#: ../../Zotlabs/Module/Profile_photo.php:489
+#: ../../Zotlabs/Module/Cover_photo.php:389
+msgid "Done Editing"
+msgstr "Edició Feta"
+
+#: ../../Zotlabs/Module/Chatsvc.php:131
+msgid "Away"
+msgstr "Absent"
+
+#: ../../Zotlabs/Module/Chatsvc.php:136
+msgid "Online"
+msgstr "En connexió"
+
+#: ../../Zotlabs/Module/Item.php:194
+msgid "Unable to locate original post."
+msgstr "No s'ha pogut trobar l'entrada original."
+
+#: ../../Zotlabs/Module/Item.php:476
+msgid "Empty post discarded."
+msgstr "S'ha descartat l'entrada perquè no té contingut."
+
+#: ../../Zotlabs/Module/Item.php:867
+msgid "Duplicate post suppressed."
+msgstr "Publicació duplicada s'ha suprimit."
+
+#: ../../Zotlabs/Module/Item.php:1012
+msgid "System error. Post not saved."
+msgstr "Hi ha hagut un error del sistema. L'entrada no s'ha desat."
+
+#: ../../Zotlabs/Module/Item.php:1048
+msgid "Your comment is awaiting approval."
+msgstr "El teu comentari encara no ha estat aprovat."
+
+#: ../../Zotlabs/Module/Item.php:1153
+msgid "Unable to obtain post information from database."
+msgstr "No s'ha pogut obtenir informació de l'entrada a la base de dades."
+
+#: ../../Zotlabs/Module/Item.php:1182
+#, php-format
+msgid "You have reached your limit of %1$.0f top level posts."
+msgstr "Has assolit el teu límit de %1$.0f entrades (descomptant comentaris)."
+
+#: ../../Zotlabs/Module/Item.php:1189
+#, php-format
+msgid "You have reached your limit of %1$.0f webpages."
+msgstr "Has assolit el teu limit de %1$.0f pàgines web."
+
+#: ../../Zotlabs/Module/Ping.php:320
+msgid "sent you a private message"
+msgstr "Se t'ha enviat un missatge privat"
+
+#: ../../Zotlabs/Module/Ping.php:372
+msgid "added your channel"
+msgstr "el teu canal s'ha afegit"
+
+#: ../../Zotlabs/Module/Ping.php:396
+msgid "requires approval"
+msgstr "requereix aprovació"
+
+#: ../../Zotlabs/Module/Ping.php:406
+msgid "g A l F d"
+msgstr "g A l F d"
+
+#: ../../Zotlabs/Module/Ping.php:424
+msgid "[today]"
+msgstr "[avui]"
+
+#: ../../Zotlabs/Module/Ping.php:433
+msgid "posted an event"
+msgstr "enviat un esdeveniment"
+
+#: ../../Zotlabs/Module/Ping.php:466
+msgid "shared a file with you"
+msgstr "ha compartit un fitxer amb tu"
+
+#: ../../Zotlabs/Module/Page.php:39 ../../Zotlabs/Module/Block.php:29
+msgid "Invalid item."
+msgstr "Article invàlid."
+
+#: ../../Zotlabs/Module/Page.php:136 ../../Zotlabs/Module/Block.php:77
+#: ../../Zotlabs/Module/Display.php:133
+#: ../../Zotlabs/Lib/NativeWikiPage.php:519 ../../Zotlabs/Web/Router.php:167
+#: ../../include/help.php:81
+msgid "Page not found."
+msgstr "Pàgina no trobada."
+
+#: ../../Zotlabs/Module/Page.php:173
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
+"tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,"
+" quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo "
+"consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse "
+"cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat "
+"non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+msgstr "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+#: ../../Zotlabs/Module/Connedit.php:79 ../../Zotlabs/Module/Defperms.php:59
+msgid "Could not access contact record."
+msgstr "No s'ha pogut accedir al llibre de contactes."
+
+#: ../../Zotlabs/Module/Connedit.php:109
+msgid "Could not locate selected profile."
+msgstr "No s'ha trobat el perfil indicat."
+
+#: ../../Zotlabs/Module/Connedit.php:246
+msgid "Connection updated."
+msgstr "S'ha actualitzat la connexió."
+
+#: ../../Zotlabs/Module/Connedit.php:248
+msgid "Failed to update connection record."
+msgstr "No s'ha pogut actualitzar el registre de connexió."
+
+#: ../../Zotlabs/Module/Connedit.php:302
+msgid "is now connected to"
+msgstr "Ara està conectat amb"
+
+#: ../../Zotlabs/Module/Connedit.php:427
+msgid "Could not access address book record."
+msgstr "No puc accedir al registre del contacte"
+
+#: ../../Zotlabs/Module/Connedit.php:475
+msgid "Refresh failed - channel is currently unavailable."
+msgstr "Ha fallat la recàrrega - el canal es actualment inaccesible."
+
+#: ../../Zotlabs/Module/Connedit.php:490 ../../Zotlabs/Module/Connedit.php:499
+#: ../../Zotlabs/Module/Connedit.php:508 ../../Zotlabs/Module/Connedit.php:517
+#: ../../Zotlabs/Module/Connedit.php:530
+msgid "Unable to set address book parameters."
+msgstr "No es poden ajustar els paràmetres dels contactes."
+
+#: ../../Zotlabs/Module/Connedit.php:554
+msgid "Connection has been removed."
+msgstr "S'han eliminat les conexions."
+
+#: ../../Zotlabs/Module/Connedit.php:594 ../../Zotlabs/Lib/Apps.php:247
+#: ../../addon/openclipatar/openclipatar.php:57
+#: ../../include/conversation.php:1032 ../../include/nav.php:114
+msgid "View Profile"
+msgstr "Veure Perfil"
+
+#: ../../Zotlabs/Module/Connedit.php:597
+#, php-format
+msgid "View %s's profile"
+msgstr "Mostra el perfil de %s"
+
+#: ../../Zotlabs/Module/Connedit.php:601
+msgid "Refresh Permissions"
+msgstr "Recarrega els Permissos"
+
+#: ../../Zotlabs/Module/Connedit.php:604
+msgid "Fetch updated permissions"
+msgstr "Obté els permisos actualitzats"
+
+#: ../../Zotlabs/Module/Connedit.php:608
+msgid "Refresh Photo"
+msgstr "Recarrega la foto"
+
+#: ../../Zotlabs/Module/Connedit.php:611
+msgid "Fetch updated photo"
+msgstr "Demana la nova foto al servidor"
+
+#: ../../Zotlabs/Module/Connedit.php:615
+msgid "Recent Activity"
+msgstr "Activitat Recent"
+
+#: ../../Zotlabs/Module/Connedit.php:618
+msgid "View recent posts and comments"
+msgstr "Mostra les entrades i comentaris recents"
+
+#: ../../Zotlabs/Module/Connedit.php:625
+msgid "Block (or Unblock) all communications with this connection"
+msgstr "Boqueja (o Desbloqueja) les comunicacions amb aquesta connexió"
+
+#: ../../Zotlabs/Module/Connedit.php:626
+msgid "This connection is blocked!"
+msgstr "Aquesta connexió està bloquejada!"
+
+#: ../../Zotlabs/Module/Connedit.php:630
+msgid "Unignore"
+msgstr "Inhabilita"
+
+#: ../../Zotlabs/Module/Connedit.php:633
+msgid "Ignore (or Unignore) all inbound communications from this connection"
+msgstr "Ignora (o Considera) les communicacions entrants d'aquesta connexió"
+
+#: ../../Zotlabs/Module/Connedit.php:634
+msgid "This connection is ignored!"
+msgstr "Aquesta connexió es ignorada!"
+
+#: ../../Zotlabs/Module/Connedit.php:638
+msgid "Unarchive"
+msgstr "Desarxiva"
+
+#: ../../Zotlabs/Module/Connedit.php:638
+msgid "Archive"
+msgstr "Arxiva"
+
+#: ../../Zotlabs/Module/Connedit.php:641
+msgid ""
+"Archive (or Unarchive) this connection - mark channel dead but keep content"
+msgstr "Arxiva (o Desarxiva) aquesta connexió - Marca el canal com a mort pero manté el contingut "
+
+#: ../../Zotlabs/Module/Connedit.php:642
+msgid "This connection is archived!"
+msgstr "Aquesta connexió està arxivada!"
+
+#: ../../Zotlabs/Module/Connedit.php:646
+msgid "Unhide"
+msgstr "Mostra"
+
+#: ../../Zotlabs/Module/Connedit.php:646
+msgid "Hide"
+msgstr "Amaga"
+
+#: ../../Zotlabs/Module/Connedit.php:649
+msgid "Hide or Unhide this connection from your other connections"
+msgstr "Amaga (o Mostra) aquesta connexió de les altres connexions teves"
+
+#: ../../Zotlabs/Module/Connedit.php:650
+msgid "This connection is hidden!"
+msgstr "Aquesta connexió està amagada!"
+
+#: ../../Zotlabs/Module/Connedit.php:657
+msgid "Delete this connection"
+msgstr "Elimina aquesta connexió"
+
+#: ../../Zotlabs/Module/Connedit.php:665
+msgid "Fetch Vcard"
+msgstr "Obté la targeta de contacte Vcard"
+
+#: ../../Zotlabs/Module/Connedit.php:668
+msgid "Fetch electronic calling card for this connection"
+msgstr "Obté la targeta de trucada electrònica d'aquesta connexió"
+
+#: ../../Zotlabs/Module/Connedit.php:679
+msgid "Open Individual Permissions section by default"
+msgstr "Obrir, per defecte,  la secció de Permisos Individuals"
+
+#: ../../Zotlabs/Module/Connedit.php:702
+msgid "Affinity"
+msgstr "Afinitat"
+
+#: ../../Zotlabs/Module/Connedit.php:705
+msgid "Open Set Affinity section by default"
+msgstr "Obrir, per defecte, la secció d'Ajustos d'Afinitat"
+
+#: ../../Zotlabs/Module/Connedit.php:709 ../../Zotlabs/Widget/Affinity.php:22
+msgid "Me"
+msgstr "Jo"
+
+#: ../../Zotlabs/Module/Connedit.php:710 ../../Zotlabs/Widget/Affinity.php:23
+msgid "Family"
+msgstr "Família"
+
+#: ../../Zotlabs/Module/Connedit.php:712 ../../Zotlabs/Widget/Affinity.php:25
+msgid "Acquaintances"
+msgstr "Coneguts"
+
+#: ../../Zotlabs/Module/Connedit.php:739
+msgid "Filter"
+msgstr "Filtre"
+
+#: ../../Zotlabs/Module/Connedit.php:742
+msgid "Open Custom Filter section by default"
+msgstr "Obrir, per defecte, la secció de Filtres a Mida"
+
+#: ../../Zotlabs/Module/Connedit.php:779
+msgid "Approve this connection"
+msgstr "Apccepta aquesta connexió"
+
+#: ../../Zotlabs/Module/Connedit.php:779
+msgid "Accept connection to allow communication"
+msgstr "Accepta la connexió per permetre la comunicació"
+
+#: ../../Zotlabs/Module/Connedit.php:784
+msgid "Set Affinity"
+msgstr "Ajusta l'Afinitat"
+
+#: ../../Zotlabs/Module/Connedit.php:787
+msgid "Set Profile"
+msgstr "Ajusta el Perfil"
+
+#: ../../Zotlabs/Module/Connedit.php:790
+msgid "Set Affinity & Profile"
+msgstr "Ajusta Afinitat i Perfil"
+
+#: ../../Zotlabs/Module/Connedit.php:838
+msgid "This connection is unreachable from this location."
+msgstr "Aquesta connexió no és accessible des d'aquest hub."
+
+#: ../../Zotlabs/Module/Connedit.php:839
+msgid "This connection may be unreachable from other channel locations."
+msgstr "Aquesta connexió no és accessibles des d'altres hubs del canal."
+
+#: ../../Zotlabs/Module/Connedit.php:841
+msgid "Location independence is not supported by their network."
+msgstr "La xarxa d'aquesta connexió no és compatible amb la independència de hub."
+
+#: ../../Zotlabs/Module/Connedit.php:847
+msgid ""
+"This connection is unreachable from this location. Location independence is "
+"not supported by their network."
+msgstr "Aquesta connexió no és accessible des d'aquest hub. La seva xarxa no és compatible amb la independència de hub."
+
+#: ../../Zotlabs/Module/Connedit.php:850 ../../Zotlabs/Module/Defperms.php:238
+#: ../../Zotlabs/Widget/Settings_menu.php:109
+msgid "Connection Default Permissions"
+msgstr "Permisos per Defecte de la Connexió"
+
+#: ../../Zotlabs/Module/Connedit.php:850 ../../include/items.php:4164
+#, php-format
+msgid "Connection: %s"
+msgstr "Connexió: %s"
+
+#: ../../Zotlabs/Module/Connedit.php:851 ../../Zotlabs/Module/Defperms.php:239
+msgid "Apply these permissions automatically"
+msgstr "Aplica aquests permissos automaticament"
+
+#: ../../Zotlabs/Module/Connedit.php:851
+msgid "Connection requests will be approved without your interaction"
+msgstr "Les peticions de connexió seran aprovades sense la teva interacció"
+
+#: ../../Zotlabs/Module/Connedit.php:852 ../../Zotlabs/Module/Defperms.php:240
+msgid "Permission role"
+msgstr "Permisos de rol"
+
+#: ../../Zotlabs/Module/Connedit.php:852 ../../Zotlabs/Module/Defperms.php:240
+#: ../../Zotlabs/Widget/Notifications.php:151 ../../include/nav.php:284
+msgid "Loading"
+msgstr "S'està carregant"
+
+#: ../../Zotlabs/Module/Connedit.php:853 ../../Zotlabs/Module/Defperms.php:241
+msgid "Add permission role"
+msgstr "Afegir permisos de rol"
+
+#: ../../Zotlabs/Module/Connedit.php:860
+msgid "This connection's primary address is"
+msgstr "La primera adreça d'aqueste connexió es"
+
+#: ../../Zotlabs/Module/Connedit.php:861
+msgid "Available locations:"
+msgstr "Localització disponible:"
+
+#: ../../Zotlabs/Module/Connedit.php:866 ../../Zotlabs/Module/Defperms.php:245
+msgid ""
+"The permissions indicated on this page will be applied to all new "
+"connections."
+msgstr "Els permisos indicats en aquesta pàgina seran aplicats a totes les noves connexions."
+
+#: ../../Zotlabs/Module/Connedit.php:867
+msgid "Connection Tools"
+msgstr "Eines de Connexió"
+
+#: ../../Zotlabs/Module/Connedit.php:869
+msgid "Slide to adjust your degree of friendship"
+msgstr "Llisca per ajustar el nivell d'amistat"
+
+#: ../../Zotlabs/Module/Connedit.php:870 ../../Zotlabs/Module/Rate.php:155
+#: ../../include/js_strings.php:20
+msgid "Rating"
+msgstr "Valora"
+
+#: ../../Zotlabs/Module/Connedit.php:871
+msgid "Slide to adjust your rating"
+msgstr "Llisca per ajustar la valoració"
+
+#: ../../Zotlabs/Module/Connedit.php:872 ../../Zotlabs/Module/Connedit.php:877
+msgid "Optionally explain your rating"
+msgstr "Opcionalment pots explicar la teva valoració"
+
+#: ../../Zotlabs/Module/Connedit.php:874
+msgid "Custom Filter"
+msgstr "Filtre a mida"
+
+#: ../../Zotlabs/Module/Connedit.php:875
+msgid "Only import posts with this text"
+msgstr "Importa exclusivament entrades amb aquest text"
+
+#: ../../Zotlabs/Module/Connedit.php:875 ../../Zotlabs/Module/Connedit.php:876
+msgid ""
+"words one per line or #tags or /patterns/ or lang=xx, leave blank to import "
+"all posts"
+msgstr "paraules una per línia o #etiquetes o /patrons/ o idioma=xx, deixar en blanc per importar totes les entrades"
+
+#: ../../Zotlabs/Module/Connedit.php:876
+msgid "Do not import posts with this text"
+msgstr "No importar entrades amb aquest text"
+
+#: ../../Zotlabs/Module/Connedit.php:878
+msgid "This information is public!"
+msgstr "Aquesta informació es pública!"
+
+#: ../../Zotlabs/Module/Connedit.php:883
+msgid "Connection Pending Approval"
+msgstr "Connexió Pendent d'Aprovació"
+
+#: ../../Zotlabs/Module/Connedit.php:888
+#, php-format
+msgid ""
+"Please choose the profile you would like to display to %s when viewing your "
+"profile securely."
+msgstr "Tria el perfil que vols mostrar a %s quan es vegi el perfil segur."
+
+#: ../../Zotlabs/Module/Connedit.php:895
+msgid ""
+"Some permissions may be inherited from your channel's <a "
+"href=\"settings\"><strong>privacy settings</strong></a>, which have higher "
+"priority than individual settings. You can change those settings here but "
+"they wont have any impact unless the inherited setting changes."
+msgstr "Alguns permisos poden ser heretats dels teus canals <a href=\"settings\"><strong>ajustos de privacitat</strong></a>, Els quals tenen més prioritat que els ajustos individuals. <strong>Pots</strong> canviar aquests ajustos aquí pero no tindran cap impacte fins que no canviis els ajustos heretats."
+
+#: ../../Zotlabs/Module/Connedit.php:896
+msgid "Last update:"
+msgstr "Darrera actualització:"
+
+#: ../../Zotlabs/Module/Connedit.php:904
+msgid "Details"
+msgstr "Detalls"
 
 #: ../../Zotlabs/Module/Chat.php:181
 msgid "Room not found"
@@ -426,26 +5716,16 @@ msgstr "Estic connectat/da"
 msgid "Bookmark this room"
 msgstr "Fes favorit aquest xat"
 
-#: ../../Zotlabs/Module/Chat.php:205 ../../Zotlabs/Module/Mail.php:205
-#: ../../Zotlabs/Module/Mail.php:314 ../../include/conversation.php:1176
+#: ../../Zotlabs/Module/Chat.php:205 ../../Zotlabs/Module/Mail.php:241
+#: ../../Zotlabs/Module/Mail.php:362 ../../include/conversation.php:1313
 msgid "Please enter a link URL:"
 msgstr "Si us plau entra l'enllaç URL:"
 
-#: ../../Zotlabs/Module/Chat.php:206 ../../Zotlabs/Module/Mail.php:258
-#: ../../Zotlabs/Module/Mail.php:383 ../../Zotlabs/Lib/ThreadItem.php:722
-#: ../../include/conversation.php:1256
+#: ../../Zotlabs/Module/Chat.php:206 ../../Zotlabs/Module/Mail.php:294
+#: ../../Zotlabs/Module/Mail.php:436 ../../Zotlabs/Lib/ThreadItem.php:764
+#: ../../include/conversation.php:1432
 msgid "Encrypt text"
 msgstr "Text encriptat"
-
-#: ../../Zotlabs/Module/Chat.php:207 ../../Zotlabs/Module/Editblock.php:111
-#: ../../Zotlabs/Module/Editwebpage.php:147 ../../Zotlabs/Module/Mail.php:252
-#: ../../Zotlabs/Module/Mail.php:377 ../../include/conversation.php:1143
-msgid "Insert web link"
-msgstr "Insereix enllaç web"
-
-#: ../../Zotlabs/Module/Chat.php:218
-msgid "Feature disabled."
-msgstr "Funcionalitat desactivada."
 
 #: ../../Zotlabs/Module/Chat.php:232
 msgid "New Chatroom"
@@ -459,2008 +5739,33 @@ msgstr "Nom de la sala de xat"
 msgid "Expiration of chats (minutes)"
 msgstr "Expiració dels chats (minuts)"
 
-#: ../../Zotlabs/Module/Chat.php:235 ../../Zotlabs/Module/Filestorage.php:153
-#: ../../Zotlabs/Module/Photos.php:671 ../../Zotlabs/Module/Photos.php:1045
-#: ../../Zotlabs/Module/Thing.php:313 ../../Zotlabs/Module/Thing.php:359
-#: ../../include/acl_selectors.php:283
-msgid "Permissions"
-msgstr "Permisos "
-
-#: ../../Zotlabs/Module/Chat.php:246
+#: ../../Zotlabs/Module/Chat.php:250
 #, php-format
 msgid "%1$s's Chatrooms"
 msgstr "%1$s de Xats"
 
-#: ../../Zotlabs/Module/Chat.php:251
+#: ../../Zotlabs/Module/Chat.php:255
 msgid "No chatrooms available"
 msgstr "No hi ha sales de xat disponibles"
 
-#: ../../Zotlabs/Module/Chat.php:252 ../../Zotlabs/Module/Manage.php:143
-#: ../../Zotlabs/Module/Profiles.php:778
-msgid "Create New"
-msgstr "Crear Nou"
-
-#: ../../Zotlabs/Module/Chat.php:255
+#: ../../Zotlabs/Module/Chat.php:259
 msgid "Expiration"
 msgstr "Expiració"
 
-#: ../../Zotlabs/Module/Chat.php:256
+#: ../../Zotlabs/Module/Chat.php:260
 msgid "min"
 msgstr "min"
 
-#: ../../Zotlabs/Module/Chatsvc.php:117
-msgid "Away"
-msgstr "Absent"
-
-#: ../../Zotlabs/Module/Chatsvc.php:122
-msgid "Online"
-msgstr "En connexió"
-
-#: ../../Zotlabs/Module/Block.php:31 ../../Zotlabs/Module/Page.php:40
-msgid "Invalid item."
-msgstr "Article invàlid."
-
-#: ../../Zotlabs/Module/Bookmarks.php:53
-msgid "Bookmark added"
-msgstr "Favorit afegit"
-
-#: ../../Zotlabs/Module/Bookmarks.php:75
-msgid "My Bookmarks"
-msgstr "Els Meus Favorits"
-
-#: ../../Zotlabs/Module/Bookmarks.php:86
-msgid "My Connections Bookmarks"
-msgstr "Les connexions dels meus Favorits"
-
-#: ../../Zotlabs/Module/Connect.php:61 ../../Zotlabs/Module/Connect.php:109
-msgid "Continue"
-msgstr "Continua"
-
-#: ../../Zotlabs/Module/Connect.php:90
-msgid "Premium Channel Setup"
-msgstr "Configuració de Canals Premium"
-
-#: ../../Zotlabs/Module/Connect.php:92
-msgid "Enable premium channel connection restrictions"
-msgstr "Habilita les restriccions de connexió del canal premium"
-
-#: ../../Zotlabs/Module/Connect.php:93
-msgid ""
-"Please enter your restrictions or conditions, such as paypal receipt, usage "
-"guidelines, etc."
-msgstr "Si us plau, introdueixi les restriccions o condicions, com ara el rebut de PayPal, les pautes d'ús, etc."
-
-#: ../../Zotlabs/Module/Connect.php:95 ../../Zotlabs/Module/Connect.php:115
-msgid ""
-"This channel may require additional steps or acknowledgement of the "
-"following conditions prior to connecting:"
-msgstr "Aquest canal pot requerir passos addicionals o reconeixement de les següents condicions abans de connectar:"
-
-#: ../../Zotlabs/Module/Connect.php:96
-msgid ""
-"Potential connections will then see the following text before proceeding:"
-msgstr "Connexions potencials veuran el següent text abans de continuar:"
-
-#: ../../Zotlabs/Module/Connect.php:97 ../../Zotlabs/Module/Connect.php:118
-msgid ""
-"By continuing, I certify that I have complied with any instructions provided"
-" on this page."
-msgstr "En continuar, certifico que he complert amb totes les instruccions proporcionades en aquesta pàgina."
-
-#: ../../Zotlabs/Module/Connect.php:106
-msgid "(No specific instructions have been provided by the channel owner.)"
-msgstr "(No s'han proporcionat instruccions específiques pel propietari del canal.)"
-
-#: ../../Zotlabs/Module/Connect.php:114
-msgid "Restricted or Premium Channel"
-msgstr "Canal Restringit o Premium"
-
-#: ../../Zotlabs/Module/Connedit.php:80
-msgid "Could not access contact record."
-msgstr "No s'ha pogut accedir al llibre de contactes."
-
-#: ../../Zotlabs/Module/Connedit.php:104
-msgid "Could not locate selected profile."
-msgstr "No s'ha trobat el perfil indicat."
-
-#: ../../Zotlabs/Module/Connedit.php:227
-msgid "Connection updated."
-msgstr "S'ha actualitzat la connexió."
-
-#: ../../Zotlabs/Module/Connedit.php:229
-msgid "Failed to update connection record."
-msgstr "No s'ha pogut actualitzar el registre de connexió."
-
-#: ../../Zotlabs/Module/Connedit.php:276
-msgid "is now connected to"
-msgstr "Ara està conectat amb"
-
-#: ../../Zotlabs/Module/Connedit.php:379 ../../Zotlabs/Module/Connedit.php:654
-#: ../../Zotlabs/Module/Events.php:459 ../../Zotlabs/Module/Events.php:460
-#: ../../Zotlabs/Module/Events.php:469 ../../Zotlabs/Module/Api.php:89
-#: ../../Zotlabs/Module/Filestorage.php:157
-#: ../../Zotlabs/Module/Filestorage.php:165 ../../Zotlabs/Module/Menu.php:100
-#: ../../Zotlabs/Module/Menu.php:157 ../../Zotlabs/Module/Mitem.php:158
-#: ../../Zotlabs/Module/Mitem.php:159 ../../Zotlabs/Module/Mitem.php:232
-#: ../../Zotlabs/Module/Mitem.php:233 ../../Zotlabs/Module/Photos.php:666
-#: ../../Zotlabs/Module/Profiles.php:647 ../../Zotlabs/Module/Admin.php:459
-#: ../../Zotlabs/Module/Removeme.php:61 ../../Zotlabs/Module/Settings.php:581
-#: ../../include/dir_fns.php:143 ../../include/dir_fns.php:144
-#: ../../include/dir_fns.php:145 ../../view/theme/redbasic/php/config.php:105
-#: ../../view/theme/redbasic/php/config.php:130 ../../boot.php:1707
-msgid "No"
-msgstr "No"
-
-#: ../../Zotlabs/Module/Connedit.php:379 ../../Zotlabs/Module/Events.php:459
-#: ../../Zotlabs/Module/Events.php:460 ../../Zotlabs/Module/Events.php:469
-#: ../../Zotlabs/Module/Api.php:88 ../../Zotlabs/Module/Filestorage.php:157
-#: ../../Zotlabs/Module/Filestorage.php:165 ../../Zotlabs/Module/Menu.php:100
-#: ../../Zotlabs/Module/Menu.php:157 ../../Zotlabs/Module/Mitem.php:158
-#: ../../Zotlabs/Module/Mitem.php:159 ../../Zotlabs/Module/Mitem.php:232
-#: ../../Zotlabs/Module/Mitem.php:233 ../../Zotlabs/Module/Photos.php:666
-#: ../../Zotlabs/Module/Profiles.php:647 ../../Zotlabs/Module/Admin.php:461
-#: ../../Zotlabs/Module/Removeme.php:61 ../../Zotlabs/Module/Settings.php:581
-#: ../../include/dir_fns.php:143 ../../include/dir_fns.php:144
-#: ../../include/dir_fns.php:145 ../../view/theme/redbasic/php/config.php:105
-#: ../../view/theme/redbasic/php/config.php:130 ../../boot.php:1707
-msgid "Yes"
-msgstr "Sí"
-
-#: ../../Zotlabs/Module/Connedit.php:411
-msgid "Could not access address book record."
-msgstr "No puc accedir al registre del contacte"
-
-#: ../../Zotlabs/Module/Connedit.php:425
-msgid "Refresh failed - channel is currently unavailable."
-msgstr "Ha fallat la recàrrega - el canal es actualment inaccesible."
-
-#: ../../Zotlabs/Module/Connedit.php:440 ../../Zotlabs/Module/Connedit.php:449
-#: ../../Zotlabs/Module/Connedit.php:458 ../../Zotlabs/Module/Connedit.php:467
-#: ../../Zotlabs/Module/Connedit.php:480
-msgid "Unable to set address book parameters."
-msgstr "No es poden ajustar els paràmetres dels contactes."
-
-#: ../../Zotlabs/Module/Connedit.php:503
-msgid "Connection has been removed."
-msgstr "S'han eliminat les conexions."
-
-#: ../../Zotlabs/Module/Connedit.php:519 ../../Zotlabs/Lib/Apps.php:219
-#: ../../include/nav.php:86 ../../include/conversation.php:954
-msgid "View Profile"
-msgstr "Veure Perfil"
-
-#: ../../Zotlabs/Module/Connedit.php:522
-#, php-format
-msgid "View %s's profile"
-msgstr "Mostra el perfil de %s"
-
-#: ../../Zotlabs/Module/Connedit.php:526
-msgid "Refresh Permissions"
-msgstr "Recarrega els Permissos"
-
-#: ../../Zotlabs/Module/Connedit.php:529
-msgid "Fetch updated permissions"
-msgstr "Obté els permisos actualitzats"
-
-#: ../../Zotlabs/Module/Connedit.php:533
-msgid "Recent Activity"
-msgstr "Activitat Recent"
-
-#: ../../Zotlabs/Module/Connedit.php:536
-msgid "View recent posts and comments"
-msgstr "Mostra les entrades i comentaris recents"
-
-#: ../../Zotlabs/Module/Connedit.php:540 ../../Zotlabs/Module/Admin.php:1041
-msgid "Unblock"
-msgstr "Desbloquejat"
-
-#: ../../Zotlabs/Module/Connedit.php:540 ../../Zotlabs/Module/Admin.php:1040
-msgid "Block"
-msgstr "Bloquejat"
-
-#: ../../Zotlabs/Module/Connedit.php:543
-msgid "Block (or Unblock) all communications with this connection"
-msgstr "Boqueja (o Desbloqueja) les comunicacions amb aquesta connexió"
-
-#: ../../Zotlabs/Module/Connedit.php:544
-msgid "This connection is blocked!"
-msgstr "Aquesta connexió està bloquejada!"
-
-#: ../../Zotlabs/Module/Connedit.php:548
-msgid "Unignore"
-msgstr "Inhabilita"
-
-#: ../../Zotlabs/Module/Connedit.php:548
-#: ../../Zotlabs/Module/Connections.php:277
-#: ../../Zotlabs/Module/Notifications.php:55
-msgid "Ignore"
-msgstr "Ignora"
-
-#: ../../Zotlabs/Module/Connedit.php:551
-msgid "Ignore (or Unignore) all inbound communications from this connection"
-msgstr "Ignora (o Considera) les communicacions entrants d'aquesta connexió"
-
-#: ../../Zotlabs/Module/Connedit.php:552
-msgid "This connection is ignored!"
-msgstr "Aquesta connexió es ignorada!"
-
-#: ../../Zotlabs/Module/Connedit.php:556
-msgid "Unarchive"
-msgstr "Desarxiva"
-
-#: ../../Zotlabs/Module/Connedit.php:556
-msgid "Archive"
-msgstr "Arxiva"
-
-#: ../../Zotlabs/Module/Connedit.php:559
-msgid ""
-"Archive (or Unarchive) this connection - mark channel dead but keep content"
-msgstr "Arxiva (o Desarxiva) aquesta connexió - Marca el canal com a mort pero manté el contingut "
-
-#: ../../Zotlabs/Module/Connedit.php:560
-msgid "This connection is archived!"
-msgstr "Aquesta connexió està arxivada!"
-
-#: ../../Zotlabs/Module/Connedit.php:564
-msgid "Unhide"
-msgstr "Mostra"
-
-#: ../../Zotlabs/Module/Connedit.php:564
-msgid "Hide"
-msgstr "Amaga"
-
-#: ../../Zotlabs/Module/Connedit.php:567
-msgid "Hide or Unhide this connection from your other connections"
-msgstr "Amaga (o Mostra) aquesta connexió de les altres connexions teves"
-
-#: ../../Zotlabs/Module/Connedit.php:568
-msgid "This connection is hidden!"
-msgstr "Aquesta connexió està amagada!"
-
-#: ../../Zotlabs/Module/Connedit.php:575
-msgid "Delete this connection"
-msgstr "Elimina aquesta connexió"
-
-#: ../../Zotlabs/Module/Connedit.php:590 ../../include/widgets.php:493
-msgid "Me"
-msgstr "Jo"
-
-#: ../../Zotlabs/Module/Connedit.php:591 ../../include/widgets.php:494
-msgid "Family"
-msgstr "Família"
-
-#: ../../Zotlabs/Module/Connedit.php:592 ../../Zotlabs/Module/Settings.php:342
-#: ../../Zotlabs/Module/Settings.php:346 ../../Zotlabs/Module/Settings.php:347
-#: ../../Zotlabs/Module/Settings.php:350 ../../Zotlabs/Module/Settings.php:361
-#: ../../include/widgets.php:495 ../../include/selectors.php:123
-#: ../../include/channel.php:389 ../../include/channel.php:390
-#: ../../include/channel.php:397
-msgid "Friends"
-msgstr "Amics"
-
-#: ../../Zotlabs/Module/Connedit.php:593 ../../include/widgets.php:496
-msgid "Acquaintances"
-msgstr "Coneguts"
-
-#: ../../Zotlabs/Module/Connedit.php:594
-#: ../../Zotlabs/Module/Connections.php:92
-#: ../../Zotlabs/Module/Connections.php:107 ../../include/widgets.php:497
-msgid "All"
-msgstr "Tots"
-
-#: ../../Zotlabs/Module/Connedit.php:654
-msgid "Approve this connection"
-msgstr "Apccepta aquesta connexió"
-
-#: ../../Zotlabs/Module/Connedit.php:654
-msgid "Accept connection to allow communication"
-msgstr "Accepta la connexió per permetre la comunicació"
-
-#: ../../Zotlabs/Module/Connedit.php:659
-msgid "Set Affinity"
-msgstr "Ajusta l'Afinitat"
-
-#: ../../Zotlabs/Module/Connedit.php:662
-msgid "Set Profile"
-msgstr "Ajusta el Perfil"
-
-#: ../../Zotlabs/Module/Connedit.php:665
-msgid "Set Affinity & Profile"
-msgstr "Ajusta Afinitat i Perfil"
-
-#: ../../Zotlabs/Module/Connedit.php:698
-msgid "none"
-msgstr "res"
-
-#: ../../Zotlabs/Module/Connedit.php:702 ../../include/widgets.php:614
-msgid "Connection Default Permissions"
-msgstr "Permisos per Defecte de la Connexió"
-
-#: ../../Zotlabs/Module/Connedit.php:702 ../../include/items.php:3926
-#, php-format
-msgid "Connection: %s"
-msgstr "Connexió: %s"
-
-#: ../../Zotlabs/Module/Connedit.php:703
-msgid "Apply these permissions automatically"
-msgstr "Aplica aquests permissos automaticament"
-
-#: ../../Zotlabs/Module/Connedit.php:703
-msgid "Connection requests will be approved without your interaction"
-msgstr "Les peticions de connexió seran aprovades sense la teva interacció"
-
-#: ../../Zotlabs/Module/Connedit.php:705
-msgid "This connection's primary address is"
-msgstr "La primera adreça d'aqueste connexió es"
-
-#: ../../Zotlabs/Module/Connedit.php:706
-msgid "Available locations:"
-msgstr "Localització disponible:"
-
-#: ../../Zotlabs/Module/Connedit.php:710
-msgid ""
-"The permissions indicated on this page will be applied to all new "
-"connections."
-msgstr "Els permisos indicats en aquesta pàgina seran aplicats a totes les noves connexions."
-
-#: ../../Zotlabs/Module/Connedit.php:711
-msgid "Connection Tools"
-msgstr "Eines de Connexió"
-
-#: ../../Zotlabs/Module/Connedit.php:713
-msgid "Slide to adjust your degree of friendship"
-msgstr "Llisca per ajustar el nivell d'amistat"
-
-#: ../../Zotlabs/Module/Connedit.php:714 ../../Zotlabs/Module/Rate.php:159
-#: ../../include/js_strings.php:20
-msgid "Rating"
-msgstr "Valora"
-
-#: ../../Zotlabs/Module/Connedit.php:715
-msgid "Slide to adjust your rating"
-msgstr "Llisca per ajustar la valoració"
-
-#: ../../Zotlabs/Module/Connedit.php:716 ../../Zotlabs/Module/Connedit.php:721
-msgid "Optionally explain your rating"
-msgstr "Opcionalment pots explicar la teva valoració"
-
-#: ../../Zotlabs/Module/Connedit.php:718
-msgid "Custom Filter"
-msgstr "Filtre a mida"
-
-#: ../../Zotlabs/Module/Connedit.php:719
-msgid "Only import posts with this text"
-msgstr "Importa exclusivament entrades amb aquest text"
-
-#: ../../Zotlabs/Module/Connedit.php:719 ../../Zotlabs/Module/Connedit.php:720
-msgid ""
-"words one per line or #tags or /patterns/ or lang=xx, leave blank to import "
-"all posts"
-msgstr "paraules una per línia o #etiquetes o /patrons/ o idioma=xx, deixar en blanc per importar totes les entrades"
-
-#: ../../Zotlabs/Module/Connedit.php:720
-msgid "Do not import posts with this text"
-msgstr "No importar entrades amb aquest text"
-
-#: ../../Zotlabs/Module/Connedit.php:722
-msgid "This information is public!"
-msgstr "Aquesta informació es pública!"
-
-#: ../../Zotlabs/Module/Connedit.php:727
-msgid "Connection Pending Approval"
-msgstr "Connexió Pendent d'Aprovació"
-
-#: ../../Zotlabs/Module/Connedit.php:730
-msgid "inherited"
-msgstr "heretat"
-
-#: ../../Zotlabs/Module/Connedit.php:732
-#, php-format
-msgid ""
-"Please choose the profile you would like to display to %s when viewing your "
-"profile securely."
-msgstr "Tria el perfil que vols mostrar a %s quan es vegi el perfil segur."
-
-#: ../../Zotlabs/Module/Connedit.php:734
-msgid "Their Settings"
-msgstr "Els seus Ajustos"
-
-#: ../../Zotlabs/Module/Connedit.php:735
-msgid "My Settings"
-msgstr "Els Meus Ajustos"
-
-#: ../../Zotlabs/Module/Connedit.php:737
-msgid "Individual Permissions"
-msgstr "Permisos Individuals"
-
-#: ../../Zotlabs/Module/Connedit.php:738
-msgid ""
-"Some permissions may be inherited from your channel's <a "
-"href=\"settings\"><strong>privacy settings</strong></a>, which have higher "
-"priority than individual settings. You can <strong>not</strong> change those"
-" settings here."
-msgstr "Alguns permisos poden ser heretats dels teus canals <a href=\"settings\"><strong>ajustos de privacitat</strong></a>, Els quals tenen més prioritat que els ajustos individuals. <strong>No</strong> pots canviar aquests ajustos aquí."
-
-#: ../../Zotlabs/Module/Connedit.php:739
-msgid ""
-"Some permissions may be inherited from your channel's <a "
-"href=\"settings\"><strong>privacy settings</strong></a>, which have higher "
-"priority than individual settings. You can change those settings here but "
-"they wont have any impact unless the inherited setting changes."
-msgstr "Alguns permisos poden ser heretats dels teus canals <a href=\"settings\"><strong>ajustos de privacitat</strong></a>, Els quals tenen més prioritat que els ajustos individuals. <strong>Pots</strong> canviar aquests ajustos aquí pero no tindran cap impacte fins que no canviis els ajustos heretats."
-
-#: ../../Zotlabs/Module/Connedit.php:740
-msgid "Last update:"
-msgstr "Darrera actualització:"
-
-#: ../../Zotlabs/Module/Directory.php:63 ../../Zotlabs/Module/Display.php:17
-#: ../../Zotlabs/Module/Photos.php:522 ../../Zotlabs/Module/Ratings.php:86
-#: ../../Zotlabs/Module/Search.php:17
-#: ../../Zotlabs/Module/Viewconnections.php:20
-msgid "Public access denied."
-msgstr "Accés públic denegat."
-
-#: ../../Zotlabs/Module/Directory.php:243
-#, php-format
-msgid "%d rating"
-msgid_plural "%d ratings"
-msgstr[0] "%d valoració"
-msgstr[1] "%d valoracions"
-
-#: ../../Zotlabs/Module/Directory.php:254
-msgid "Gender: "
-msgstr "Gènere:"
-
-#: ../../Zotlabs/Module/Directory.php:256
-msgid "Status: "
-msgstr "Estatus:"
-
-#: ../../Zotlabs/Module/Directory.php:258
-msgid "Homepage: "
-msgstr "Pàgina Personal:"
-
-#: ../../Zotlabs/Module/Directory.php:306 ../../include/channel.php:1183
-msgid "Age:"
-msgstr "Edat:"
-
-#: ../../Zotlabs/Module/Directory.php:311 ../../include/event.php:52
-#: ../../include/event.php:84 ../../include/channel.php:1027
-#: ../../include/bb2diaspora.php:507
-msgid "Location:"
-msgstr "Localització:"
-
-#: ../../Zotlabs/Module/Directory.php:317
-msgid "Description:"
-msgstr "Descripció:"
-
-#: ../../Zotlabs/Module/Directory.php:322 ../../include/channel.php:1199
-msgid "Hometown:"
-msgstr "Ciutat Natal:"
-
-#: ../../Zotlabs/Module/Directory.php:324 ../../include/channel.php:1207
-msgid "About:"
-msgstr "Sobre:"
-
-#: ../../Zotlabs/Module/Directory.php:325 ../../Zotlabs/Module/Match.php:68
-#: ../../Zotlabs/Module/Suggest.php:56 ../../include/widgets.php:147
-#: ../../include/widgets.php:184 ../../include/connections.php:78
-#: ../../include/conversation.php:956 ../../include/channel.php:1012
-msgid "Connect"
-msgstr "Connecta "
-
-#: ../../Zotlabs/Module/Directory.php:326
-msgid "Public Forum:"
-msgstr "Forum Públic:"
-
-#: ../../Zotlabs/Module/Directory.php:329
-msgid "Keywords: "
-msgstr "Paraules Clau:"
-
-#: ../../Zotlabs/Module/Directory.php:332
-msgid "Don't suggest"
-msgstr "No suggerir"
-
-#: ../../Zotlabs/Module/Directory.php:334
-msgid "Common connections:"
-msgstr "Connexions en comú:"
-
-#: ../../Zotlabs/Module/Directory.php:383
-msgid "Global Directory"
-msgstr "Directori Global"
-
-#: ../../Zotlabs/Module/Directory.php:383
-msgid "Local Directory"
-msgstr "Directori Local"
-
-#: ../../Zotlabs/Module/Directory.php:388
-#: ../../Zotlabs/Module/Directory.php:393
-#: ../../Zotlabs/Module/Connections.php:309
-#: ../../include/contact_widgets.php:23
-msgid "Find"
-msgstr "Troba"
-
-#: ../../Zotlabs/Module/Directory.php:389
-msgid "Finding:"
-msgstr "Cercant:"
-
-#: ../../Zotlabs/Module/Directory.php:392 ../../Zotlabs/Module/Suggest.php:64
-#: ../../include/contact_widgets.php:24
-msgid "Channel Suggestions"
-msgstr "Canals Suggerits"
-
-#: ../../Zotlabs/Module/Directory.php:394
-msgid "next page"
-msgstr "pàgina següent"
-
-#: ../../Zotlabs/Module/Directory.php:394
-msgid "previous page"
-msgstr "pàgina anterior"
-
-#: ../../Zotlabs/Module/Directory.php:395
-msgid "Sort options"
-msgstr "Opcions per ordenar"
-
-#: ../../Zotlabs/Module/Directory.php:396
-msgid "Alphabetic"
-msgstr "Alfabètic"
-
-#: ../../Zotlabs/Module/Directory.php:397
-msgid "Reverse Alphabetic"
-msgstr "Alfabètic Invers"
-
-#: ../../Zotlabs/Module/Directory.php:398
-msgid "Newest to Oldest"
-msgstr "De més Nou a més Vell"
-
-#: ../../Zotlabs/Module/Directory.php:399
-msgid "Oldest to Newest"
-msgstr "De més Antic a més Nou"
-
-#: ../../Zotlabs/Module/Directory.php:416
-msgid "No entries (some entries may be hidden)."
-msgstr "Sense entrades (algunes podrien estar amagades)."
-
-#: ../../Zotlabs/Module/Display.php:40 ../../Zotlabs/Module/Filestorage.php:33
-#: ../../Zotlabs/Module/Admin.php:164 ../../Zotlabs/Module/Admin.php:1255
-#: ../../Zotlabs/Module/Admin.php:1561 ../../Zotlabs/Module/Thing.php:89
-#: ../../Zotlabs/Module/Viewsrc.php:24 ../../include/items.php:3359
-msgid "Item not found."
-msgstr "Element no trobat."
-
-#: ../../Zotlabs/Module/Editblock.php:79 ../../Zotlabs/Module/Editblock.php:95
-#: ../../Zotlabs/Module/Editpost.php:24 ../../Zotlabs/Module/Editlayout.php:79
-#: ../../Zotlabs/Module/Editwebpage.php:81
-msgid "Item not found"
-msgstr "No s'ha trobat l'element"
-
-#: ../../Zotlabs/Module/Editblock.php:124 ../../include/conversation.php:1228
-msgid "Title (optional)"
-msgstr "Títol (opcional)"
-
-#: ../../Zotlabs/Module/Editblock.php:133
-msgid "Edit Block"
-msgstr "Editar Bloc"
-
-#: ../../Zotlabs/Module/Common.php:14
-msgid "No channel."
-msgstr "No s'ha trobat el canal"
-
-#: ../../Zotlabs/Module/Common.php:43
-msgid "Common connections"
-msgstr "Connexions en comú"
-
-#: ../../Zotlabs/Module/Common.php:48
-msgid "No connections in common."
-msgstr "No hi ha connexions en comú."
-
-#: ../../Zotlabs/Module/Connections.php:56
-#: ../../Zotlabs/Module/Connections.php:161
-#: ../../Zotlabs/Module/Connections.php:242
-msgid "Blocked"
-msgstr "Bloquejades"
-
-#: ../../Zotlabs/Module/Connections.php:61
-#: ../../Zotlabs/Module/Connections.php:168
-#: ../../Zotlabs/Module/Connections.php:241
-msgid "Ignored"
-msgstr "Ignorades"
-
-#: ../../Zotlabs/Module/Connections.php:66
-#: ../../Zotlabs/Module/Connections.php:182
-#: ../../Zotlabs/Module/Connections.php:240
-msgid "Hidden"
-msgstr "Amagades"
-
-#: ../../Zotlabs/Module/Connections.php:71
-#: ../../Zotlabs/Module/Connections.php:175
-#: ../../Zotlabs/Module/Connections.php:239
-msgid "Archived"
-msgstr "Arxivades"
-
-#: ../../Zotlabs/Module/Connections.php:76
-#: ../../Zotlabs/Module/Connections.php:86 ../../Zotlabs/Module/Menu.php:116
-#: ../../include/conversation.php:1535
-msgid "New"
-msgstr "Nou"
-
-#: ../../Zotlabs/Module/Connections.php:138
-msgid "New Connections"
-msgstr "Noves Connexions"
-
-#: ../../Zotlabs/Module/Connections.php:141
-msgid "Show pending (new) connections"
-msgstr "Mostra les connexions pendents (noves)"
-
-#: ../../Zotlabs/Module/Connections.php:145
-#: ../../Zotlabs/Module/Profperm.php:144
-msgid "All Connections"
-msgstr "Totes les Connexions"
-
-#: ../../Zotlabs/Module/Connections.php:148
-msgid "Show all connections"
-msgstr "Mostra totes les connexions"
-
-#: ../../Zotlabs/Module/Connections.php:164
-msgid "Only show blocked connections"
-msgstr "Mostra només les connexions bloquejades"
-
-#: ../../Zotlabs/Module/Connections.php:171
-msgid "Only show ignored connections"
-msgstr "Mostra només les connexions ignorades"
-
-#: ../../Zotlabs/Module/Connections.php:178
-msgid "Only show archived connections"
-msgstr "Mostra només les connexions arxivades"
-
-#: ../../Zotlabs/Module/Connections.php:185
-msgid "Only show hidden connections"
-msgstr "Mostra només les connexions amagades"
-
-#: ../../Zotlabs/Module/Connections.php:238
-msgid "Pending approval"
-msgstr "Pendent d'aprovació"
-
-#: ../../Zotlabs/Module/Connections.php:254
-#, php-format
-msgid "%1$s [%2$s]"
-msgstr "%1$s [%2$s]"
-
-#: ../../Zotlabs/Module/Connections.php:255
-msgid "Edit connection"
-msgstr "Modifica la connexió"
-
-#: ../../Zotlabs/Module/Connections.php:256
-msgid "Delete connection"
-msgstr "Elimina la connexió"
-
-#: ../../Zotlabs/Module/Connections.php:265
-msgid "Channel address"
-msgstr "Adreça del canal"
-
-#: ../../Zotlabs/Module/Connections.php:267
-msgid "Network"
-msgstr "Xarxa"
-
-#: ../../Zotlabs/Module/Connections.php:270 ../../Zotlabs/Module/Admin.php:710
-msgid "Status"
-msgstr "Estat"
-
-#: ../../Zotlabs/Module/Connections.php:272
-msgid "Connected"
-msgstr "Connectat"
-
-#: ../../Zotlabs/Module/Connections.php:274
-msgid "Approve connection"
-msgstr "Aprovar la Connexió "
-
-#: ../../Zotlabs/Module/Connections.php:275
-#: ../../Zotlabs/Module/Admin.php:1037
-msgid "Approve"
-msgstr "Aprovat"
-
-#: ../../Zotlabs/Module/Connections.php:276
-msgid "Ignore connection"
-msgstr "Ignorar connexió"
-
-#: ../../Zotlabs/Module/Connections.php:278
-msgid "Recent activity"
-msgstr "Activitat recent"
-
-#: ../../Zotlabs/Module/Connections.php:302 ../../Zotlabs/Lib/Apps.php:208
-#: ../../include/text.php:875 ../../include/nav.php:186
-msgid "Connections"
-msgstr "Connexions"
-
-#: ../../Zotlabs/Module/Connections.php:306 ../../Zotlabs/Module/Search.php:44
-#: ../../Zotlabs/Lib/Apps.php:228 ../../include/text.php:945
-#: ../../include/text.php:957 ../../include/nav.php:165
-#: ../../include/acl_selectors.php:276
-msgid "Search"
-msgstr "Cerca"
-
-#: ../../Zotlabs/Module/Connections.php:307
-msgid "Search your connections"
-msgstr "Cerca entre les teves connexions"
-
-#: ../../Zotlabs/Module/Connections.php:308
-msgid "Connections search"
-msgstr "Cerca connexions"
-
-#: ../../Zotlabs/Module/Cover_photo.php:58
-#: ../../Zotlabs/Module/Profile_photo.php:79
-msgid "Image uploaded but image cropping failed."
-msgstr "S'ha pujat la imatge però no s'ha pogut retallar."
-
-#: ../../Zotlabs/Module/Cover_photo.php:134
-#: ../../Zotlabs/Module/Cover_photo.php:181
-msgid "Cover Photos"
-msgstr "Fotos de Portada"
-
-#: ../../Zotlabs/Module/Cover_photo.php:154
-#: ../../Zotlabs/Module/Profile_photo.php:133
-msgid "Image resize failed."
-msgstr "No s'ha pogut escalar la imatge."
-
-#: ../../Zotlabs/Module/Cover_photo.php:168
-#: ../../Zotlabs/Module/Profile_photo.php:192 ../../include/photos.php:144
-msgid "Unable to process image"
-msgstr "incapaç de processar la imatge"
-
-#: ../../Zotlabs/Module/Cover_photo.php:192
-#: ../../Zotlabs/Module/Profile_photo.php:217
-msgid "Image upload failed."
-msgstr "La pujada de la imatge va fracassar."
-
-#: ../../Zotlabs/Module/Cover_photo.php:210
-#: ../../Zotlabs/Module/Profile_photo.php:236
-msgid "Unable to process image."
-msgstr "Incapaç de processar l'imatge."
-
-#: ../../Zotlabs/Module/Cover_photo.php:233 ../../include/items.php:4270
-msgid "female"
-msgstr "femení"
-
-#: ../../Zotlabs/Module/Cover_photo.php:234 ../../include/items.php:4271
-#, php-format
-msgid "%1$s updated her %2$s"
-msgstr "%1$s actualitzà el seu %2$s"
-
-#: ../../Zotlabs/Module/Cover_photo.php:235 ../../include/items.php:4272
-msgid "male"
-msgstr "masculí"
-
-#: ../../Zotlabs/Module/Cover_photo.php:236 ../../include/items.php:4273
-#, php-format
-msgid "%1$s updated his %2$s"
-msgstr "%1$s actualitzà el seu %2$s"
-
-#: ../../Zotlabs/Module/Cover_photo.php:238 ../../include/items.php:4275
-#, php-format
-msgid "%1$s updated their %2$s"
-msgstr "%1$s actualitzà els seus %2$s"
-
-#: ../../Zotlabs/Module/Cover_photo.php:240 ../../include/channel.php:1661
-msgid "cover photo"
-msgstr "Foto de la portada"
-
-#: ../../Zotlabs/Module/Cover_photo.php:303
-#: ../../Zotlabs/Module/Cover_photo.php:318
-#: ../../Zotlabs/Module/Profile_photo.php:283
-#: ../../Zotlabs/Module/Profile_photo.php:324
-msgid "Photo not available."
-msgstr "Foto no disponible."
-
-#: ../../Zotlabs/Module/Cover_photo.php:354
-#: ../../Zotlabs/Module/Profile_photo.php:365
-msgid "Upload File:"
-msgstr "Puja Arxiu:"
-
-#: ../../Zotlabs/Module/Cover_photo.php:355
-#: ../../Zotlabs/Module/Profile_photo.php:366
-msgid "Select a profile:"
-msgstr "Tria un perfil:"
-
-#: ../../Zotlabs/Module/Cover_photo.php:356
-msgid "Upload Cover Photo"
-msgstr "Puja Foto de Portada"
-
-#: ../../Zotlabs/Module/Cover_photo.php:361
-#: ../../Zotlabs/Module/Profile_photo.php:374
-#: ../../Zotlabs/Module/Settings.php:985
-msgid "or"
-msgstr "o"
-
-#: ../../Zotlabs/Module/Cover_photo.php:361
-#: ../../Zotlabs/Module/Profile_photo.php:374
-msgid "skip this step"
-msgstr "salta aquest pas"
-
-#: ../../Zotlabs/Module/Cover_photo.php:361
-#: ../../Zotlabs/Module/Profile_photo.php:374
-msgid "select a photo from your photo albums"
-msgstr "tria una foto del teu àlbum de fotos"
-
-#: ../../Zotlabs/Module/Cover_photo.php:377
-#: ../../Zotlabs/Module/Profile_photo.php:390
-msgid "Crop Image"
-msgstr "Retalla Imatge"
-
-#: ../../Zotlabs/Module/Cover_photo.php:378
-#: ../../Zotlabs/Module/Profile_photo.php:391
-msgid "Please adjust the image cropping for optimum viewing."
-msgstr "Si us plau, retalla la imatge per a una optima visualització"
-
-#: ../../Zotlabs/Module/Cover_photo.php:380
-#: ../../Zotlabs/Module/Profile_photo.php:393
-msgid "Done Editing"
-msgstr "Edició Feta"
-
-#: ../../Zotlabs/Module/Editpost.php:35
-msgid "Item is not editable"
-msgstr "Article no editable"
-
-#: ../../Zotlabs/Module/Editpost.php:106 ../../Zotlabs/Module/Rpost.php:135
-msgid "Edit post"
-msgstr "Modifica l'entrada"
-
-#: ../../Zotlabs/Module/Events.php:26
-msgid "Calendar entries imported."
-msgstr "Entrades de Calendari importades."
-
-#: ../../Zotlabs/Module/Events.php:28
-msgid "No calendar entries found."
-msgstr "No es troben entrades decalendari."
-
-#: ../../Zotlabs/Module/Events.php:105
-msgid "Event can not end before it has started."
-msgstr "L'esdeveniment ha de començar abans d'acabar."
-
-#: ../../Zotlabs/Module/Events.php:107 ../../Zotlabs/Module/Events.php:116
-#: ../../Zotlabs/Module/Events.php:136
-msgid "Unable to generate preview."
-msgstr "No s'ha pogut generar la vista prèvia."
-
-#: ../../Zotlabs/Module/Events.php:114
-msgid "Event title and start time are required."
-msgstr "Cal indicar l'inici i el final de l'esdeveniment."
-
-#: ../../Zotlabs/Module/Events.php:134 ../../Zotlabs/Module/Events.php:259
-msgid "Event not found."
-msgstr "No s'ha trobat l'esdeveniment."
-
-#: ../../Zotlabs/Module/Events.php:254 ../../Zotlabs/Module/Like.php:373
-#: ../../Zotlabs/Module/Tagger.php:51 ../../include/event.php:949
-#: ../../include/text.php:1943 ../../include/conversation.php:123
-msgid "event"
-msgstr "succés"
-
-#: ../../Zotlabs/Module/Events.php:449
-msgid "Edit event title"
-msgstr "Edita el títol d'esdeveniment"
-
-#: ../../Zotlabs/Module/Events.php:449
-msgid "Event title"
-msgstr "Títol esdeveniment"
-
-#: ../../Zotlabs/Module/Events.php:449 ../../Zotlabs/Module/Events.php:454
-#: ../../Zotlabs/Module/Profiles.php:709 ../../Zotlabs/Module/Profiles.php:713
-#: ../../Zotlabs/Module/Appman.php:115 ../../Zotlabs/Module/Appman.php:116
-#: ../../include/datetime.php:245
-msgid "Required"
-msgstr "Requerit"
-
-#: ../../Zotlabs/Module/Events.php:451
-msgid "Categories (comma-separated list)"
-msgstr "Categories (llista separada per comes)"
-
-#: ../../Zotlabs/Module/Events.php:452
-msgid "Edit Category"
-msgstr "Editar Categoria"
-
-#: ../../Zotlabs/Module/Events.php:452
-msgid "Category"
-msgstr "Categoria"
-
-#: ../../Zotlabs/Module/Events.php:455
-msgid "Edit start date and time"
-msgstr "Editar data i hora d'inici"
-
-#: ../../Zotlabs/Module/Events.php:455
-msgid "Start date and time"
-msgstr "Data i hora d'inici"
-
-#: ../../Zotlabs/Module/Events.php:456 ../../Zotlabs/Module/Events.php:459
-msgid "Finish date and time are not known or not relevant"
-msgstr "L'ora de finalització no es coneix o es irrelevant."
-
-#: ../../Zotlabs/Module/Events.php:458
-msgid "Edit finish date and time"
-msgstr "Editar la data i hora de finalització"
-
-#: ../../Zotlabs/Module/Events.php:458
-msgid "Finish date and time"
-msgstr "Data i hora de finalització"
-
-#: ../../Zotlabs/Module/Events.php:460 ../../Zotlabs/Module/Events.php:461
-msgid "Adjust for viewer timezone"
-msgstr "Ajusta a la zona horària del visitant."
-
-#: ../../Zotlabs/Module/Events.php:460
-msgid ""
-"Important for events that happen in a particular place. Not practical for "
-"global holidays."
-msgstr "És important per esdeveniments locals, però pels globals no és pràctic."
-
-#: ../../Zotlabs/Module/Events.php:462
-msgid "Edit Description"
-msgstr "Editar la Descripció"
-
-#: ../../Zotlabs/Module/Events.php:462 ../../Zotlabs/Module/Appman.php:117
-#: ../../Zotlabs/Module/Rbmark.php:101
-msgid "Description"
-msgstr "Descripció"
-
-#: ../../Zotlabs/Module/Events.php:464
-msgid "Edit Location"
-msgstr "Editar la localització"
-
-#: ../../Zotlabs/Module/Events.php:464 ../../Zotlabs/Module/Locs.php:117
-#: ../../Zotlabs/Module/Profiles.php:477 ../../Zotlabs/Module/Profiles.php:698
-#: ../../Zotlabs/Module/Pubsites.php:41 ../../include/js_strings.php:25
-msgid "Location"
-msgstr "Localització"
-
-#: ../../Zotlabs/Module/Events.php:467 ../../Zotlabs/Module/Events.php:469
-msgid "Share this event"
-msgstr "Comparteix aquest esdeveniment"
-
-#: ../../Zotlabs/Module/Events.php:470 ../../Zotlabs/Module/Photos.php:1093
-#: ../../Zotlabs/Module/Webpages.php:194 ../../Zotlabs/Lib/ThreadItem.php:719
-#: ../../include/conversation.php:1187 ../../include/page_widgets.php:40
-msgid "Preview"
-msgstr "Avanç"
-
-#: ../../Zotlabs/Module/Events.php:471 ../../include/conversation.php:1232
-msgid "Permission settings"
-msgstr "Ajustos de permisos"
-
-#: ../../Zotlabs/Module/Events.php:476
-msgid "Advanced Options"
-msgstr "Opcions Avançades"
-
-#: ../../Zotlabs/Module/Events.php:610
-msgid "Edit event"
-msgstr "Edita l'esdeveniment"
-
-#: ../../Zotlabs/Module/Events.php:612
-msgid "Delete event"
-msgstr "Esborra l'esdeveniment"
-
-#: ../../Zotlabs/Module/Events.php:646
-msgid "calendar"
-msgstr "calendari"
-
-#: ../../Zotlabs/Module/Events.php:706
-msgid "Event removed"
-msgstr "S'ha eliminat l'esdeveniment"
-
-#: ../../Zotlabs/Module/Events.php:709
-msgid "Failed to remove event"
-msgstr "No s'ha pogut esborrar l'esdeveniment"
-
-#: ../../Zotlabs/Module/Fbrowser.php:29 ../../Zotlabs/Lib/Apps.php:220
-#: ../../include/nav.php:92 ../../include/conversation.php:1632
+#: ../../Zotlabs/Module/Fbrowser.php:29 ../../Zotlabs/Lib/Apps.php:248
+#: ../../include/conversation.php:1831 ../../include/nav.php:401
 msgid "Photos"
 msgstr "Fotos"
 
-#: ../../Zotlabs/Module/Fbrowser.php:66 ../../Zotlabs/Module/Fbrowser.php:88
-#: ../../Zotlabs/Module/Admin.php:1406 ../../Zotlabs/Module/Settings.php:591
-#: ../../Zotlabs/Module/Settings.php:617 ../../Zotlabs/Module/Tagrm.php:15
-#: ../../Zotlabs/Module/Tagrm.php:138 ../../include/conversation.php:1259
-msgid "Cancel"
-msgstr "Cancel·la"
-
-#: ../../Zotlabs/Module/Dirsearch.php:25 ../../Zotlabs/Module/Regdir.php:49
-msgid "This site is not a directory server"
-msgstr "Aquest lloc web no és un servidor de directori"
-
-#: ../../Zotlabs/Module/Dirsearch.php:33
-msgid "This directory server requires an access token"
-msgstr "Aquest servidor de directori requereix un token de accès"
-
-#: ../../Zotlabs/Module/Filer.php:52
-msgid "Save to Folder:"
-msgstr "Guardar en la Carpeta"
-
-#: ../../Zotlabs/Module/Filer.php:52
-msgid "- select -"
-msgstr "- selecciona -"
-
-#: ../../Zotlabs/Module/Filer.php:53 ../../Zotlabs/Module/Admin.php:2033
-#: ../../Zotlabs/Module/Admin.php:2053 ../../Zotlabs/Module/Rbmark.php:32
-#: ../../Zotlabs/Module/Rbmark.php:104 ../../include/text.php:946
-#: ../../include/text.php:958 ../../include/widgets.php:201
-msgid "Save"
-msgstr "Guardar"
-
-#: ../../Zotlabs/Module/Dreport.php:27
-msgid "Invalid message"
-msgstr "Missatge invàlid."
-
-#: ../../Zotlabs/Module/Dreport.php:59
-msgid "no results"
-msgstr "sense resultats"
-
-#: ../../Zotlabs/Module/Dreport.php:64
-#, php-format
-msgid "Delivery report for %1$s"
-msgstr "Informe de lliurament per %1$s"
-
-#: ../../Zotlabs/Module/Dreport.php:78
-msgid "channel sync processed"
-msgstr "sincronització del canal processada"
-
-#: ../../Zotlabs/Module/Dreport.php:82
-msgid "queued"
-msgstr "Posat en cua"
-
-#: ../../Zotlabs/Module/Dreport.php:86
-msgid "posted"
-msgstr "enviat"
-
-#: ../../Zotlabs/Module/Dreport.php:90
-msgid "accepted for delivery"
-msgstr "acceptat per entregar"
-
-#: ../../Zotlabs/Module/Dreport.php:94
-msgid "updated"
-msgstr "actualitzat"
-
-#: ../../Zotlabs/Module/Dreport.php:97
-msgid "update ignored"
-msgstr "actualització ignorada"
-
-#: ../../Zotlabs/Module/Dreport.php:100
-msgid "permission denied"
-msgstr "permís denegat"
-
-#: ../../Zotlabs/Module/Dreport.php:104
-msgid "recipient not found"
-msgstr "Contenidor no trobat"
-
-#: ../../Zotlabs/Module/Dreport.php:107
-msgid "mail recalled"
-msgstr "Recupera el correu"
-
-#: ../../Zotlabs/Module/Dreport.php:110
-msgid "duplicate mail received"
-msgstr "rebut correu duplicat"
-
-#: ../../Zotlabs/Module/Dreport.php:113
-msgid "mail delivered"
-msgstr "correu entregat"
-
-#: ../../Zotlabs/Module/Editlayout.php:126
-#: ../../Zotlabs/Module/Layouts.php:127 ../../Zotlabs/Module/Layouts.php:186
-msgid "Layout Name"
-msgstr "Nom del Format Gràfic"
-
-#: ../../Zotlabs/Module/Editlayout.php:127
-#: ../../Zotlabs/Module/Layouts.php:130
-msgid "Layout Description (Optional)"
-msgstr "Descripció del Format (Opcional)"
-
-#: ../../Zotlabs/Module/Editlayout.php:135
-msgid "Edit Layout"
-msgstr "Edita Format Gràfic"
-
-#: ../../Zotlabs/Module/Editwebpage.php:143
-msgid "Page link"
-msgstr "Enllaç de la pàgina"
-
-#: ../../Zotlabs/Module/Editwebpage.php:169
-msgid "Edit Webpage"
-msgstr "Edita la Pàgina Web"
-
-#: ../../Zotlabs/Module/Follow.php:34
-msgid "Channel added."
-msgstr "S'ha afegit el canal."
-
-#: ../../Zotlabs/Module/Acl.php:227
-msgid "network"
-msgstr "xarxa"
-
-#: ../../Zotlabs/Module/Acl.php:237
-msgid "RSS"
-msgstr "RSS"
-
-#: ../../Zotlabs/Module/Group.php:24
-msgid "Privacy group created."
-msgstr "Creat grup privat."
-
-#: ../../Zotlabs/Module/Group.php:30
-msgid "Could not create privacy group."
-msgstr "No es pot crear el grup privat."
-
-#: ../../Zotlabs/Module/Group.php:42 ../../Zotlabs/Module/Group.php:141
-#: ../../include/items.php:3893
-msgid "Privacy group not found."
-msgstr "No es troben grups privats."
-
-#: ../../Zotlabs/Module/Group.php:58
-msgid "Privacy group updated."
-msgstr "Grup privat actualitzat."
-
-#: ../../Zotlabs/Module/Group.php:90
-msgid "Create a group of channels."
-msgstr "Crear un grup de canals."
-
-#: ../../Zotlabs/Module/Group.php:91 ../../Zotlabs/Module/Group.php:184
-msgid "Privacy group name: "
-msgstr "Nom del grup privat:"
-
-#: ../../Zotlabs/Module/Group.php:93 ../../Zotlabs/Module/Group.php:187
-msgid "Members are visible to other channels"
-msgstr "Els membres son visibles en altres canals"
-
-#: ../../Zotlabs/Module/Group.php:111
-msgid "Privacy group removed."
-msgstr "Grup privat eliminat."
-
-#: ../../Zotlabs/Module/Group.php:113
-msgid "Unable to remove privacy group."
-msgstr "No puc eliminar el grup privat."
-
-#: ../../Zotlabs/Module/Group.php:183
-msgid "Privacy group editor"
-msgstr "Editor del grup privat"
-
-#: ../../Zotlabs/Module/Group.php:197
-msgid "Members"
-msgstr "Membres"
-
-#: ../../Zotlabs/Module/Group.php:199
-msgid "All Connected Channels"
-msgstr "Tots els Canals Connectats"
-
-#: ../../Zotlabs/Module/Group.php:231
-msgid "Click on a channel to add or remove."
-msgstr "Clic sobre el canal per afegir o esborrar."
-
-#: ../../Zotlabs/Module/Ffsapi.php:12
-msgid "Share content from Firefox to $Projectname"
-msgstr "Compartir contingut des de Firefox a $Projectname"
-
-#: ../../Zotlabs/Module/Ffsapi.php:15
-msgid "Activate the Firefox $Projectname provider"
-msgstr "Activar el proveïdor de $Projectname a Firefox"
-
-#: ../../Zotlabs/Module/Api.php:61 ../../Zotlabs/Module/Api.php:85
-msgid "Authorize application connection"
-msgstr "Autoritza la connexió de l'aplicació"
-
-#: ../../Zotlabs/Module/Api.php:62
-msgid "Return to your app and insert this Securty Code:"
-msgstr "Torna a la teva aplicació i insereix aquest Codi de Seguretat:"
-
-#: ../../Zotlabs/Module/Api.php:72
-msgid "Please login to continue."
-msgstr "Si et plau, identifica't per continuar."
-
-#: ../../Zotlabs/Module/Api.php:87
-msgid ""
-"Do you want to authorize this application to access your posts and contacts,"
-" and/or create new posts for you?"
-msgstr "Vols autoritzar a aquesta aplicació l'accés a les teves entrades i contactes i/o a crear noves entrades com si fos tu mateix."
-
-#: ../../Zotlabs/Module/Help.php:26
-msgid "Documentation Search"
-msgstr "Cerca de Documentació"
-
-#: ../../Zotlabs/Module/Help.php:67 ../../Zotlabs/Module/Help.php:73
-#: ../../Zotlabs/Module/Help.php:79
-msgid "Help:"
-msgstr "Ajuda:"
-
-#: ../../Zotlabs/Module/Help.php:85 ../../Zotlabs/Module/Help.php:90
-#: ../../Zotlabs/Module/Layouts.php:183 ../../Zotlabs/Lib/Apps.php:223
-#: ../../include/nav.php:159
-msgid "Help"
-msgstr "Ajuda"
-
-#: ../../Zotlabs/Module/Help.php:120
-msgid "$Projectname Documentation"
-msgstr "$Projectname Documentació"
-
-#: ../../Zotlabs/Module/Filestorage.php:88
-msgid "Permission Denied."
-msgstr "Permisos Denegats."
-
-#: ../../Zotlabs/Module/Filestorage.php:104
-msgid "File not found."
-msgstr "Arxiu no torbat."
-
-#: ../../Zotlabs/Module/Filestorage.php:147
-msgid "Edit file permissions"
-msgstr "Edita els permisos d'arxiu"
-
-#: ../../Zotlabs/Module/Filestorage.php:156
-msgid "Set/edit permissions"
-msgstr "Canvia/edita permisos"
-
-#: ../../Zotlabs/Module/Filestorage.php:157
-msgid "Include all files and sub folders"
-msgstr "Inclou tots als arxius i subdirectoris"
-
-#: ../../Zotlabs/Module/Filestorage.php:158
-msgid "Return to file list"
-msgstr "Tornar al llistat d'arxius"
-
-#: ../../Zotlabs/Module/Filestorage.php:160
-msgid "Copy/paste this code to attach file to a post"
-msgstr "Copia/enganxa aquest codi per a adjuntar un arxiu a l'entrada"
-
-#: ../../Zotlabs/Module/Filestorage.php:161
-msgid "Copy/paste this URL to link file from a web page"
-msgstr "Copia/enganxa aquesta URL per a enllaçar l'arxiu d'una pàgina web"
-
-#: ../../Zotlabs/Module/Filestorage.php:163
-msgid "Share this file"
-msgstr "Comparteix l'arxiu"
-
-#: ../../Zotlabs/Module/Filestorage.php:164
-msgid "Show URL to this file"
-msgstr "Mostra la URL d'aquest arxiu"
-
-#: ../../Zotlabs/Module/Filestorage.php:165
-msgid "Notify your contacts about this file"
-msgstr "Notifica als teus contactes aquest arxiu"
-
-#: ../../Zotlabs/Module/Apps.php:47 ../../include/widgets.php:102
-#: ../../include/nav.php:163
-msgid "Apps"
-msgstr "Aplicatius"
-
-#: ../../Zotlabs/Module/Attach.php:13
-msgid "Item not available."
-msgstr "Article no disponible."
-
-#: ../../Zotlabs/Module/Import.php:32
-#, php-format
-msgid "Your service plan only allows %d channels."
-msgstr "El teu paquet de serveis només admet %d canals."
-
-#: ../../Zotlabs/Module/Import.php:70 ../../Zotlabs/Module/Import_items.php:42
-msgid "Nothing to import."
-msgstr "No hi ha res a importar."
-
-#: ../../Zotlabs/Module/Import.php:94 ../../Zotlabs/Module/Import_items.php:66
-msgid "Unable to download data from old server"
-msgstr "No s'han pogut descarregar les dades del servidor antic"
-
-#: ../../Zotlabs/Module/Import.php:100
-#: ../../Zotlabs/Module/Import_items.php:72
-msgid "Imported file is empty."
-msgstr "El fitxer importat està buit."
-
-#: ../../Zotlabs/Module/Import.php:122
-#: ../../Zotlabs/Module/Import_items.php:86
-#, php-format
-msgid "Warning: Database versions differ by %1$d updates."
-msgstr "Atenció: Les versions de la Base de Dades difereixen en %1$d actualitzacions."
-
-#: ../../Zotlabs/Module/Import.php:150 ../../include/import.php:86
-msgid "Cloned channel not found. Import failed."
-msgstr "No s'ha pogut importar el canal perquè el canal clonat no s'ha trobat."
-
-#: ../../Zotlabs/Module/Import.php:160
-msgid "No channel. Import failed."
-msgstr "Sense canal. No s'ha pogut importar."
-
-#: ../../Zotlabs/Module/Import.php:510
-#: ../../include/Import/import_diaspora.php:142
-msgid "Import completed."
-msgstr "S'ha completat la importació."
-
-#: ../../Zotlabs/Module/Import.php:532
-msgid "You must be logged in to use this feature."
-msgstr "Has d'estar registrat per fer servir aquesta funcionalitat."
-
-#: ../../Zotlabs/Module/Import.php:537
-msgid "Import Channel"
-msgstr "Importa un canal"
-
-#: ../../Zotlabs/Module/Import.php:538
-msgid ""
-"Use this form to import an existing channel from a different server/hub. You"
-" may retrieve the channel identity from the old server/hub via the network "
-"or provide an export file."
-msgstr "Empra aquest formulari per importar un canal existent en un altre servidor/concentrador. Pots recuperar el canal  des de l'antic servidor/concentrador via la xarxa o mitjançant un fitxer d'exportació"
-
-#: ../../Zotlabs/Module/Import.php:539
-#: ../../Zotlabs/Module/Import_items.php:119
-msgid "File to Upload"
-msgstr "Fitxer a pujar"
-
-#: ../../Zotlabs/Module/Import.php:540
-msgid "Or provide the old server/hub details"
-msgstr "O proveeix els detalls de l'antic servidor/node"
-
-#: ../../Zotlabs/Module/Import.php:541
-msgid "Your old identity address (xyz@example.com)"
-msgstr "La teva adreça de canal antiga. El format és canal@exemple.org"
-
-#: ../../Zotlabs/Module/Import.php:542
-msgid "Your old login email address"
-msgstr "La teva adreça de correu electrònic antiga"
-
-#: ../../Zotlabs/Module/Import.php:543
-msgid "Your old login password"
-msgstr "La teva contrasenya antiga"
-
-#: ../../Zotlabs/Module/Import.php:544
-msgid ""
-"For either option, please choose whether to make this hub your new primary "
-"address, or whether your old location should continue this role. You will be"
-" able to post from either location, but only one can be marked as the "
-"primary location for files, photos, and media."
-msgstr "Per a qualsevol de les opcions, escull si vols fer primària l'adreça d'aquest node o mantenir l'anterior com a primària. Podràs penjar entrades des de totes dues adreces, però per als fitxers, imatges i altres en cal una de primària."
-
-#: ../../Zotlabs/Module/Import.php:545
-msgid "Make this hub my primary location"
-msgstr "Fes d'aquest node la meva ubicació primària"
-
-#: ../../Zotlabs/Module/Import.php:546
-msgid ""
-"Import existing posts if possible (experimental - limited by available "
-"memory"
-msgstr "Importa les entrades existents si es possible (experimental - limitat per la memòria disponible"
-
-#: ../../Zotlabs/Module/Import.php:547
-msgid ""
-"This process may take several minutes to complete. Please submit the form "
-"only once and leave this page open until finished."
-msgstr "Aquest procès pot trigar minuts en completar. Si et plau envia el formulari només una vegada i manté aquesta pàgina oberta fins que finalitzi."
-
-#: ../../Zotlabs/Module/Item.php:178
-msgid "Unable to locate original post."
-msgstr "No s'ha pogut trobar l'entrada original."
-
-#: ../../Zotlabs/Module/Item.php:427
-msgid "Empty post discarded."
-msgstr "S'ha descartat l'entrada perquè no té contingut."
-
-#: ../../Zotlabs/Module/Item.php:467
-msgid "Executable content type not permitted to this channel."
-msgstr "No està permès el contingut de tipus executable en aquest canal."
-
-#: ../../Zotlabs/Module/Item.php:847
-msgid "Duplicate post suppressed."
-msgstr "Publicació duplicada s'ha suprimit."
-
-#: ../../Zotlabs/Module/Item.php:977
-msgid "System error. Post not saved."
-msgstr "Hi ha hagut un error del sistema. L'entrada no s'ha desat."
-
-#: ../../Zotlabs/Module/Item.php:1241
-msgid "Unable to obtain post information from database."
-msgstr "No s'ha pogut obtenir informació de l'entrada a la base de dades."
-
-#: ../../Zotlabs/Module/Item.php:1248
-#, php-format
-msgid "You have reached your limit of %1$.0f top level posts."
-msgstr "Has assolit el teu límit de %1$.0f entrades (descomptant comentaris)."
-
-#: ../../Zotlabs/Module/Item.php:1255
-#, php-format
-msgid "You have reached your limit of %1$.0f webpages."
-msgstr "Has assolit el teu limit de %1$.0f pàgines web."
-
-#: ../../Zotlabs/Module/Layouts.php:181 ../../include/text.php:2267
-msgid "Layouts"
-msgstr "Format Gràfic"
-
-#: ../../Zotlabs/Module/Layouts.php:183
-msgid "Comanche page description language help"
-msgstr "Pgina d'ajuda del llenguatge Comanche"
-
-#: ../../Zotlabs/Module/Layouts.php:187
-msgid "Layout Description"
-msgstr "Descripció del Disseny de la Pàgina"
-
-#: ../../Zotlabs/Module/Layouts.php:192
-msgid "Download PDL file"
-msgstr "Descarrega l'arxiu PDL"
-
-#: ../../Zotlabs/Module/Home.php:61 ../../Zotlabs/Module/Home.php:69
-#: ../../Zotlabs/Module/Siteinfo.php:65
-msgid "$Projectname"
-msgstr "$Projectname"
-
-#: ../../Zotlabs/Module/Home.php:79
-#, php-format
-msgid "Welcome to %s"
-msgstr "Benvingut a %s"
-
-#: ../../Zotlabs/Module/Id.php:13
-msgid "First Name"
-msgstr "Nom"
-
-#: ../../Zotlabs/Module/Id.php:14
-msgid "Last Name"
-msgstr "Cognoms"
-
-#: ../../Zotlabs/Module/Id.php:15
-msgid "Nickname"
-msgstr "Àlies"
-
-#: ../../Zotlabs/Module/Id.php:16
-msgid "Full Name"
-msgstr "Nom Sencer"
-
-#: ../../Zotlabs/Module/Id.php:17 ../../Zotlabs/Module/Id.php:18
-#: ../../Zotlabs/Module/Admin.php:1035 ../../Zotlabs/Module/Admin.php:1047
-#: ../../include/network.php:2151 ../../boot.php:1705
-msgid "Email"
-msgstr "Correu electrónic"
-
-#: ../../Zotlabs/Module/Id.php:19 ../../Zotlabs/Module/Id.php:20
-#: ../../Zotlabs/Module/Id.php:21 ../../Zotlabs/Lib/Apps.php:236
-msgid "Profile Photo"
-msgstr "Foto del Perfil"
-
-#: ../../Zotlabs/Module/Id.php:22
-msgid "Profile Photo 16px"
-msgstr "Foto del Perfil 16px"
-
-#: ../../Zotlabs/Module/Id.php:23
-msgid "Profile Photo 32px"
-msgstr "Foto del Perfil 32px"
-
-#: ../../Zotlabs/Module/Id.php:24
-msgid "Profile Photo 48px"
-msgstr "Foto del Perfil 48px"
-
-#: ../../Zotlabs/Module/Id.php:25
-msgid "Profile Photo 64px"
-msgstr "Foto del Perfil 64px"
-
-#: ../../Zotlabs/Module/Id.php:26
-msgid "Profile Photo 80px"
-msgstr "Foto del Perfil 80px"
-
-#: ../../Zotlabs/Module/Id.php:27
-msgid "Profile Photo 128px"
-msgstr "Foto del Perfil 128px"
-
-#: ../../Zotlabs/Module/Id.php:28
-msgid "Timezone"
-msgstr "Zona horària"
-
-#: ../../Zotlabs/Module/Id.php:29 ../../Zotlabs/Module/Profiles.php:731
-msgid "Homepage URL"
-msgstr "URL de la pàgina d'inici"
-
-#: ../../Zotlabs/Module/Id.php:30 ../../Zotlabs/Lib/Apps.php:234
-msgid "Language"
-msgstr "Idioma"
-
-#: ../../Zotlabs/Module/Id.php:31
-msgid "Birth Year"
-msgstr "Any de Naixement"
-
-#: ../../Zotlabs/Module/Id.php:32
-msgid "Birth Month"
-msgstr "Mes de Naixement"
-
-#: ../../Zotlabs/Module/Id.php:33
-msgid "Birth Day"
-msgstr "Dia de Naixement"
-
-#: ../../Zotlabs/Module/Id.php:34
-msgid "Birthdate"
-msgstr "Aniversari"
-
-#: ../../Zotlabs/Module/Id.php:35 ../../Zotlabs/Module/Profiles.php:454
-msgid "Gender"
-msgstr "Gènere"
-
-#: ../../Zotlabs/Module/Id.php:108 ../../include/selectors.php:49
-#: ../../include/selectors.php:66
-msgid "Male"
-msgstr "Masculí"
-
-#: ../../Zotlabs/Module/Id.php:110 ../../include/selectors.php:49
-#: ../../include/selectors.php:66
-msgid "Female"
-msgstr "Femení"
-
-#: ../../Zotlabs/Module/Impel.php:41 ../../include/bbcode.php:192
-msgid "webpage"
-msgstr "pàgina web"
-
-#: ../../Zotlabs/Module/Impel.php:46 ../../include/bbcode.php:198
-msgid "block"
-msgstr "bloc"
-
-#: ../../Zotlabs/Module/Impel.php:51 ../../include/bbcode.php:195
-msgid "layout"
-msgstr "disposició"
-
-#: ../../Zotlabs/Module/Impel.php:58 ../../include/bbcode.php:201
-msgid "menu"
-msgstr "menú"
-
-#: ../../Zotlabs/Module/Impel.php:196
-#, php-format
-msgid "%s element installed"
-msgstr "%s element instal·lat"
-
-#: ../../Zotlabs/Module/Impel.php:199
-#, php-format
-msgid "%s element installation failed"
-msgstr "%s instal·lació d'element va fallar"
-
-#: ../../Zotlabs/Module/Like.php:19
-msgid "Like/Dislike"
-msgstr "M'agrada / No m'agrada"
-
-#: ../../Zotlabs/Module/Like.php:24
-msgid "This action is restricted to members."
-msgstr "Aquesta acció està restringida als membres."
-
-#: ../../Zotlabs/Module/Like.php:25
-msgid ""
-"Please <a href=\"rmagic\">login with your $Projectname ID</a> or <a "
-"href=\"register\">register as a new $Projectname member</a> to continue."
-msgstr "<a href=\"rmagic\">Entra amb la teva identitat $Projectname</a> o <a href=\"register\">registra't a $Projectname</a> per continuar."
-
-#: ../../Zotlabs/Module/Like.php:105 ../../Zotlabs/Module/Like.php:131
-#: ../../Zotlabs/Module/Like.php:169
-msgid "Invalid request."
-msgstr "Sol·licitud invàlida."
-
-#: ../../Zotlabs/Module/Like.php:117 ../../include/conversation.php:126
-msgid "channel"
-msgstr "canal"
-
-#: ../../Zotlabs/Module/Like.php:146
-msgid "thing"
-msgstr "cosa"
-
-#: ../../Zotlabs/Module/Like.php:192
-msgid "Channel unavailable."
-msgstr "El canal està inactiu."
-
-#: ../../Zotlabs/Module/Like.php:240
-msgid "Previous action reversed."
-msgstr "S'ha desfet l'acció anterior."
-
-#: ../../Zotlabs/Module/Like.php:371 ../../Zotlabs/Module/Subthread.php:87
-#: ../../Zotlabs/Module/Tagger.php:47 ../../include/text.php:1940
-#: ../../include/conversation.php:120
-msgid "photo"
-msgstr "foto"
-
-#: ../../Zotlabs/Module/Like.php:371 ../../Zotlabs/Module/Subthread.php:87
-#: ../../include/text.php:1946 ../../include/conversation.php:148
-msgid "status"
-msgstr "estat"
-
-#: ../../Zotlabs/Module/Like.php:420 ../../include/conversation.php:164
-#, php-format
-msgid "%1$s likes %2$s's %3$s"
-msgstr "%1$s agrada %2$s de %3$s"
-
-#: ../../Zotlabs/Module/Like.php:422 ../../include/conversation.php:167
-#, php-format
-msgid "%1$s doesn't like %2$s's %3$s"
-msgstr "%1$s no agrada %2$s de %3$s"
-
-#: ../../Zotlabs/Module/Like.php:424
-#, php-format
-msgid "%1$s agrees with %2$s's %3$s"
-msgstr "%1$s està d'acord amb %3$s de %2$s"
-
-#: ../../Zotlabs/Module/Like.php:426
-#, php-format
-msgid "%1$s doesn't agree with %2$s's %3$s"
-msgstr "%1$s no està d'acord amb %3$s de %2$s"
-
-#: ../../Zotlabs/Module/Like.php:428
-#, php-format
-msgid "%1$s abstains from a decision on %2$s's %3$s"
-msgstr "%1$s s'abstén en %3$s de %2$s"
-
-#: ../../Zotlabs/Module/Like.php:430
-#, php-format
-msgid "%1$s is attending %2$s's %3$s"
-msgstr "%1$s assistirà a %3$s de %2$s"
-
-#: ../../Zotlabs/Module/Like.php:432
-#, php-format
-msgid "%1$s is not attending %2$s's %3$s"
-msgstr "%1$s no assistirà a %3$s de %2$s"
-
-#: ../../Zotlabs/Module/Like.php:434
-#, php-format
-msgid "%1$s may attend %2$s's %3$s"
-msgstr "%1$s potser assistirà a %3$s de %2$s"
-
-#: ../../Zotlabs/Module/Like.php:537
-msgid "Action completed."
-msgstr "S'ha completat l'acció."
-
-#: ../../Zotlabs/Module/Like.php:538
-msgid "Thank you."
-msgstr "Gràcies."
-
-#: ../../Zotlabs/Module/Import_items.php:102
-msgid "Import completed"
-msgstr "S'ha completat la importació"
-
-#: ../../Zotlabs/Module/Import_items.php:117
-msgid "Import Items"
-msgstr "Importa Articles"
-
-#: ../../Zotlabs/Module/Import_items.php:118
-msgid ""
-"Use this form to import existing posts and content from an export file."
-msgstr "Empra aquest formulari per importar entrades existents i contingut d'un arxiu d'exportació."
-
-#: ../../Zotlabs/Module/Invite.php:29
-msgid "Total invitation limit exceeded."
-msgstr "El límit total invitacions s'ha superat."
-
-#: ../../Zotlabs/Module/Invite.php:53
-#, php-format
-msgid "%s : Not a valid email address."
-msgstr "%s: adreça de correu electrònic no vàlida."
-
-#: ../../Zotlabs/Module/Invite.php:63
-msgid "Please join us on $Projectname"
-msgstr "Si us plau uneix-te a nosaltres a $Projectname."
-
-#: ../../Zotlabs/Module/Invite.php:74
-msgid "Invitation limit exceeded. Please contact your site administrator."
-msgstr "Límit d'invitacions excedit. Si us plau, poseu-vos en contacte amb l'administrador del lloc."
-
-#: ../../Zotlabs/Module/Invite.php:79
-#, php-format
-msgid "%s : Message delivery failed."
-msgstr "%s : Entrega del Missatge fallida."
-
-#: ../../Zotlabs/Module/Invite.php:83
-#, php-format
-msgid "%d message sent."
-msgid_plural "%d messages sent."
-msgstr[0] "%d missatge enviat."
-msgstr[1] "%d missatges enviats."
-
-#: ../../Zotlabs/Module/Invite.php:102
-msgid "You have no more invitations available"
-msgstr "No té més invitacions disponibles"
-
-#: ../../Zotlabs/Module/Invite.php:133
-msgid "Send invitations"
-msgstr "Enviar invitacions"
-
-#: ../../Zotlabs/Module/Invite.php:134
-msgid "Enter email addresses, one per line:"
-msgstr "Introduïu les adreces de correu electrònic, una per línia:"
-
-#: ../../Zotlabs/Module/Invite.php:135 ../../Zotlabs/Module/Mail.php:249
-msgid "Your message:"
-msgstr "El teu missatge:"
-
-#: ../../Zotlabs/Module/Invite.php:136
-msgid "Please join my community on $Projectname."
-msgstr "Si us plau uneix-te la meva comunitat en $Projectname."
-
-#: ../../Zotlabs/Module/Invite.php:138
-msgid "You will need to supply this invitation code:"
-msgstr "Hauràs de facilitar aquest codi d'invitació:"
-
-#: ../../Zotlabs/Module/Invite.php:139
-msgid ""
-"1. Register at any $Projectname location (they are all inter-connected)"
-msgstr "1. Pots registrar-te a qualsevol node de $Projectname (estàn tots interconnectats)"
-
-#: ../../Zotlabs/Module/Invite.php:141
-msgid "2. Enter my $Projectname network address into the site searchbar."
-msgstr "2. Escriu la meva adreça de xarxa al $Projectname,  a la barra de cerca del lloc."
-
-#: ../../Zotlabs/Module/Invite.php:142
-msgid "or visit"
-msgstr "o visitar"
-
-#: ../../Zotlabs/Module/Invite.php:144
-msgid "3. Click [Connect]"
-msgstr "3. Clicar [Conectar]"
-
-#: ../../Zotlabs/Module/Lockview.php:61
-msgid "Remote privacy information not available."
-msgstr "informació privada remota no disponible."
-
-#: ../../Zotlabs/Module/Lockview.php:82
-msgid "Visible to:"
-msgstr "Visible per:"
-
-#: ../../Zotlabs/Module/Locs.php:25 ../../Zotlabs/Module/Locs.php:54
-msgid "Location not found."
-msgstr "Situació que no es troba."
-
-#: ../../Zotlabs/Module/Locs.php:62
-msgid "Location lookup failed."
-msgstr "Ha fallat la cerca d'ubicació."
-
-#: ../../Zotlabs/Module/Locs.php:66
-msgid ""
-"Please select another location to become primary before removing the primary"
-" location."
-msgstr "Seleccioneu una altra ubicació per esdevenir primària abans de retirar la ubicació principal."
-
-#: ../../Zotlabs/Module/Locs.php:95
-msgid "Syncing locations"
-msgstr "Sincronitza ubicacions"
-
-#: ../../Zotlabs/Module/Locs.php:105
-msgid "No locations found."
-msgstr "No es troben els llocs."
-
-#: ../../Zotlabs/Module/Locs.php:116
-msgid "Manage Channel Locations"
-msgstr "Gestionar Ubicacions de Canal"
-
-#: ../../Zotlabs/Module/Locs.php:118 ../../Zotlabs/Module/Profiles.php:470
-#: ../../Zotlabs/Module/Admin.php:1224
-msgid "Address"
-msgstr "Adreça"
-
-#: ../../Zotlabs/Module/Locs.php:119
-msgid "Primary"
-msgstr "Primari"
-
-#: ../../Zotlabs/Module/Locs.php:120 ../../Zotlabs/Module/Menu.php:113
-msgid "Drop"
-msgstr "Menysprea"
-
-#: ../../Zotlabs/Module/Locs.php:122
-msgid "Sync Now"
-msgstr "Sincronitza Ara"
-
-#: ../../Zotlabs/Module/Locs.php:123
-msgid "Please wait several minutes between consecutive operations."
-msgstr "Si us plau espera diversos minuts entre operacions consecutives."
-
-#: ../../Zotlabs/Module/Locs.php:124
-msgid ""
-"When possible, drop a location by logging into that website/hub and removing"
-" your channel."
-msgstr "Quan sigui possible, per desapareixer d'un lloc, accedeix a aquest lloc web/node i elimina el teu canal."
-
-#: ../../Zotlabs/Module/Locs.php:125
-msgid "Use this form to drop the location if the hub is no longer operating."
-msgstr "Empra aquest formulari per desapareixer del lloc si el node ja no està operatiu."
-
-#: ../../Zotlabs/Module/Magic.php:71
-msgid "Hub not found."
-msgstr "Node no trobat."
-
-#: ../../Zotlabs/Module/Mail.php:38
-msgid "Unable to lookup recipient."
-msgstr "Incapaç de trobar el destinatari."
-
-#: ../../Zotlabs/Module/Mail.php:45
-msgid "Unable to communicate with requested channel."
-msgstr "Incapaç de comunicar amb el canal demanat."
-
-#: ../../Zotlabs/Module/Mail.php:52
-msgid "Cannot verify requested channel."
-msgstr "No puc verificar el canal demanat."
-
-#: ../../Zotlabs/Module/Mail.php:78
-msgid "Selected channel has private message restrictions. Send failed."
-msgstr "El canal seleccionat te restriccions sobre els missatges privats. L'enviament ha fallat."
-
-#: ../../Zotlabs/Module/Mail.php:143
-msgid "Messages"
-msgstr "Missatges"
-
-#: ../../Zotlabs/Module/Mail.php:178
-msgid "Message recalled."
-msgstr "Recupera el missatge."
-
-#: ../../Zotlabs/Module/Mail.php:191
-msgid "Conversation removed."
-msgstr "Conversació eliminada."
-
-#: ../../Zotlabs/Module/Mail.php:206 ../../Zotlabs/Module/Mail.php:315
-msgid "Expires YYYY-MM-DD HH:MM"
-msgstr "Expira YYYY-MM-DD HH:MM"
-
-#: ../../Zotlabs/Module/Mail.php:234
-msgid "Requested channel is not in this network"
-msgstr "El canal demanat no hi es en questa xarxa"
-
-#: ../../Zotlabs/Module/Mail.php:242
-msgid "Send Private Message"
-msgstr "Envia Missatge Privat"
-
-#: ../../Zotlabs/Module/Mail.php:243 ../../Zotlabs/Module/Mail.php:368
-msgid "To:"
-msgstr "Per:"
-
-#: ../../Zotlabs/Module/Mail.php:246 ../../Zotlabs/Module/Mail.php:370
-msgid "Subject:"
-msgstr "Assumpte:"
-
-#: ../../Zotlabs/Module/Mail.php:251 ../../Zotlabs/Module/Mail.php:376
-#: ../../include/conversation.php:1220
-msgid "Attach file"
-msgstr "Adjunta arxiu"
-
-#: ../../Zotlabs/Module/Mail.php:253
-msgid "Send"
-msgstr "Envia"
-
-#: ../../Zotlabs/Module/Mail.php:256 ../../Zotlabs/Module/Mail.php:381
-#: ../../include/conversation.php:1251
-msgid "Set expiration date"
-msgstr "Ajusta la data d'expiració"
-
-#: ../../Zotlabs/Module/Mail.php:340
-msgid "Delete message"
-msgstr "Elimina el missatge"
-
-#: ../../Zotlabs/Module/Mail.php:341
-msgid "Delivery report"
-msgstr "Informe d'entrega"
-
-#: ../../Zotlabs/Module/Mail.php:342
-msgid "Recall message"
-msgstr "Recupera el missatge"
-
-#: ../../Zotlabs/Module/Mail.php:344
-msgid "Message has been recalled."
-msgstr "El missatge s'ha recuperat."
-
-#: ../../Zotlabs/Module/Mail.php:361
-msgid "Delete Conversation"
-msgstr "Conversació esborrada"
-
-#: ../../Zotlabs/Module/Mail.php:363
-msgid ""
-"No secure communications available. You <strong>may</strong> be able to "
-"respond from the sender's profile page."
-msgstr "Comunicació segura no disponible. Pots respondre des de la pàgina de perfil del remitent."
-
-#: ../../Zotlabs/Module/Mail.php:367
-msgid "Send Reply"
-msgstr "Envia Resposta"
-
-#: ../../Zotlabs/Module/Mail.php:372
-#, php-format
-msgid "Your message for %s (%s):"
-msgstr "El teu missatge per %s (%s):"
-
-#: ../../Zotlabs/Module/Manage.php:136
-#: ../../Zotlabs/Module/New_channel.php:121
-#, php-format
-msgid "You have created %1$.0f of %2$.0f allowed channels."
-msgstr "Has creat %1$.0f de %2$.0f canals permesos."
-
-#: ../../Zotlabs/Module/Manage.php:143
-msgid "Create a new channel"
-msgstr "Crear un nou canal"
-
-#: ../../Zotlabs/Module/Manage.php:164 ../../Zotlabs/Lib/Apps.php:213
-#: ../../include/nav.php:206
-msgid "Channel Manager"
-msgstr "Gestor de Canals"
-
-#: ../../Zotlabs/Module/Manage.php:165
-msgid "Current Channel"
-msgstr "Canal Actual"
-
-#: ../../Zotlabs/Module/Manage.php:167
-msgid "Switch to one of your channels by selecting it."
-msgstr "Canviar a un altre dels teus canals seleccionant-ho."
-
-#: ../../Zotlabs/Module/Manage.php:168
-msgid "Default Channel"
-msgstr "Canal per Defecte"
-
-#: ../../Zotlabs/Module/Manage.php:169
-msgid "Make Default"
-msgstr "Estableix com a Predeterminat"
-
-#: ../../Zotlabs/Module/Manage.php:172
-#, php-format
-msgid "%d new messages"
-msgstr "%d missatges nous"
-
-#: ../../Zotlabs/Module/Manage.php:173
-#, php-format
-msgid "%d new introductions"
-msgstr "%d noves presentacions"
-
-#: ../../Zotlabs/Module/Manage.php:175
-msgid "Delegated Channel"
-msgstr "Canal Delegat"
-
-#: ../../Zotlabs/Module/Lostpass.php:19
-msgid "No valid account found."
-msgstr "No es troba un compte vàlid."
-
-#: ../../Zotlabs/Module/Lostpass.php:33
-msgid "Password reset request issued. Check your email."
-msgstr "Sol·licitud de restabliment de contrasenya emesa. Consulta el teu correu electrònic."
-
-#: ../../Zotlabs/Module/Lostpass.php:39 ../../Zotlabs/Module/Lostpass.php:107
-#, php-format
-msgid "Site Member (%s)"
-msgstr "Lloc d'Usuari (%s)"
-
-#: ../../Zotlabs/Module/Lostpass.php:44
-#, php-format
-msgid "Password reset requested at %s"
-msgstr "S'ha soŀlicitat restablir la contrasenya al hub %s"
-
-#: ../../Zotlabs/Module/Lostpass.php:67
-msgid ""
-"Request could not be verified. (You may have previously submitted it.) "
-"Password reset failed."
-msgstr "Ha fallat el restabliment de contrasenya perquè la no s'ha pogut verificar soŀlicitud. Pot ser que ja ho hàgiu soŀlicitat abans."
-
-#: ../../Zotlabs/Module/Lostpass.php:90 ../../boot.php:1711
-msgid "Password Reset"
-msgstr "Restabliment de contrasenya"
-
-#: ../../Zotlabs/Module/Lostpass.php:91
-msgid "Your password has been reset as requested."
-msgstr "S'ha restablert la vostra contrasenya."
-
-#: ../../Zotlabs/Module/Lostpass.php:92
-msgid "Your new password is"
-msgstr "La nova contrasenya és"
-
-#: ../../Zotlabs/Module/Lostpass.php:93
-msgid "Save or copy your new password - and then"
-msgstr "Desa o copia la nova contrasenya, i després"
-
-#: ../../Zotlabs/Module/Lostpass.php:94
-msgid "click here to login"
-msgstr "fes clic aquí per iniciar sessió"
-
-#: ../../Zotlabs/Module/Lostpass.php:95
-msgid ""
-"Your password may be changed from the <em>Settings</em> page after "
-"successful login."
-msgstr "Pots canviar la contrasenya a la pàgina <em>Paràmetres</em>, un cop iniciada la sessió."
-
-#: ../../Zotlabs/Module/Lostpass.php:112
-#, php-format
-msgid "Your password has changed at %s"
-msgstr "La teva contrasenya a %s ha canviat"
-
-#: ../../Zotlabs/Module/Lostpass.php:127
-msgid "Forgot your Password?"
-msgstr "No recordes la contrasenya?"
-
-#: ../../Zotlabs/Module/Lostpass.php:128
-msgid ""
-"Enter your email address and submit to have your password reset. Then check "
-"your email for further instructions."
-msgstr "Escriu la teva adreça de correu electrònic i envia per restablir la contrasenya. Després revisa el seu correu electrònic per obtenir més instruccions."
-
-#: ../../Zotlabs/Module/Lostpass.php:129
-msgid "Email Address"
-msgstr "Adreça electrònica"
-
-#: ../../Zotlabs/Module/Lostpass.php:130
-msgid "Reset"
-msgstr "Reajustar"
+#: ../../Zotlabs/Module/Fbrowser.php:85 ../../Zotlabs/Lib/Apps.php:243
+#: ../../Zotlabs/Storage/Browser.php:272 ../../include/conversation.php:1839
+#: ../../include/nav.php:409
+msgid "Files"
+msgstr "Arxius"
 
 #: ../../Zotlabs/Module/Menu.php:49
 msgid "Unable to update menu."
@@ -2498,7 +5803,7 @@ msgstr "El menú es pot emprar per a guardar marcadors"
 msgid "Submit and proceed"
 msgstr "Envia i procedeix"
 
-#: ../../Zotlabs/Module/Menu.php:107 ../../include/text.php:2266
+#: ../../Zotlabs/Module/Menu.php:107 ../../include/text.php:2403
 msgid "Menus"
 msgstr "Menús"
 
@@ -2521,10 +5826,6 @@ msgstr "Edita el menú"
 #: ../../Zotlabs/Module/Menu.php:136
 msgid "Menu could not be deleted."
 msgstr "El menu no es pot esborrar."
-
-#: ../../Zotlabs/Module/Menu.php:144 ../../Zotlabs/Module/Mitem.php:28
-msgid "Menu not found."
-msgstr "Menú no trobat."
 
 #: ../../Zotlabs/Module/Menu.php:149
 msgid "Edit Menu"
@@ -2554,592 +5855,79 @@ msgstr "Títol del menú vist pels altres"
 msgid "Allow bookmarks"
 msgstr "Marcadors permesos"
 
-#: ../../Zotlabs/Module/Menu.php:166 ../../Zotlabs/Module/Mitem.php:120
-#: ../../Zotlabs/Module/Xchan.php:41
-msgid "Not found."
-msgstr "No trobat."
+#: ../../Zotlabs/Module/Layouts.php:184 ../../include/text.php:2404
+msgid "Layouts"
+msgstr "Dissenys"
 
-#: ../../Zotlabs/Module/Mood.php:67 ../../include/conversation.php:260
-#, php-format
-msgctxt "mood"
-msgid "%1$s is %2$s"
-msgstr "%1$s es %2$s"
+#: ../../Zotlabs/Module/Layouts.php:186 ../../Zotlabs/Lib/Apps.php:251
+#: ../../include/nav.php:176 ../../include/nav.php:280
+#: ../../include/help.php:68 ../../include/help.php:74
+msgid "Help"
+msgstr "Ajuda"
 
-#: ../../Zotlabs/Module/Mood.php:135 ../../Zotlabs/Lib/Apps.php:225
-msgid "Mood"
-msgstr "Ànim"
+#: ../../Zotlabs/Module/Layouts.php:186
+msgid "Comanche page description language help"
+msgstr "Pgina d'ajuda del llenguatge Comanche"
 
-#: ../../Zotlabs/Module/Mood.php:136
-msgid "Set your current mood and tell your friends"
-msgstr "Estableix el teu estat d'ànim actual i digues-li als teus amics"
+#: ../../Zotlabs/Module/Layouts.php:190
+msgid "Layout Description"
+msgstr "Descripció del disseny pàgina"
 
-#: ../../Zotlabs/Module/Match.php:26
-msgid "Profile Match"
-msgstr "Perfils compatibles"
+#: ../../Zotlabs/Module/Layouts.php:195
+msgid "Download PDL file"
+msgstr "Descarrega l'arxiu PDL"
 
-#: ../../Zotlabs/Module/Match.php:35
-msgid "No keywords to match. Please add keywords to your default profile."
-msgstr "No tens paraules clau al perfil principal per poder cercar perfils semblants."
+#: ../../Zotlabs/Module/Cloud.php:114
+msgid "Please refresh page"
+msgstr "Recarrega la pàgina"
 
-#: ../../Zotlabs/Module/Match.php:67
-msgid "is interested in:"
-msgstr "té interès en:"
+#: ../../Zotlabs/Module/Cloud.php:117
+msgid "Unknown error"
+msgstr "S'ha produït un error desconegut"
 
-#: ../../Zotlabs/Module/Match.php:74
-msgid "No matches"
-msgstr "No s'han trobat perfils compatibles"
+#: ../../Zotlabs/Module/Email_validation.php:24
+#: ../../Zotlabs/Module/Email_resend.php:12
+msgid "Token verification failed."
+msgstr "Ha fallat la verificació del token."
 
-#: ../../Zotlabs/Module/Network.php:96
-msgid "No such group"
-msgstr "No existeix el grup"
+#: ../../Zotlabs/Module/Email_validation.php:36
+msgid "Email Verification Required"
+msgstr "Cal verificar el correu"
 
-#: ../../Zotlabs/Module/Network.php:136
-msgid "No such channel"
-msgstr "No existeix el canal"
-
-#: ../../Zotlabs/Module/Network.php:141
-msgid "forum"
-msgstr "fòrum"
-
-#: ../../Zotlabs/Module/Network.php:153
-msgid "Search Results For:"
-msgstr "Cerca resultats per:"
-
-#: ../../Zotlabs/Module/Network.php:217
-msgid "Privacy group is empty"
-msgstr "el grup privat està vuit"
-
-#: ../../Zotlabs/Module/Network.php:226
-msgid "Privacy group: "
-msgstr "Grup privat:"
-
-#: ../../Zotlabs/Module/Network.php:252
-msgid "Invalid connection."
-msgstr "La connexió és invàlida."
-
-#: ../../Zotlabs/Module/Notify.php:57
-#: ../../Zotlabs/Module/Notifications.php:98
-msgid "No more system notifications."
-msgstr "No hi ha més notificacions del sistema."
-
-#: ../../Zotlabs/Module/Notify.php:61
-#: ../../Zotlabs/Module/Notifications.php:102
-msgid "System Notifications"
-msgstr "Notificacions del sistema"
-
-#: ../../Zotlabs/Module/Mitem.php:52
-msgid "Unable to create element."
-msgstr "Incapaç de crear l'element."
-
-#: ../../Zotlabs/Module/Mitem.php:76
-msgid "Unable to update menu element."
-msgstr "Incapaç d'actualitzar un element del menú."
-
-#: ../../Zotlabs/Module/Mitem.php:92
-msgid "Unable to add menu element."
-msgstr "Incapaç d'afegir l'element del menú."
-
-#: ../../Zotlabs/Module/Mitem.php:153 ../../Zotlabs/Module/Mitem.php:226
-msgid "Menu Item Permissions"
-msgstr "Permisos de l'Article del Menú"
-
-#: ../../Zotlabs/Module/Mitem.php:154 ../../Zotlabs/Module/Mitem.php:227
-#: ../../Zotlabs/Module/Settings.php:1068
-msgid "(click to open/close)"
-msgstr "(clica per obrir/tancar)"
-
-#: ../../Zotlabs/Module/Mitem.php:156 ../../Zotlabs/Module/Mitem.php:172
-msgid "Link Name"
-msgstr "Nom de l'Enllaç"
-
-#: ../../Zotlabs/Module/Mitem.php:157 ../../Zotlabs/Module/Mitem.php:231
-msgid "Link or Submenu Target"
-msgstr "Enllaç o Submenú Objectiu"
-
-#: ../../Zotlabs/Module/Mitem.php:157
-msgid "Enter URL of the link or select a menu name to create a submenu"
-msgstr "Entra la URL de l'enlla´o tria un nom de menú per crear un submenú"
-
-#: ../../Zotlabs/Module/Mitem.php:158 ../../Zotlabs/Module/Mitem.php:232
-msgid "Use magic-auth if available"
-msgstr "Empra magic-auth si esta disponible"
-
-#: ../../Zotlabs/Module/Mitem.php:159 ../../Zotlabs/Module/Mitem.php:233
-msgid "Open link in new window"
-msgstr "Obrir l'enllaç en una nova finestra"
-
-#: ../../Zotlabs/Module/Mitem.php:160 ../../Zotlabs/Module/Mitem.php:234
-msgid "Order in list"
-msgstr "Ordre per llista"
-
-#: ../../Zotlabs/Module/Mitem.php:160 ../../Zotlabs/Module/Mitem.php:234
-msgid "Higher numbers will sink to bottom of listing"
-msgstr "Els números més alts aniràn al fons de la llista"
-
-#: ../../Zotlabs/Module/Mitem.php:161
-msgid "Submit and finish"
-msgstr "Envia i termina"
-
-#: ../../Zotlabs/Module/Mitem.php:162
-msgid "Submit and continue"
-msgstr "Envia i continua"
-
-#: ../../Zotlabs/Module/Mitem.php:170
-msgid "Menu:"
-msgstr "Menú:"
-
-#: ../../Zotlabs/Module/Mitem.php:173
-msgid "Link Target"
-msgstr "Enllaç Objectiu"
-
-#: ../../Zotlabs/Module/Mitem.php:176
-msgid "Edit menu"
-msgstr "Edita menú"
-
-#: ../../Zotlabs/Module/Mitem.php:179
-msgid "Edit element"
-msgstr "Edita element"
-
-#: ../../Zotlabs/Module/Mitem.php:180
-msgid "Drop element"
-msgstr "Deixa anar element"
-
-#: ../../Zotlabs/Module/Mitem.php:181
-msgid "New element"
-msgstr "Nou element"
-
-#: ../../Zotlabs/Module/Mitem.php:182
-msgid "Edit this menu container"
-msgstr "Edita aquest contenidor de menú"
-
-#: ../../Zotlabs/Module/Mitem.php:183
-msgid "Add menu element"
-msgstr "Afegeix element de menú"
-
-#: ../../Zotlabs/Module/Mitem.php:184
-msgid "Delete this menu item"
-msgstr "Esborra aquest article del menú"
-
-#: ../../Zotlabs/Module/Mitem.php:185
-msgid "Edit this menu item"
-msgstr "Edita aquest article del menú"
-
-#: ../../Zotlabs/Module/Mitem.php:202
-msgid "Menu item not found."
-msgstr "Article del menú no trobat."
-
-#: ../../Zotlabs/Module/Mitem.php:215
-msgid "Menu item deleted."
-msgstr "Article del menú eliminat."
-
-#: ../../Zotlabs/Module/Mitem.php:217
-msgid "Menu item could not be deleted."
-msgstr "Article del menú no es pot eliminar."
-
-#: ../../Zotlabs/Module/Mitem.php:224
-msgid "Edit Menu Element"
-msgstr "Editar Element del Menú"
-
-#: ../../Zotlabs/Module/Mitem.php:230
-msgid "Link text"
-msgstr "Enllaç de text"
-
-#: ../../Zotlabs/Module/New_channel.php:128
-#: ../../Zotlabs/Module/Register.php:231
-msgid "Name or caption"
-msgstr "Nom o llegenda"
-
-#: ../../Zotlabs/Module/New_channel.php:128
-#: ../../Zotlabs/Module/Register.php:231
-msgid "Examples: \"Bob Jameson\", \"Lisa and her Horses\", \"Soccer\", \"Aviation Group\""
-msgstr "Exemples: \"Pep Gomila\", \"Manel i els seus Cavalls\", \"Fútbol\", \"Grup d'Aviadors\""
-
-#: ../../Zotlabs/Module/New_channel.php:130
-#: ../../Zotlabs/Module/Register.php:233
-msgid "Choose a short nickname"
-msgstr "Tria un àlies curt"
-
-#: ../../Zotlabs/Module/New_channel.php:130
-#: ../../Zotlabs/Module/Register.php:233
+#: ../../Zotlabs/Module/Email_validation.php:37
 #, php-format
 msgid ""
-"Your nickname will be used to create an easy to remember channel address "
-"e.g. nickname%s"
-msgstr "El teu àlies serà emprat per crear un nom fàcil per recordar l'adreça del canal p.e. àlies%s"
+"A verification token was sent to your email address [%s]. Enter that token "
+"here to complete the account verification step. Please allow a few minutes "
+"for delivery, and check your spam folder if you do not see the message."
+msgstr "S'ha enviat al teu correu (%s) un token de verificació. Introdueix-lo aquí per a completar la verificació del compte. Tingues en compte que el correu pot trigar uns minuts en arribar, i que hi ha proveïdors de correu que el classificaran com a correu brossa."
 
-#: ../../Zotlabs/Module/New_channel.php:132
-#: ../../Zotlabs/Module/Register.php:235
-msgid "Channel role and privacy"
-msgstr "Funció i privacitat del canal"
+#: ../../Zotlabs/Module/Email_validation.php:38
+msgid "Resend Email"
+msgstr "Torna a enviar el correu"
 
-#: ../../Zotlabs/Module/New_channel.php:132
-#: ../../Zotlabs/Module/Register.php:235
-msgid "Select a channel role with your privacy requirements."
-msgstr "Tria una funció pel canal amb els teus requisits de privacitat."
+#: ../../Zotlabs/Module/Email_validation.php:41
+msgid "Validation token"
+msgstr "Token de validació"
 
-#: ../../Zotlabs/Module/New_channel.php:132
-#: ../../Zotlabs/Module/Register.php:235
-msgid "Read more about roles"
-msgstr "Llegix més sobre els rols"
+#: ../../Zotlabs/Module/Tagger.php:48
+msgid "Post not found."
+msgstr "No s'ha trobat l'entrada"
 
-#: ../../Zotlabs/Module/New_channel.php:135
-msgid "Create Channel"
-msgstr "Crea un Canal"
+#: ../../Zotlabs/Module/Tagger.php:77 ../../include/markdown.php:160
+#: ../../include/bbcode.php:339
+msgid "post"
+msgstr "entrada"
 
-#: ../../Zotlabs/Module/New_channel.php:136
-msgid ""
-"A channel is your identity on this network. It can represent a person, a "
-"blog, or a forum to name a few. Channels can make connections with other "
-"channels to share information with highly detailed permissions."
-msgstr "Un canal es la tva identitat en aquesta xarxa. Pot representar una persona, un bloc, o un fòrum per anomenar alguns. Els canals poden connectar-se amb altres canals per compartir informació amb permisos molt detallats."
+#: ../../Zotlabs/Module/Tagger.php:79 ../../include/conversation.php:146
+#: ../../include/text.php:2012
+msgid "comment"
+msgstr "comentari"
 
-#: ../../Zotlabs/Module/New_channel.php:137
-msgid ""
-"or <a href=\"import\">import an existing channel</a> from another location."
-msgstr "o <a href=\"import\">importa un canal existent</a> des d'un altre ubicació."
-
-#: ../../Zotlabs/Module/Notifications.php:30
-msgid "Invalid request identifier."
-msgstr "Sol·licitud d'identificació invàlida."
-
-#: ../../Zotlabs/Module/Notifications.php:39
-msgid "Discard"
-msgstr "Descarta"
-
-#: ../../Zotlabs/Module/Notifications.php:103 ../../include/nav.php:191
-msgid "Mark all system notifications seen"
-msgstr "Marca totes les notificacions vistes"
-
-#: ../../Zotlabs/Module/Photos.php:84
-msgid "Page owner information could not be retrieved."
-msgstr "La informació del propietari de la pàgina no va poder ser recuperada"
-
-#: ../../Zotlabs/Module/Photos.php:99 ../../Zotlabs/Module/Photos.php:743
-#: ../../Zotlabs/Module/Profile_photo.php:114
-#: ../../Zotlabs/Module/Profile_photo.php:206
-#: ../../Zotlabs/Module/Profile_photo.php:294
-#: ../../include/photo/photo_driver.php:718
-msgid "Profile Photos"
-msgstr "Fotos del Perfil"
-
-#: ../../Zotlabs/Module/Photos.php:105 ../../Zotlabs/Module/Photos.php:149
-msgid "Album not found."
-msgstr "Àlbum no trobat"
-
-#: ../../Zotlabs/Module/Photos.php:132
-msgid "Delete Album"
-msgstr "Esborra Àlbum"
-
-#: ../../Zotlabs/Module/Photos.php:153
-msgid ""
-"Multiple storage folders exist with this album name, but within different "
-"directories. Please remove the desired folder or folders using the Files "
-"manager"
-msgstr "Existeixen moltes carpetes de emmagatzemament amb aquest nom d'àlbum, però en diferents directoris.  Si us plau esborra la carpeta o carpetes amb el gestor d'arxius."
-
-#: ../../Zotlabs/Module/Photos.php:210 ../../Zotlabs/Module/Photos.php:1053
-msgid "Delete Photo"
-msgstr "Esborra Foto"
-
-#: ../../Zotlabs/Module/Photos.php:533
-msgid "No photos selected"
-msgstr "No has seleccionat fotos"
-
-#: ../../Zotlabs/Module/Photos.php:582
-msgid "Access to this item is restricted."
-msgstr "L'accés a aquest element esta restringit."
-
-#: ../../Zotlabs/Module/Photos.php:621
+#: ../../Zotlabs/Module/Tagger.php:117
 #, php-format
-msgid "%1$.2f MB of %2$.2f MB photo storage used."
-msgstr "S'estan fent servir %1$.2f MB de %2$.2f MB de l'espai per a imatges."
-
-#: ../../Zotlabs/Module/Photos.php:624
-#, php-format
-msgid "%1$.2f MB photo storage used."
-msgstr "S'estan fent servir %1$.2f MB de l'espai per a imatges."
-
-#: ../../Zotlabs/Module/Photos.php:660
-msgid "Upload Photos"
-msgstr "Puja imatges"
-
-#: ../../Zotlabs/Module/Photos.php:664
-msgid "Enter an album name"
-msgstr "Escriu el nom del àlbum"
-
-#: ../../Zotlabs/Module/Photos.php:665
-msgid "or select an existing album (doubleclick)"
-msgstr "o bé fes doble clic a un d'existent"
-
-#: ../../Zotlabs/Module/Photos.php:666
-msgid "Create a status post for this upload"
-msgstr "Genera una entrada a partir de la pujada"
-
-#: ../../Zotlabs/Module/Photos.php:667
-msgid "Caption (optional):"
-msgstr "Subtítol (opcional):"
-
-#: ../../Zotlabs/Module/Photos.php:668
-msgid "Description (optional):"
-msgstr "Descripció (opcional):"
-
-#: ../../Zotlabs/Module/Photos.php:695
-msgid "Album name could not be decoded"
-msgstr "No s'ha pogut descodificar el nom de l'àlbum"
-
-#: ../../Zotlabs/Module/Photos.php:743
-msgid "Contact Photos"
-msgstr "Imatges de contactes"
-
-#: ../../Zotlabs/Module/Photos.php:766
-msgid "Show Newest First"
-msgstr "Ordena de més nou a més antic"
-
-#: ../../Zotlabs/Module/Photos.php:768
-msgid "Show Oldest First"
-msgstr "Ordena de més antic a més nou"
-
-#: ../../Zotlabs/Module/Photos.php:792 ../../Zotlabs/Module/Photos.php:1331
-#: ../../include/widgets.php:1499
-msgid "View Photo"
-msgstr "Mostra la imatge"
-
-#: ../../Zotlabs/Module/Photos.php:823 ../../include/widgets.php:1516
-msgid "Edit Album"
-msgstr "Modifica l'àlbum"
-
-#: ../../Zotlabs/Module/Photos.php:870
-msgid "Permission denied. Access to this item may be restricted."
-msgstr "S'ha denegat el permís. Pot ser que l'accés estigui restringit."
-
-#: ../../Zotlabs/Module/Photos.php:872
-msgid "Photo not available"
-msgstr "La imatge no està disponible"
-
-#: ../../Zotlabs/Module/Photos.php:930
-msgid "Use as profile photo"
-msgstr "Fes-la imatge de perfil"
-
-#: ../../Zotlabs/Module/Photos.php:931
-msgid "Use as cover photo"
-msgstr "Emprar com a foto de portada"
-
-#: ../../Zotlabs/Module/Photos.php:938
-msgid "Private Photo"
-msgstr "Imatge privada"
-
-#: ../../Zotlabs/Module/Photos.php:953
-msgid "View Full Size"
-msgstr "Mostra a mida completa"
-
-#: ../../Zotlabs/Module/Photos.php:998 ../../Zotlabs/Module/Admin.php:1437
-#: ../../Zotlabs/Module/Tagrm.php:137
-msgid "Remove"
-msgstr "Esborra"
-
-#: ../../Zotlabs/Module/Photos.php:1032
-msgid "Edit photo"
-msgstr "Modifica la imatge"
-
-#: ../../Zotlabs/Module/Photos.php:1034
-msgid "Rotate CW (right)"
-msgstr "Tomba cap a la dreta"
-
-#: ../../Zotlabs/Module/Photos.php:1035
-msgid "Rotate CCW (left)"
-msgstr "Tomba cap a l'esquerra"
-
-#: ../../Zotlabs/Module/Photos.php:1038
-msgid "Enter a new album name"
-msgstr "Escriu el nom del nou àlbum"
-
-#: ../../Zotlabs/Module/Photos.php:1039
-msgid "or select an existing one (doubleclick)"
-msgstr "o bé fes doble clic a un d'existent"
-
-#: ../../Zotlabs/Module/Photos.php:1042
-msgid "Caption"
-msgstr "Llegenda"
-
-#: ../../Zotlabs/Module/Photos.php:1044
-msgid "Add a Tag"
-msgstr "Afegeix una etiqueta"
-
-#: ../../Zotlabs/Module/Photos.php:1048
-msgid "Example: @bob, @Barbara_Jensen, @jim@example.com"
-msgstr "Exemple: @joan, @Paula_Peris, @mar@exemple.org"
-
-#: ../../Zotlabs/Module/Photos.php:1051
-msgid "Flag as adult in album view"
-msgstr "Marca com a contingut adult"
-
-#: ../../Zotlabs/Module/Photos.php:1070 ../../Zotlabs/Lib/ThreadItem.php:261
-msgid "I like this (toggle)"
-msgstr "M'agrada això (canvia)"
-
-#: ../../Zotlabs/Module/Photos.php:1071 ../../Zotlabs/Lib/ThreadItem.php:262
-msgid "I don't like this (toggle)"
-msgstr "No m'agrada això (canvia)"
-
-#: ../../Zotlabs/Module/Photos.php:1073 ../../Zotlabs/Lib/ThreadItem.php:397
-#: ../../include/conversation.php:740
-msgid "Please wait"
-msgstr "Si us plau, espera"
-
-#: ../../Zotlabs/Module/Photos.php:1089 ../../Zotlabs/Module/Photos.php:1207
-#: ../../Zotlabs/Lib/ThreadItem.php:707
-msgid "This is you"
-msgstr "Ets tú"
-
-#: ../../Zotlabs/Module/Photos.php:1091 ../../Zotlabs/Module/Photos.php:1209
-#: ../../Zotlabs/Lib/ThreadItem.php:709 ../../include/js_strings.php:6
-msgid "Comment"
-msgstr "Comentari"
-
-#: ../../Zotlabs/Module/Photos.php:1107 ../../include/conversation.php:574
-msgctxt "title"
-msgid "Likes"
-msgstr "Agrada"
-
-#: ../../Zotlabs/Module/Photos.php:1107 ../../include/conversation.php:574
-msgctxt "title"
-msgid "Dislikes"
-msgstr "Desagrada"
-
-#: ../../Zotlabs/Module/Photos.php:1108 ../../include/conversation.php:575
-msgctxt "title"
-msgid "Agree"
-msgstr "Acord"
-
-#: ../../Zotlabs/Module/Photos.php:1108 ../../include/conversation.php:575
-msgctxt "title"
-msgid "Disagree"
-msgstr "Desacord"
-
-#: ../../Zotlabs/Module/Photos.php:1108 ../../include/conversation.php:575
-msgctxt "title"
-msgid "Abstain"
-msgstr "Abstenirse"
-
-#: ../../Zotlabs/Module/Photos.php:1109 ../../include/conversation.php:576
-msgctxt "title"
-msgid "Attending"
-msgstr "Assistint"
-
-#: ../../Zotlabs/Module/Photos.php:1109 ../../include/conversation.php:576
-msgctxt "title"
-msgid "Not attending"
-msgstr "Desassistint"
-
-#: ../../Zotlabs/Module/Photos.php:1109 ../../include/conversation.php:576
-msgctxt "title"
-msgid "Might attend"
-msgstr "Podrien assistir"
-
-#: ../../Zotlabs/Module/Photos.php:1126 ../../Zotlabs/Module/Photos.php:1138
-#: ../../Zotlabs/Lib/ThreadItem.php:181 ../../Zotlabs/Lib/ThreadItem.php:193
-#: ../../include/conversation.php:1717
-msgid "View all"
-msgstr "Veure tot"
-
-#: ../../Zotlabs/Module/Photos.php:1130 ../../Zotlabs/Lib/ThreadItem.php:185
-#: ../../include/taxonomy.php:403 ../../include/conversation.php:1741
-#: ../../include/channel.php:1158
-msgctxt "noun"
-msgid "Like"
-msgid_plural "Likes"
-msgstr[0] "Agrada"
-msgstr[1] "Agraden"
-
-#: ../../Zotlabs/Module/Photos.php:1135 ../../Zotlabs/Lib/ThreadItem.php:190
-#: ../../include/conversation.php:1744
-msgctxt "noun"
-msgid "Dislike"
-msgid_plural "Dislikes"
-msgstr[0] "Desagrada"
-msgstr[1] "Desagrada"
-
-#: ../../Zotlabs/Module/Photos.php:1235
-msgid "Photo Tools"
-msgstr "Eines per Fotos"
-
-#: ../../Zotlabs/Module/Photos.php:1244
-msgid "In This Photo:"
-msgstr "Hi apareixen:"
-
-#: ../../Zotlabs/Module/Photos.php:1249
-msgid "Map"
-msgstr "Mapa"
-
-#: ../../Zotlabs/Module/Photos.php:1257 ../../Zotlabs/Lib/ThreadItem.php:386
-msgctxt "noun"
-msgid "Likes"
-msgstr "Agrada"
-
-#: ../../Zotlabs/Module/Photos.php:1258 ../../Zotlabs/Lib/ThreadItem.php:387
-msgctxt "noun"
-msgid "Dislikes"
-msgstr "Desagrada"
-
-#: ../../Zotlabs/Module/Photos.php:1263 ../../Zotlabs/Lib/ThreadItem.php:392
-#: ../../include/acl_selectors.php:285
-msgid "Close"
-msgstr "Tanca"
-
-#: ../../Zotlabs/Module/Photos.php:1337
-msgid "View Album"
-msgstr "Mostra'n l'àlbum"
-
-#: ../../Zotlabs/Module/Photos.php:1348 ../../Zotlabs/Module/Photos.php:1361
-#: ../../Zotlabs/Module/Photos.php:1362
-msgid "Recent Photos"
-msgstr "Imatges recents"
-
-#: ../../Zotlabs/Module/Ping.php:265
-msgid "sent you a private message"
-msgstr "Se t'ha enviat un missatge privat"
-
-#: ../../Zotlabs/Module/Ping.php:313
-msgid "added your channel"
-msgstr "el teu canal s'ha afegit"
-
-#: ../../Zotlabs/Module/Ping.php:323
-msgid "g A l F d"
-msgstr "g A l F d"
-
-#: ../../Zotlabs/Module/Ping.php:346
-msgid "[today]"
-msgstr "[avui]"
-
-#: ../../Zotlabs/Module/Ping.php:355
-msgid "posted an event"
-msgstr "enviat un esdeveniment"
-
-#: ../../Zotlabs/Module/Oexchange.php:27
-msgid "Unable to find your hub."
-msgstr "No es possible trobar el node"
-
-#: ../../Zotlabs/Module/Oexchange.php:41
-msgid "Post successful."
-msgstr "Entrada realitzada amb èxit. "
-
-#: ../../Zotlabs/Module/Openid.php:30
-msgid "OpenID protocol error. No ID returned."
-msgstr "Error del protocol OpenID. No ha retornat ID"
-
-#: ../../Zotlabs/Module/Openid.php:193 ../../include/auth.php:226
-msgid "Login failed."
-msgstr "Identificació fallida."
-
-#: ../../Zotlabs/Module/Page.php:133
-msgid ""
-"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
-"tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,"
-" quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo "
-"consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse "
-"cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat "
-"non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-msgstr "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+msgid "%1$s tagged %2$s's %3$s with %4$s"
+msgstr "%1$s ha etiquetat %3$s de %2$s amb %4$s"
 
 #: ../../Zotlabs/Module/Pconfig.php:26 ../../Zotlabs/Module/Pconfig.php:59
 msgid "This setting requires special processing and editing has been blocked."
@@ -3156,62 +5944,76 @@ msgid ""
 " to correctly use this feature."
 msgstr "atenció: Realitzar segons quins ajustos pot fer el canal inoperable. Deixa aquesta pàgina si no estas segur i tens suficients coneixements sobre l'ús correcte d'aquesta característica."
 
-#: ../../Zotlabs/Module/Pdledit.php:18
-msgid "Layout updated."
-msgstr "S'ha actualitzat la disposició."
+#: ../../Zotlabs/Module/Defperms.php:239
+msgid ""
+"If enabled, connection requests will be approved without your interaction"
+msgstr "Si s'habilita, les soŀlicituds de connexió s'aprovaran automàticament sense requerir la teva interacció"
 
-#: ../../Zotlabs/Module/Pdledit.php:34 ../../Zotlabs/Module/Pdledit.php:61
-msgid "Edit System Page Description"
-msgstr "Editor del Sistema de Descripció de Pàgines"
+#: ../../Zotlabs/Module/Defperms.php:246
+msgid "Automatic approval settings"
+msgstr "Aprovació automàtica de soŀlicituds de connexió"
 
-#: ../../Zotlabs/Module/Pdledit.php:56
-msgid "Layout not found."
-msgstr "No s'ha trobat cap disposició de pàgina."
+#: ../../Zotlabs/Module/Defperms.php:254
+msgid ""
+"Some individual permissions may have been preset or locked based on your "
+"channel type and privacy settings."
+msgstr "El valor per defecte dels permisos individuals poden tenir valors per defecte segons el tipus de canal i les opcions de privacitat. Pot ser que no estiguis autoritzat/da a modificar-los."
 
-#: ../../Zotlabs/Module/Pdledit.php:62
-msgid "Module Name:"
-msgstr "Nom del mòdul:"
+#: ../../Zotlabs/Module/Group.php:24
+msgid "Privacy group created."
+msgstr "Creat grup privat."
 
-#: ../../Zotlabs/Module/Pdledit.php:63
-msgid "Layout Help"
-msgstr "Ajuda per la disposició de pàgina"
+#: ../../Zotlabs/Module/Group.php:30
+msgid "Could not create privacy group."
+msgstr "No es pot crear el grup privat."
 
-#: ../../Zotlabs/Module/Poke.php:168 ../../Zotlabs/Lib/Apps.php:226
-#: ../../include/conversation.php:960
-msgid "Poke"
-msgstr "Esperonar"
+#: ../../Zotlabs/Module/Group.php:42 ../../Zotlabs/Module/Group.php:143
+#: ../../include/items.php:4131
+msgid "Privacy group not found."
+msgstr "No es troben grups privats."
 
-#: ../../Zotlabs/Module/Poke.php:169
-msgid "Poke somebody"
-msgstr "Emprenyar algú"
+#: ../../Zotlabs/Module/Group.php:58
+msgid "Privacy group updated."
+msgstr "Grup privat actualitzat."
 
-#: ../../Zotlabs/Module/Poke.php:172
-msgid "Poke/Prod"
-msgstr "Esperonat/Picat"
+#: ../../Zotlabs/Module/Group.php:92
+msgid "Create a group of channels."
+msgstr "Crear un grup de canals."
 
-#: ../../Zotlabs/Module/Poke.php:173
-msgid "Poke, prod or do other things to somebody"
-msgstr "emprenyar, picar o fer altres coses a algú"
+#: ../../Zotlabs/Module/Group.php:93 ../../Zotlabs/Module/Group.php:186
+msgid "Privacy group name: "
+msgstr "Nom del grup privat:"
 
-#: ../../Zotlabs/Module/Poke.php:180
-msgid "Recipient"
-msgstr "Destinatari"
+#: ../../Zotlabs/Module/Group.php:95 ../../Zotlabs/Module/Group.php:189
+msgid "Members are visible to other channels"
+msgstr "Els membres son visibles en altres canals"
 
-#: ../../Zotlabs/Module/Poke.php:181
-msgid "Choose what you wish to do to recipient"
-msgstr "Tria que vols fer amb el destinatari"
+#: ../../Zotlabs/Module/Group.php:113
+msgid "Privacy group removed."
+msgstr "Grup privat eliminat."
 
-#: ../../Zotlabs/Module/Poke.php:184 ../../Zotlabs/Module/Poke.php:185
-msgid "Make this post private"
-msgstr "Fer aquesta entrada privada"
+#: ../../Zotlabs/Module/Group.php:115
+msgid "Unable to remove privacy group."
+msgstr "No puc eliminar el grup privat."
 
-#: ../../Zotlabs/Module/Probe.php:30 ../../Zotlabs/Module/Probe.php:34
-#, php-format
-msgid "Fetching URL returns error: %1$s"
-msgstr "URL sol·licitada retorna error: %1$s"
+#: ../../Zotlabs/Module/Group.php:185
+msgid "Privacy group editor"
+msgstr "Editor del grup privat"
 
-#: ../../Zotlabs/Module/Profiles.php:24 ../../Zotlabs/Module/Profiles.php:189
-#: ../../Zotlabs/Module/Profiles.php:246 ../../Zotlabs/Module/Profiles.php:625
+#: ../../Zotlabs/Module/Group.php:199 ../../Zotlabs/Module/Help.php:81
+msgid "Members"
+msgstr "Membres"
+
+#: ../../Zotlabs/Module/Group.php:201
+msgid "All Connected Channels"
+msgstr "Tots els Canals Connectats"
+
+#: ../../Zotlabs/Module/Group.php:233
+msgid "Click on a channel to add or remove."
+msgstr "Clic sobre el canal per afegir o esborrar."
+
+#: ../../Zotlabs/Module/Profiles.php:24 ../../Zotlabs/Module/Profiles.php:184
+#: ../../Zotlabs/Module/Profiles.php:241 ../../Zotlabs/Module/Profiles.php:659
 msgid "Profile not found."
 msgstr "Perfil no trobat."
 
@@ -3219,2776 +6021,621 @@ msgstr "Perfil no trobat."
 msgid "Profile deleted."
 msgstr "Perfil eliminat."
 
-#: ../../Zotlabs/Module/Profiles.php:68 ../../Zotlabs/Module/Profiles.php:104
+#: ../../Zotlabs/Module/Profiles.php:68 ../../Zotlabs/Module/Profiles.php:105
 msgid "Profile-"
 msgstr "Perfil-"
 
-#: ../../Zotlabs/Module/Profiles.php:89 ../../Zotlabs/Module/Profiles.php:132
+#: ../../Zotlabs/Module/Profiles.php:90 ../../Zotlabs/Module/Profiles.php:127
 msgid "New profile created."
 msgstr "Nou perfil creat."
 
-#: ../../Zotlabs/Module/Profiles.php:110
+#: ../../Zotlabs/Module/Profiles.php:111
 msgid "Profile unavailable to clone."
 msgstr "Perfil que no es pot clonar."
 
-#: ../../Zotlabs/Module/Profiles.php:151
+#: ../../Zotlabs/Module/Profiles.php:146
 msgid "Profile unavailable to export."
 msgstr "Perfil que no es pot exportar."
 
-#: ../../Zotlabs/Module/Profiles.php:256
+#: ../../Zotlabs/Module/Profiles.php:252
 msgid "Profile Name is required."
 msgstr "Es requereix el Nom del Perfil."
 
-#: ../../Zotlabs/Module/Profiles.php:427
+#: ../../Zotlabs/Module/Profiles.php:459
 msgid "Marital Status"
 msgstr "Estat Marital"
 
-#: ../../Zotlabs/Module/Profiles.php:431
+#: ../../Zotlabs/Module/Profiles.php:463
 msgid "Romantic Partner"
 msgstr "Company/a Romàntic"
 
-#: ../../Zotlabs/Module/Profiles.php:435 ../../Zotlabs/Module/Profiles.php:736
+#: ../../Zotlabs/Module/Profiles.php:467 ../../Zotlabs/Module/Profiles.php:775
 msgid "Likes"
 msgstr "Agrada"
 
-#: ../../Zotlabs/Module/Profiles.php:439 ../../Zotlabs/Module/Profiles.php:737
+#: ../../Zotlabs/Module/Profiles.php:471 ../../Zotlabs/Module/Profiles.php:776
 msgid "Dislikes"
 msgstr "Desagrada"
 
-#: ../../Zotlabs/Module/Profiles.php:443 ../../Zotlabs/Module/Profiles.php:744
+#: ../../Zotlabs/Module/Profiles.php:475 ../../Zotlabs/Module/Profiles.php:783
 msgid "Work/Employment"
 msgstr "Treball/Feina"
 
-#: ../../Zotlabs/Module/Profiles.php:446
+#: ../../Zotlabs/Module/Profiles.php:478
 msgid "Religion"
 msgstr "Religió"
 
-#: ../../Zotlabs/Module/Profiles.php:450
+#: ../../Zotlabs/Module/Profiles.php:482
 msgid "Political Views"
 msgstr "Idees Polítiques"
 
-#: ../../Zotlabs/Module/Profiles.php:458
+#: ../../Zotlabs/Module/Profiles.php:486
+#: ../../addon/openid/MysqlProvider.php:74
+msgid "Gender"
+msgstr "Gènere"
+
+#: ../../Zotlabs/Module/Profiles.php:490
 msgid "Sexual Preference"
 msgstr "Preferència Sexual"
 
-#: ../../Zotlabs/Module/Profiles.php:462
+#: ../../Zotlabs/Module/Profiles.php:494
 msgid "Homepage"
 msgstr "Pàgina Personal"
 
-#: ../../Zotlabs/Module/Profiles.php:466
+#: ../../Zotlabs/Module/Profiles.php:498
 msgid "Interests"
 msgstr "Interessos"
 
-#: ../../Zotlabs/Module/Profiles.php:560
+#: ../../Zotlabs/Module/Profiles.php:594
 msgid "Profile updated."
 msgstr "Perfil actualitzat."
 
-#: ../../Zotlabs/Module/Profiles.php:644
+#: ../../Zotlabs/Module/Profiles.php:678
 msgid "Hide your connections list from viewers of this profile"
 msgstr "Amaga dels curiosos la teva llista de connexions d'aquest perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:686
+#: ../../Zotlabs/Module/Profiles.php:725
 msgid "Edit Profile Details"
 msgstr "Edita els Detalls del Perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:688
+#: ../../Zotlabs/Module/Profiles.php:727
 msgid "View this profile"
 msgstr "Veure aquest perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:689 ../../Zotlabs/Module/Profiles.php:771
-#: ../../include/channel.php:959
+#: ../../Zotlabs/Module/Profiles.php:728 ../../Zotlabs/Module/Profiles.php:827
+#: ../../include/channel.php:1320
 msgid "Edit visibility"
 msgstr "Editar visibilitat"
 
-#: ../../Zotlabs/Module/Profiles.php:690
+#: ../../Zotlabs/Module/Profiles.php:729
 msgid "Profile Tools"
 msgstr "Eines per Perfils"
 
-#: ../../Zotlabs/Module/Profiles.php:691
+#: ../../Zotlabs/Module/Profiles.php:730
 msgid "Change cover photo"
 msgstr "Canviar la foto de portada"
 
-#: ../../Zotlabs/Module/Profiles.php:692 ../../include/channel.php:930
+#: ../../Zotlabs/Module/Profiles.php:731 ../../include/channel.php:1290
 msgid "Change profile photo"
 msgstr "Canviar la foto del perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:693
+#: ../../Zotlabs/Module/Profiles.php:732
 msgid "Create a new profile using these settings"
 msgstr "Crea un perfil nou amb aquests ajustos"
 
-#: ../../Zotlabs/Module/Profiles.php:694
+#: ../../Zotlabs/Module/Profiles.php:733
 msgid "Clone this profile"
 msgstr "Clonar aquest perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:695
+#: ../../Zotlabs/Module/Profiles.php:734
 msgid "Delete this profile"
 msgstr "Elimina aquest perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:696
+#: ../../Zotlabs/Module/Profiles.php:735
 msgid "Add profile things"
 msgstr "Afegeix coses al perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:697 ../../include/widgets.php:105
-#: ../../include/conversation.php:1526
+#: ../../Zotlabs/Module/Profiles.php:736 ../../include/conversation.php:1705
 msgid "Personal"
 msgstr "Personal"
 
-#: ../../Zotlabs/Module/Profiles.php:699
+#: ../../Zotlabs/Module/Profiles.php:738
 msgid "Relation"
 msgstr "Relació"
 
-#: ../../Zotlabs/Module/Profiles.php:700 ../../include/datetime.php:48
+#: ../../Zotlabs/Module/Profiles.php:739 ../../Zotlabs/Widget/Newmember.php:53
+#: ../../include/datetime.php:58
 msgid "Miscellaneous"
 msgstr "Miscelania"
 
-#: ../../Zotlabs/Module/Profiles.php:702
+#: ../../Zotlabs/Module/Profiles.php:741
 msgid "Import profile from file"
 msgstr "Importa perfil des d'un arxiu"
 
-#: ../../Zotlabs/Module/Profiles.php:703
+#: ../../Zotlabs/Module/Profiles.php:742
 msgid "Export profile to file"
 msgstr "Exporta perfil a un arxiu"
 
-#: ../../Zotlabs/Module/Profiles.php:704
+#: ../../Zotlabs/Module/Profiles.php:743
 msgid "Your gender"
 msgstr "El teu gènere"
 
-#: ../../Zotlabs/Module/Profiles.php:705
+#: ../../Zotlabs/Module/Profiles.php:744
 msgid "Marital status"
 msgstr "Estat marital"
 
-#: ../../Zotlabs/Module/Profiles.php:706
+#: ../../Zotlabs/Module/Profiles.php:745
 msgid "Sexual preference"
 msgstr "Preferència sexual"
 
-#: ../../Zotlabs/Module/Profiles.php:709
+#: ../../Zotlabs/Module/Profiles.php:748
 msgid "Profile name"
 msgstr "Nom del perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:711
+#: ../../Zotlabs/Module/Profiles.php:750
 msgid "This is your default profile."
 msgstr "Aquest es el teu perfil per defecte"
 
-#: ../../Zotlabs/Module/Profiles.php:713
+#: ../../Zotlabs/Module/Profiles.php:752
 msgid "Your full name"
 msgstr "El teu nom complet"
 
-#: ../../Zotlabs/Module/Profiles.php:714
+#: ../../Zotlabs/Module/Profiles.php:753
 msgid "Title/Description"
 msgstr "Títol/Descripció"
 
-#: ../../Zotlabs/Module/Profiles.php:717
+#: ../../Zotlabs/Module/Profiles.php:756
 msgid "Street address"
 msgstr "Carrer"
 
-#: ../../Zotlabs/Module/Profiles.php:718
+#: ../../Zotlabs/Module/Profiles.php:757
 msgid "Locality/City"
 msgstr "Població/Ciutat"
 
-#: ../../Zotlabs/Module/Profiles.php:719
+#: ../../Zotlabs/Module/Profiles.php:758
 msgid "Region/State"
 msgstr "Regió/Estat"
 
-#: ../../Zotlabs/Module/Profiles.php:720
+#: ../../Zotlabs/Module/Profiles.php:759
 msgid "Postal/Zip code"
 msgstr "Codi Postal"
 
-#: ../../Zotlabs/Module/Profiles.php:721
-msgid "Country"
-msgstr "País"
-
-#: ../../Zotlabs/Module/Profiles.php:726
+#: ../../Zotlabs/Module/Profiles.php:765
 msgid "Who (if applicable)"
 msgstr "Qui (si es aplicable)"
 
-#: ../../Zotlabs/Module/Profiles.php:726
+#: ../../Zotlabs/Module/Profiles.php:765
 msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
 msgstr "Examples: cathy123, Cathy Williams, cathy@example.com"
 
-#: ../../Zotlabs/Module/Profiles.php:727
+#: ../../Zotlabs/Module/Profiles.php:766
 msgid "Since (date)"
 msgstr "Des de (data)"
 
-#: ../../Zotlabs/Module/Profiles.php:730
+#: ../../Zotlabs/Module/Profiles.php:769
 msgid "Tell us about yourself"
 msgstr "Quelcom sobre tu"
 
-#: ../../Zotlabs/Module/Profiles.php:732
+#: ../../Zotlabs/Module/Profiles.php:770
+#: ../../addon/openid/MysqlProvider.php:68
+msgid "Homepage URL"
+msgstr "URL de la pàgina d'inici"
+
+#: ../../Zotlabs/Module/Profiles.php:771
 msgid "Hometown"
 msgstr "Ciutat Natal"
 
-#: ../../Zotlabs/Module/Profiles.php:733
+#: ../../Zotlabs/Module/Profiles.php:772
 msgid "Political views"
 msgstr "Idees polítiques"
 
-#: ../../Zotlabs/Module/Profiles.php:734
+#: ../../Zotlabs/Module/Profiles.php:773
 msgid "Religious views"
 msgstr "Creences religioses"
 
-#: ../../Zotlabs/Module/Profiles.php:735
+#: ../../Zotlabs/Module/Profiles.php:774
 msgid "Keywords used in directory listings"
 msgstr "Paraules clau emprades en els llistats de directoris"
 
-#: ../../Zotlabs/Module/Profiles.php:735
+#: ../../Zotlabs/Module/Profiles.php:774
 msgid "Example: fishing photography software"
 msgstr "Exemple: software de fotografia submarina"
 
-#: ../../Zotlabs/Module/Profiles.php:738
+#: ../../Zotlabs/Module/Profiles.php:777
 msgid "Musical interests"
 msgstr "Interessos Musicals"
 
-#: ../../Zotlabs/Module/Profiles.php:739
+#: ../../Zotlabs/Module/Profiles.php:778
 msgid "Books, literature"
 msgstr "Llibres, literatura"
 
-#: ../../Zotlabs/Module/Profiles.php:740
+#: ../../Zotlabs/Module/Profiles.php:779
 msgid "Television"
 msgstr "Televisió"
 
-#: ../../Zotlabs/Module/Profiles.php:741
+#: ../../Zotlabs/Module/Profiles.php:780
 msgid "Film/Dance/Culture/Entertainment"
 msgstr "Pel·lícules/Dansa/Cultura/Entreteniment"
 
-#: ../../Zotlabs/Module/Profiles.php:742
+#: ../../Zotlabs/Module/Profiles.php:781
 msgid "Hobbies/Interests"
 msgstr "Aficions/Interessos"
 
-#: ../../Zotlabs/Module/Profiles.php:743
+#: ../../Zotlabs/Module/Profiles.php:782
 msgid "Love/Romance"
 msgstr "Amor/Romace"
 
-#: ../../Zotlabs/Module/Profiles.php:745
+#: ../../Zotlabs/Module/Profiles.php:784
 msgid "School/Education"
 msgstr "Escola/Educació"
 
-#: ../../Zotlabs/Module/Profiles.php:746
+#: ../../Zotlabs/Module/Profiles.php:785
 msgid "Contact information and social networks"
 msgstr "Informació de contacte i xarxes socials"
 
-#: ../../Zotlabs/Module/Profiles.php:747
+#: ../../Zotlabs/Module/Profiles.php:786
 msgid "My other channels"
 msgstr "Els meus altres canals"
 
-#: ../../Zotlabs/Module/Profiles.php:767 ../../include/channel.php:955
+#: ../../Zotlabs/Module/Profiles.php:788
+msgid "Communications"
+msgstr "Comunicacions"
+
+#: ../../Zotlabs/Module/Profiles.php:823 ../../include/channel.php:1316
 msgid "Profile Image"
 msgstr "Imatge del Perfil"
 
-#: ../../Zotlabs/Module/Profiles.php:777 ../../include/nav.php:88
-#: ../../include/channel.php:937
+#: ../../Zotlabs/Module/Profiles.php:833 ../../include/channel.php:1297
+#: ../../include/nav.php:117
 msgid "Edit Profiles"
 msgstr "Editar Perfils"
 
-#: ../../Zotlabs/Module/Profile_photo.php:179
+#: ../../Zotlabs/Module/Go.php:21
+msgid "This page is available only to site members"
+msgstr "Aquesta pàgina només és accessible per als membres del node."
+
+#: ../../Zotlabs/Module/Go.php:27
+msgid "Welcome"
+msgstr "Benvingut/da"
+
+#: ../../Zotlabs/Module/Go.php:29
+msgid "What would you like to do?"
+msgstr "Què t'agradaria fer?"
+
+#: ../../Zotlabs/Module/Go.php:31
 msgid ""
-"Shift-reload the page or clear browser cache if the new photo does not "
-"display immediately."
-msgstr "Refresca la memòria cau del navegador si la foto no s'actualitza immediatament. Dreceres: «Ctrl+F5» i «Ctrl+Maj+R»"
+"Please bookmark this page if you would like to return to it in the future"
+msgstr "Marca aquesta pàgina si vols tornar-hi en un futur"
 
-#: ../../Zotlabs/Module/Profile_photo.php:367
-msgid "Upload Profile Photo"
-msgstr "Puja una Foto pel Perfil"
+#: ../../Zotlabs/Module/Go.php:35
+msgid "Upload a profile photo"
+msgstr "Puja una imatge de perfil"
 
-#: ../../Zotlabs/Module/Profperm.php:34 ../../Zotlabs/Module/Profperm.php:63
-msgid "Invalid profile identifier."
-msgstr "Identificador invàlid de perfil."
+#: ../../Zotlabs/Module/Go.php:36
+msgid "Upload a cover photo"
+msgstr "Puja una imatge de portada"
 
-#: ../../Zotlabs/Module/Profperm.php:115
-msgid "Profile Visibility Editor"
-msgstr "Perfil del Editor de Visibilitat"
+#: ../../Zotlabs/Module/Go.php:37
+msgid "Edit your default profile"
+msgstr "Modifica el teu perfil"
 
-#: ../../Zotlabs/Module/Profperm.php:117 ../../include/channel.php:1249
-msgid "Profile"
-msgstr "Perfil"
+#: ../../Zotlabs/Module/Go.php:38 ../../Zotlabs/Widget/Newmember.php:43
+msgid "View friend suggestions"
+msgstr "Mostra suggerències de connexions"
 
-#: ../../Zotlabs/Module/Profperm.php:119
-msgid "Click on a contact to add or remove."
-msgstr "Clica sobre el contacte per afegir o esborrar."
+#: ../../Zotlabs/Module/Go.php:39 ../../Zotlabs/Widget/Newmember.php:42
+msgid "View the channel directory"
+msgstr "Mostra el directori del canal"
 
-#: ../../Zotlabs/Module/Profperm.php:128
-msgid "Visible To"
-msgstr "Visible per"
+#: ../../Zotlabs/Module/Go.php:40
+msgid "View/edit your channel settings"
+msgstr "Mostra o modifica la configuració del teu canal"
 
-#: ../../Zotlabs/Module/Pubsites.php:22 ../../include/widgets.php:1270
-msgid "Public Hubs"
-msgstr "Nodes Públics"
+#: ../../Zotlabs/Module/Go.php:41
+msgid "View the site or project documentation"
+msgstr "Mostra la documentació del projecte"
 
-#: ../../Zotlabs/Module/Pubsites.php:25
+#: ../../Zotlabs/Module/Go.php:42
+msgid "Visit your channel homepage"
+msgstr "Ves a la pàgina del teu canal"
+
+#: ../../Zotlabs/Module/Go.php:43
 msgid ""
-"The listed hubs allow public registration for the $Projectname network. All "
-"hubs in the network are interlinked so membership on any of them conveys "
-"membership in the network as a whole. Some hubs may require subscription or "
-"provide tiered service plans. The hub itself <strong>may</strong> provide "
-"additional details."
-msgstr "Els nodes llistats permeten registrar usuaris de la xarxa $Projectname. Com que tots els nodes estan enllaçats entre ells, la identitat és vàlida a tota la xarxa. Alguns nodes poden demanar subscripció o oferir serveis addicional de pagament. Per a més detalls, <strong>proveu</strong> de seguir els enllaços dels proveïdors."
+"View your connections and/or add somebody whose address you already know"
+msgstr "Mostra les teves connexions o afegeix-ne una de nova introduint la seva adreça a mà."
 
-#: ../../Zotlabs/Module/Pubsites.php:31
-msgid "Hub URL"
-msgstr "URL del Node"
+#: ../../Zotlabs/Module/Go.php:44
+msgid ""
+"View your personal stream (this may be empty until you add some connections)"
+msgstr "Mostra el teu flux personal. Estarà buit mentre no et connectis amb ningú."
 
-#: ../../Zotlabs/Module/Pubsites.php:31
-msgid "Access Type"
-msgstr "Tipus d'accés"
+#: ../../Zotlabs/Module/Go.php:52
+msgid "View the public stream. Warning: this content is not moderated"
+msgstr "Mostra el flux públic. Avís: aquest contingut no està moderat"
 
-#: ../../Zotlabs/Module/Pubsites.php:31
-msgid "Registration Policy"
-msgstr "Condicions de registre"
+#: ../../Zotlabs/Module/Editwebpage.php:139
+msgid "Page link"
+msgstr "Enllaç de la pàgina"
 
-#: ../../Zotlabs/Module/Pubsites.php:31
-msgid "Stats"
-msgstr "Estadístiques"
+#: ../../Zotlabs/Module/Editwebpage.php:166
+msgid "Edit Webpage"
+msgstr "Edita la Pàgina Web"
 
-#: ../../Zotlabs/Module/Pubsites.php:31
-msgid "Software"
-msgstr "Programari"
+#: ../../Zotlabs/Module/Manage.php:145
+msgid "Create a new channel"
+msgstr "Crear un nou canal"
 
-#: ../../Zotlabs/Module/Pubsites.php:31 ../../Zotlabs/Module/Ratings.php:103
-#: ../../include/conversation.php:959
-msgid "Ratings"
-msgstr "Valoracions"
+#: ../../Zotlabs/Module/Manage.php:170 ../../Zotlabs/Lib/Apps.php:240
+#: ../../include/nav.php:102 ../../include/nav.php:190
+msgid "Channel Manager"
+msgstr "Gestor de Canals"
 
-#: ../../Zotlabs/Module/Pubsites.php:38
-msgid "Rate"
-msgstr "Puntua"
+#: ../../Zotlabs/Module/Manage.php:171
+msgid "Current Channel"
+msgstr "Canal Actual"
 
-#: ../../Zotlabs/Module/Rate.php:160
-msgid "Website:"
-msgstr "Lloc web:"
+#: ../../Zotlabs/Module/Manage.php:173
+msgid "Switch to one of your channels by selecting it."
+msgstr "Canviar a un altre dels teus canals seleccionant-ho."
 
-#: ../../Zotlabs/Module/Rate.php:163
+#: ../../Zotlabs/Module/Manage.php:174
+msgid "Default Channel"
+msgstr "Canal per Defecte"
+
+#: ../../Zotlabs/Module/Manage.php:175
+msgid "Make Default"
+msgstr "Estableix com a Predeterminat"
+
+#: ../../Zotlabs/Module/Manage.php:178
 #, php-format
-msgid "Remote Channel [%s] (not yet known on this site)"
-msgstr "Canal Remot [%s] (encara no es coneix en aquest lloc)"
+msgid "%d new messages"
+msgstr "%d missatges nous"
 
-#: ../../Zotlabs/Module/Rate.php:164
-msgid "Rating (this information is public)"
-msgstr "Valoració (aquesta informació és pública)"
-
-#: ../../Zotlabs/Module/Rate.php:165
-msgid "Optionally explain your rating (this information is public)"
-msgstr "Opcionalment pots explicar la teva qualificació (aquesta informació és pública)"
-
-#: ../../Zotlabs/Module/Ratings.php:73
-msgid "No ratings"
-msgstr "No valorat"
-
-#: ../../Zotlabs/Module/Ratings.php:104
-msgid "Rating: "
-msgstr "Valoració:"
-
-#: ../../Zotlabs/Module/Ratings.php:105
-msgid "Website: "
-msgstr "Lloc web:"
-
-#: ../../Zotlabs/Module/Ratings.php:107
-msgid "Description: "
-msgstr "Descripció:"
-
-#: ../../Zotlabs/Module/Admin.php:77
-msgid "Theme settings updated."
-msgstr "Ajustos de tema actualitzats."
-
-#: ../../Zotlabs/Module/Admin.php:197
-msgid "# Accounts"
-msgstr "# Comptes"
-
-#: ../../Zotlabs/Module/Admin.php:198
-msgid "# blocked accounts"
-msgstr "# comptes bloquejats"
-
-#: ../../Zotlabs/Module/Admin.php:199
-msgid "# expired accounts"
-msgstr "# comptes expirats"
-
-#: ../../Zotlabs/Module/Admin.php:200
-msgid "# expiring accounts"
-msgstr "# comptes expirant"
-
-#: ../../Zotlabs/Module/Admin.php:211
-msgid "# Channels"
-msgstr "# Canals"
-
-#: ../../Zotlabs/Module/Admin.php:212
-msgid "# primary"
-msgstr "# primari"
-
-#: ../../Zotlabs/Module/Admin.php:213
-msgid "# clones"
-msgstr "# clons"
-
-#: ../../Zotlabs/Module/Admin.php:219
-msgid "Message queues"
-msgstr "Cues de missatges"
-
-#: ../../Zotlabs/Module/Admin.php:236
-msgid "Your software should be updated"
-msgstr "El teu programari cal que s'actualitzi"
-
-#: ../../Zotlabs/Module/Admin.php:241 ../../Zotlabs/Module/Admin.php:490
-#: ../../Zotlabs/Module/Admin.php:711 ../../Zotlabs/Module/Admin.php:755
-#: ../../Zotlabs/Module/Admin.php:1030 ../../Zotlabs/Module/Admin.php:1209
-#: ../../Zotlabs/Module/Admin.php:1329 ../../Zotlabs/Module/Admin.php:1419
-#: ../../Zotlabs/Module/Admin.php:1612 ../../Zotlabs/Module/Admin.php:1646
-#: ../../Zotlabs/Module/Admin.php:1731
-msgid "Administration"
-msgstr "Administració"
-
-#: ../../Zotlabs/Module/Admin.php:242
-msgid "Summary"
-msgstr "Sumari"
-
-#: ../../Zotlabs/Module/Admin.php:245
-msgid "Registered accounts"
-msgstr "Comptes registrades"
-
-#: ../../Zotlabs/Module/Admin.php:246 ../../Zotlabs/Module/Admin.php:715
-msgid "Pending registrations"
-msgstr "Comptes pendents de registre"
-
-#: ../../Zotlabs/Module/Admin.php:247
-msgid "Registered channels"
-msgstr "Canals registrats"
-
-#: ../../Zotlabs/Module/Admin.php:248 ../../Zotlabs/Module/Admin.php:716
-msgid "Active plugins"
-msgstr "Plugins actius"
-
-#: ../../Zotlabs/Module/Admin.php:249
-msgid "Version"
-msgstr "Versió"
-
-#: ../../Zotlabs/Module/Admin.php:250
-msgid "Repository version (master)"
-msgstr "Versió (master) del repositori"
-
-#: ../../Zotlabs/Module/Admin.php:251
-msgid "Repository version (dev)"
-msgstr "Versió (desenvolupament) del repositori"
-
-#: ../../Zotlabs/Module/Admin.php:373
-msgid "Site settings updated."
-msgstr "Ajustos del Lloc actualitzats"
-
-#: ../../Zotlabs/Module/Admin.php:400 ../../include/text.php:2841
-msgid "Default"
-msgstr "Predeterminat"
-
-#: ../../Zotlabs/Module/Admin.php:410 ../../Zotlabs/Module/Settings.php:798
-msgid "mobile"
-msgstr "mòbil"
-
-#: ../../Zotlabs/Module/Admin.php:412
-msgid "experimental"
-msgstr "experimental"
-
-#: ../../Zotlabs/Module/Admin.php:414
-msgid "unsupported"
-msgstr "no soportat"
-
-#: ../../Zotlabs/Module/Admin.php:460
-msgid "Yes - with approval"
-msgstr "Sí - amb aprovació"
-
-#: ../../Zotlabs/Module/Admin.php:466
-msgid "My site is not a public server"
-msgstr "El meu lloc no es un servidor públic"
-
-#: ../../Zotlabs/Module/Admin.php:467
-msgid "My site has paid access only"
-msgstr "El meu lloc te accès per pagament"
-
-#: ../../Zotlabs/Module/Admin.php:468
-msgid "My site has free access only"
-msgstr "El meu lloc te lliure accés"
-
-#: ../../Zotlabs/Module/Admin.php:469
-msgid "My site offers free accounts with optional paid upgrades"
-msgstr "El meu lloc te comptes gratis amb opció de millores per pagament"
-
-#: ../../Zotlabs/Module/Admin.php:491 ../../include/widgets.php:1382
-msgid "Site"
-msgstr "Lloc"
-
-#: ../../Zotlabs/Module/Admin.php:493 ../../Zotlabs/Module/Register.php:245
-msgid "Registration"
-msgstr "Registre"
-
-#: ../../Zotlabs/Module/Admin.php:494
-msgid "File upload"
-msgstr "Pujar arxiu"
-
-#: ../../Zotlabs/Module/Admin.php:495
-msgid "Policies"
-msgstr "Polítiques"
-
-#: ../../Zotlabs/Module/Admin.php:496 ../../include/contact_widgets.php:16
-msgid "Advanced"
-msgstr "Avançat"
-
-#: ../../Zotlabs/Module/Admin.php:500
-msgid "Site name"
-msgstr "Nom del lloc"
-
-#: ../../Zotlabs/Module/Admin.php:501
-msgid "Banner/Logo"
-msgstr "Senyera/Logo"
-
-#: ../../Zotlabs/Module/Admin.php:502
-msgid "Administrator Information"
-msgstr "Informació de l'Administrador"
-
-#: ../../Zotlabs/Module/Admin.php:502
-msgid ""
-"Contact information for site administrators.  Displayed on siteinfo page.  "
-"BBCode can be used here"
-msgstr "Informació per contactar amb els administradors del lloc. Mostrada a la pàgina d'informació del lloc. Es pot emprar BBCode aquí"
-
-#: ../../Zotlabs/Module/Admin.php:503
-msgid "System language"
-msgstr "Idioma del sistema"
-
-#: ../../Zotlabs/Module/Admin.php:504
-msgid "System theme"
-msgstr "Tema del sistema"
-
-#: ../../Zotlabs/Module/Admin.php:504
-msgid ""
-"Default system theme - may be over-ridden by user profiles - <a href='#' "
-"id='cnftheme'>change theme settings</a>"
-msgstr "Tema del sistema per defecte - pot ser sobrescrit pel perfils dels usuaris - <a href='#' id='cnftheme'>Ajustos de canvi del tema</a>"
-
-#: ../../Zotlabs/Module/Admin.php:505
-msgid "Mobile system theme"
-msgstr "Tema del sistema per a mòbils"
-
-#: ../../Zotlabs/Module/Admin.php:505
-msgid "Theme for mobile devices"
-msgstr "Tema per a aparells mòbils"
-
-#: ../../Zotlabs/Module/Admin.php:507
-msgid "Allow Feeds as Connections"
-msgstr "Permetre Retroalimentadors com Connexions"
-
-#: ../../Zotlabs/Module/Admin.php:507
-msgid "(Heavy system resource usage)"
-msgstr "(Demana molts recursos del sistema)"
-
-#: ../../Zotlabs/Module/Admin.php:508
-msgid "Maximum image size"
-msgstr "Mida màxima d'imatge"
-
-#: ../../Zotlabs/Module/Admin.php:508
-msgid ""
-"Maximum size in bytes of uploaded images. Default is 0, which means no "
-"limits."
-msgstr "Mida màxima en bytes d'imatges pujades. Per defecte es 0, el que vol dir sense límits."
-
-#: ../../Zotlabs/Module/Admin.php:509
-msgid "Does this site allow new member registration?"
-msgstr "Permet aquest lloc registre de nous membres?"
-
-#: ../../Zotlabs/Module/Admin.php:510
-msgid "Invitation only"
-msgstr "Només per invitació"
-
-#: ../../Zotlabs/Module/Admin.php:510
-msgid ""
-"Only allow new member registrations with an invitation code. Above register "
-"policy must be set to Yes."
-msgstr "Només permet registre de nos membres amb codi d'invitació. A més la política de registre s'ha d'establir a Sí."
-
-#: ../../Zotlabs/Module/Admin.php:511
-msgid "Which best describes the types of account offered by this hub?"
-msgstr "Que es es que millor descriu la mena de comptes oferits per aquest concentrador?"
-
-#: ../../Zotlabs/Module/Admin.php:512
-msgid "Register text"
-msgstr "text de registre"
-
-#: ../../Zotlabs/Module/Admin.php:512
-msgid "Will be displayed prominently on the registration page."
-msgstr "Es mostrarà preminentment a la pàgina de registre"
-
-#: ../../Zotlabs/Module/Admin.php:513
-msgid "Site homepage to show visitors (default: login box)"
-msgstr "Pàgina d'inici a mostrar als visitants (per defecte: la pàgina d'identificació)"
-
-#: ../../Zotlabs/Module/Admin.php:513
-msgid ""
-"example: 'public' to show public stream, 'page/sys/home' to show a system "
-"webpage called 'home' or 'include:home.html' to include a file."
-msgstr "exemple: 'públic' per a mostrar un flux públic, 'page/sys/home' per a mostrar una pàgina web dita 'home' o 'include:home.html' per a incloure un arxiu."
-
-#: ../../Zotlabs/Module/Admin.php:514
-msgid "Preserve site homepage URL"
-msgstr "Preservar URL de la pàgina web"
-
-#: ../../Zotlabs/Module/Admin.php:514
-msgid ""
-"Present the site homepage in a frame at the original location instead of "
-"redirecting"
-msgstr "Presenta la pàgina web del lloc en un marc en el lloc original enlloc de redirigir cap a ella"
-
-#: ../../Zotlabs/Module/Admin.php:515
-msgid "Accounts abandoned after x days"
-msgstr "Els copmte es consideren abandonats despres de x dies"
-
-#: ../../Zotlabs/Module/Admin.php:515
-msgid ""
-"Will not waste system resources polling external sites for abandonded "
-"accounts. Enter 0 for no time limit."
-msgstr "No malgastar recursos del sistema sondejant llocs externs per acomptes abandonats. Entrar 0 vol dir sense límit de temps."
-
-#: ../../Zotlabs/Module/Admin.php:516
-msgid "Allowed friend domains"
-msgstr "dominis amics permesos"
-
-#: ../../Zotlabs/Module/Admin.php:516
-msgid ""
-"Comma separated list of domains which are allowed to establish friendships "
-"with this site. Wildcards are accepted. Empty to allow any domains"
-msgstr "llista separada per comes de dominis en els que està permès establir relacions d'amistat amb aquest lloc. S'accepten comodins. Deixar buit per acceptar qualsevol domini"
-
-#: ../../Zotlabs/Module/Admin.php:517
-msgid "Allowed email domains"
-msgstr "Dominis de correu electonic acceptats"
-
-#: ../../Zotlabs/Module/Admin.php:517
-msgid ""
-"Comma separated list of domains which are allowed in email addresses for "
-"registrations to this site. Wildcards are accepted. Empty to allow any "
-"domains"
-msgstr "llista separada per comes de dominis d'adreces de correu electrònic permeses en aquest lloc. S'accepten comodins. Deixar buit per acceptar qualsevol domini"
-
-#: ../../Zotlabs/Module/Admin.php:518
-msgid "Not allowed email domains"
-msgstr "Dominis de correu electrònic no acceptats"
-
-#: ../../Zotlabs/Module/Admin.php:518
-msgid ""
-"Comma separated list of domains which are not allowed in email addresses for"
-" registrations to this site. Wildcards are accepted. Empty to allow any "
-"domains, unless allowed domains have been defined."
-msgstr "llista separada per comes de dominis d'adreces de correu electrònic no permeses en aquest lloc. S'accepten comodins. Deixar buit per no acceptar cap domini, excepte els que s'hagin definits com acceptats."
-
-#: ../../Zotlabs/Module/Admin.php:519
-msgid "Verify Email Addresses"
-msgstr "Verifica l'Adreça de Correu Electrònic"
-
-#: ../../Zotlabs/Module/Admin.php:519
-msgid ""
-"Check to verify email addresses used in account registration (recommended)."
-msgstr "Activa per comprovar l'adreça de correu electrònic emprada durant el registre d'un nou compte (recomanat)"
-
-#: ../../Zotlabs/Module/Admin.php:520
-msgid "Force publish"
-msgstr "Forza la publicació"
-
-#: ../../Zotlabs/Module/Admin.php:520
-msgid ""
-"Check to force all profiles on this site to be listed in the site directory."
-msgstr "Activa per forzar que tots el perfils en aquest lloc siguin llistats en el directori del lloc."
-
-#: ../../Zotlabs/Module/Admin.php:521
-msgid "Import Public Streams"
-msgstr "Importar Fluxos Públics"
-
-#: ../../Zotlabs/Module/Admin.php:521
-msgid ""
-"Import and allow access to public content pulled from other sites. Warning: "
-"this content is unmoderated."
-msgstr "Importa i permet l'accés a contingut públic sondejat d'altres llocs. Avís: aquest contingut no estarà moderat."
-
-#: ../../Zotlabs/Module/Admin.php:522
-msgid "Login on Homepage"
-msgstr "Accés a la Pàgina d'inici"
-
-#: ../../Zotlabs/Module/Admin.php:522
-msgid ""
-"Present a login box to visitors on the home page if no other content has "
-"been configured."
-msgstr "Presenta una casella d'identificació a la pàgina d'inici als visitants si no s'ha configurat altre contingut."
-
-#: ../../Zotlabs/Module/Admin.php:523
-msgid "Enable context help"
-msgstr "Activar l'ajuda contextual"
-
-#: ../../Zotlabs/Module/Admin.php:523
-msgid ""
-"Display contextual help for the current page when the help button is "
-"pressed."
-msgstr "Mostra l'ajuda contextual per la pàgina actual quan el botó d'ajuda es pressionat."
-
-#: ../../Zotlabs/Module/Admin.php:525
-msgid "Directory Server URL"
-msgstr "URL del Servidor de Directoris"
-
-#: ../../Zotlabs/Module/Admin.php:525
-msgid "Default directory server"
-msgstr "Servidor de directori per defecte"
-
-#: ../../Zotlabs/Module/Admin.php:527
-msgid "Proxy user"
-msgstr "Usuari Proxy"
-
-#: ../../Zotlabs/Module/Admin.php:528
-msgid "Proxy URL"
-msgstr "URL del Proxy"
-
-#: ../../Zotlabs/Module/Admin.php:529
-msgid "Network timeout"
-msgstr "Temps d'espera de la xarxa"
-
-#: ../../Zotlabs/Module/Admin.php:529
-msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
-msgstr "Valor en segons. Ajusta a 0 per a sense límits (no recomanat)"
-
-#: ../../Zotlabs/Module/Admin.php:530
-msgid "Delivery interval"
-msgstr "Interval de lliurament"
-
-#: ../../Zotlabs/Module/Admin.php:530
-msgid ""
-"Delay background delivery processes by this many seconds to reduce system "
-"load. Recommend: 4-5 for shared hosts, 2-3 for virtual private servers. 0-1 "
-"for large dedicated servers."
-msgstr "Retarda en segon plà l'interval de lliurament per aquests segons per reduir la càrrega del sistema. Recomanat:  4-5 per a hostes compartits, 2-3 per a servidors privats virtuals. 0-1 per a servidors dedicats."
-
-#: ../../Zotlabs/Module/Admin.php:531
-msgid "Deliveries per process"
-msgstr "Entregues per processar"
-
-#: ../../Zotlabs/Module/Admin.php:531
-msgid ""
-"Number of deliveries to attempt in a single operating system process. Adjust"
-" if necessary to tune system performance. Recommend: 1-5."
-msgstr "Nombre de entregues a intentar processar en un únic procèss del sistema operatiu. Ajustar si es necessari per millorar el rendiment. Es recomana: 1-5."
-
-#: ../../Zotlabs/Module/Admin.php:532
-msgid "Poll interval"
-msgstr "interval de sondeig"
-
-#: ../../Zotlabs/Module/Admin.php:532
-msgid ""
-"Delay background polling processes by this many seconds to reduce system "
-"load. If 0, use delivery interval."
-msgstr "Retarda en segon pla el sondeig en aquesta quantitat de segons per a reduir la càrrega dels sistema. Si es 0 , empra l'interval de lliurament."
-
-#: ../../Zotlabs/Module/Admin.php:533
-msgid "Maximum Load Average"
-msgstr "Càrrega Mitja Màxima"
-
-#: ../../Zotlabs/Module/Admin.php:533
-msgid ""
-"Maximum system load before delivery and poll processes are deferred - "
-"default 50."
-msgstr "Càrrega màxima del sistema, abans que els processos de lliurament i sondeig es difereixin - 50 per defecte."
-
-#: ../../Zotlabs/Module/Admin.php:534
-msgid "Expiration period in days for imported (grid/network) content"
-msgstr "Període d'expiració en dies per contingut importat (malla/xarxa)"
-
-#: ../../Zotlabs/Module/Admin.php:534
-msgid "0 for no expiration of imported content"
-msgstr "0 vol dir sense temps d'expiració pel contingut importat"
-
-#: ../../Zotlabs/Module/Admin.php:677 ../../Zotlabs/Module/Admin.php:678
-#: ../../Zotlabs/Module/Settings.php:722
-msgid "Off"
-msgstr "Apagat"
-
-#: ../../Zotlabs/Module/Admin.php:677 ../../Zotlabs/Module/Admin.php:678
-#: ../../Zotlabs/Module/Settings.php:722
-msgid "On"
-msgstr "Funcionant"
-
-#: ../../Zotlabs/Module/Admin.php:678
+#: ../../Zotlabs/Module/Manage.php:179
 #, php-format
-msgid "Lock feature %s"
-msgstr "Bloca característica %s"
-
-#: ../../Zotlabs/Module/Admin.php:686
-msgid "Manage Additional Features"
-msgstr "Gestiona Funcionalitats Addicionals"
-
-#: ../../Zotlabs/Module/Admin.php:703
-msgid "No server found"
-msgstr "No es troba servidor"
-
-#: ../../Zotlabs/Module/Admin.php:710 ../../Zotlabs/Module/Admin.php:1046
-msgid "ID"
-msgstr "ID"
-
-#: ../../Zotlabs/Module/Admin.php:710
-msgid "for channel"
-msgstr "per a canal"
-
-#: ../../Zotlabs/Module/Admin.php:710
-msgid "on server"
-msgstr "al servidor"
-
-#: ../../Zotlabs/Module/Admin.php:712
-msgid "Server"
-msgstr "Servidor"
-
-#: ../../Zotlabs/Module/Admin.php:746
-msgid ""
-"By default, unfiltered HTML is allowed in embedded media. This is inherently"
-" insecure."
-msgstr "Per defecte, HTML no filtrat està permés als media embeguts. Això es inherentment no segur."
-
-#: ../../Zotlabs/Module/Admin.php:749
-msgid ""
-"The recommended setting is to only allow unfiltered HTML from the following "
-"sites:"
-msgstr "L'ajust recomanat és només permetre HTML sense filtrar dels següents llocs:"
-
-#: ../../Zotlabs/Module/Admin.php:750
-msgid ""
-"https://youtube.com/<br />https://www.youtube.com/<br />https://youtu.be/<br"
-" />https://vimeo.com/<br />https://soundcloud.com/<br />"
-msgstr "https://youtube.com/<br />https://www.youtube.com/<br />https://youtu.be/<br />https://vimeo.com/<br />https://soundcloud.com/<br />"
-
-#: ../../Zotlabs/Module/Admin.php:751
-msgid ""
-"All other embedded content will be filtered, <strong>unless</strong> "
-"embedded content from that site is explicitly blocked."
-msgstr "Tota la resta de contingut embegut seà filtrat, <strong>excepte</strong> contingut embegut d'aquest lloc que està blocat explícitament."
-
-#: ../../Zotlabs/Module/Admin.php:756 ../../include/widgets.php:1385
-msgid "Security"
-msgstr "Seguretat"
-
-#: ../../Zotlabs/Module/Admin.php:758
-msgid "Block public"
-msgstr "Bloca que sigui públic"
-
-#: ../../Zotlabs/Module/Admin.php:758
-msgid ""
-"Check to block public access to all otherwise public personal pages on this "
-"site unless you are currently authenticated."
-msgstr "activa per blocar l'accés a les pàgines personals públiques a tothom excepte aquells/es que s'hagin autenticat en aquest node."
-
-#: ../../Zotlabs/Module/Admin.php:759
-msgid "Set \"Transport Security\" HTTP header"
-msgstr "Set \"Transport Security\" HTTP header"
-
-#: ../../Zotlabs/Module/Admin.php:760
-msgid "Set \"Content Security Policy\" HTTP header"
-msgstr "Set \"Content Security Policy\" HTTP header"
-
-#: ../../Zotlabs/Module/Admin.php:761
-msgid "Allow communications only from these sites"
-msgstr "Permetre comunicacions únicament des de aquests llocs"
-
-#: ../../Zotlabs/Module/Admin.php:761
-msgid ""
-"One site per line. Leave empty to allow communication from anywhere by "
-"default"
-msgstr "Un lloc per línia. Deixar en blanc per permetre, per defecte,  la comunicació amb tothom."
-
-#: ../../Zotlabs/Module/Admin.php:762
-msgid "Block communications from these sites"
-msgstr "Bloca comunicacions que venen d'aquests llocs"
-
-#: ../../Zotlabs/Module/Admin.php:763
-msgid "Allow communications only from these channels"
-msgstr "Permet la comunicació només per aquests canals"
-
-#: ../../Zotlabs/Module/Admin.php:763
-msgid ""
-"One channel (hash) per line. Leave empty to allow from any channel by "
-"default"
-msgstr "Un canal (hash) per línia. Deixa en blanc per permetre, per defecte,  la comunicació qualsevol canal."
-
-#: ../../Zotlabs/Module/Admin.php:764
-msgid "Block communications from these channels"
-msgstr "Bloca les comunicacions que venen d'aquests canals"
-
-#: ../../Zotlabs/Module/Admin.php:765
-msgid "Only allow embeds from secure (SSL) websites and links."
-msgstr "Permetre embeguts només de llocs web i enllaços segurs (SSL)."
-
-#: ../../Zotlabs/Module/Admin.php:766
-msgid "Allow unfiltered embedded HTML content only from these domains"
-msgstr "Permetre HTML embegut sense filtrar només d'aquests dominis."
-
-#: ../../Zotlabs/Module/Admin.php:766
-msgid "One site per line. By default embedded content is filtered."
-msgstr "Un lloc per línia. Per defecte el contingut embegut es filtrat."
-
-#: ../../Zotlabs/Module/Admin.php:767
-msgid "Block embedded HTML from these domains"
-msgstr "Bloca HTML embegut d'aquests dominis"
-
-#: ../../Zotlabs/Module/Admin.php:785
-msgid "Update has been marked successful"
-msgstr "Actualització marcada amb exit"
-
-#: ../../Zotlabs/Module/Admin.php:795
-#, php-format
-msgid "Executing %s failed. Check system logs."
-msgstr "Executant %s ha fallat. Comprova els logs del sistema."
-
-#: ../../Zotlabs/Module/Admin.php:798
-#, php-format
-msgid "Update %s was successfully applied."
-msgstr "Actualització %s es va realitzar correctament."
-
-#: ../../Zotlabs/Module/Admin.php:802
-#, php-format
-msgid "Update %s did not return a status. Unknown if it succeeded."
-msgstr "Actualització %s no ha retornat l'estat. Es desconeix si ha finalitzat amb exit."
-
-#: ../../Zotlabs/Module/Admin.php:805
-#, php-format
-msgid "Update function %s could not be found."
-msgstr "La funció d'actualitzacio %s no es pot trobar."
-
-#: ../../Zotlabs/Module/Admin.php:821
-msgid "No failed updates."
-msgstr "No hi ha actualitzacions fallides."
-
-#: ../../Zotlabs/Module/Admin.php:825
-msgid "Failed Updates"
-msgstr "Actualitzacions Fallides"
-
-#: ../../Zotlabs/Module/Admin.php:827
-msgid "Mark success (if update was manually applied)"
-msgstr "Marca èxit (si l'actualització s'ha aplicat de forma manual)"
-
-#: ../../Zotlabs/Module/Admin.php:828
-msgid "Attempt to execute this update step automatically"
-msgstr "Prova a fer automàticament aquesta actualització"
-
-#: ../../Zotlabs/Module/Admin.php:859
-msgid "Queue Statistics"
-msgstr "Cua d'Estadístiques"
-
-#: ../../Zotlabs/Module/Admin.php:860
-msgid "Total Entries"
-msgstr "Total d'Entrades"
-
-#: ../../Zotlabs/Module/Admin.php:861
-msgid "Priority"
-msgstr "Prioritat"
-
-#: ../../Zotlabs/Module/Admin.php:862
-msgid "Destination URL"
-msgstr "URL de Destí"
-
-#: ../../Zotlabs/Module/Admin.php:863
-msgid "Mark hub permanently offline"
-msgstr "Marca el node com a permanentment fora de línia"
-
-#: ../../Zotlabs/Module/Admin.php:864
-msgid "Empty queue for this hub"
-msgstr "Cua buida per aquest node"
-
-#: ../../Zotlabs/Module/Admin.php:865
-msgid "Last known contact"
-msgstr "Últim contacte conegut"
-
-#: ../../Zotlabs/Module/Admin.php:901
-#, php-format
-msgid "%s account blocked/unblocked"
-msgid_plural "%s account blocked/unblocked"
-msgstr[0] "S'ha [des]bloquejat %s compte"
-msgstr[1] "S'han [des]bloquejat %s comptes"
-
-#: ../../Zotlabs/Module/Admin.php:908
-#, php-format
-msgid "%s account deleted"
-msgid_plural "%s accounts deleted"
-msgstr[0] "S'ha esborrat el compte %s"
-msgstr[1] "S'han esborrat %s comptes"
-
-#: ../../Zotlabs/Module/Admin.php:944
-msgid "Account not found"
-msgstr "Compte no trobat"
-
-#: ../../Zotlabs/Module/Admin.php:955
-#, php-format
-msgid "Account '%s' deleted"
-msgstr "S'ha esborrat el compte '%s'"
-
-#: ../../Zotlabs/Module/Admin.php:963
-#, php-format
-msgid "Account '%s' blocked"
-msgstr "S'ha bloquejat el compte '%s'"
-
-#: ../../Zotlabs/Module/Admin.php:971
-#, php-format
-msgid "Account '%s' unblocked"
-msgstr "S'ha desbloquejat el compte '%s'"
-
-#: ../../Zotlabs/Module/Admin.php:1031 ../../Zotlabs/Module/Admin.php:1044
-#: ../../include/widgets.php:1383
-msgid "Accounts"
-msgstr "Comptes"
-
-#: ../../Zotlabs/Module/Admin.php:1033 ../../Zotlabs/Module/Admin.php:1212
-msgid "select all"
-msgstr "Sel·leciona-ho tot"
-
-#: ../../Zotlabs/Module/Admin.php:1034
-msgid "Registrations waiting for confirm"
-msgstr ""
-
-#: ../../Zotlabs/Module/Admin.php:1035
-msgid "Request date"
-msgstr "Data de la petició"
-
-#: ../../Zotlabs/Module/Admin.php:1036
-msgid "No registrations."
-msgstr "Sense registracions."
-
-#: ../../Zotlabs/Module/Admin.php:1038
-msgid "Deny"
-msgstr "Denegat"
-
-#: ../../Zotlabs/Module/Admin.php:1048 ../../include/group.php:267
-msgid "All Channels"
-msgstr "Tots els Canals"
-
-#: ../../Zotlabs/Module/Admin.php:1049
-msgid "Register date"
-msgstr "Data de registre"
-
-#: ../../Zotlabs/Module/Admin.php:1050
-msgid "Last login"
-msgstr "Darrera identificació"
-
-#: ../../Zotlabs/Module/Admin.php:1051
-msgid "Expires"
-msgstr "Expira"
-
-#: ../../Zotlabs/Module/Admin.php:1052
-msgid "Service Class"
-msgstr "Classe de Servei"
-
-#: ../../Zotlabs/Module/Admin.php:1054
-msgid ""
-"Selected accounts will be deleted!\\n\\nEverything these accounts had posted"
-" on this site will be permanently deleted!\\n\\nAre you sure?"
-msgstr "Els comptes seleccionats seran eliminats!\\n\\nTot el que hagin publicat en aquest lloc serà esborrat permanentment!\\n\\nN'estàs segur de continuar?"
-
-#: ../../Zotlabs/Module/Admin.php:1055
-msgid ""
-"The account {0} will be deleted!\\n\\nEverything this account has posted on "
-"this site will be permanently deleted!\\n\\nAre you sure?"
-msgstr "L'usuari {0} serà eliminat!\\n\\nTot el que hagi publicat l'usuari en aquest lloc serà esborrat de permanentment!\\n\\nN'estàs segur?"
-
-#: ../../Zotlabs/Module/Admin.php:1091
-#, php-format
-msgid "%s channel censored/uncensored"
-msgid_plural "%s channels censored/uncensored"
-msgstr[0] "%s canal censurat/no censurat"
-msgstr[1] "%s canals censurats/no censurats"
-
-#: ../../Zotlabs/Module/Admin.php:1100
-#, php-format
-msgid "%s channel code allowed/disallowed"
-msgid_plural "%s channels code allowed/disallowed"
-msgstr[0] "%s codi permes/no permes al canal"
-msgstr[1] "%s codi permesos/no permesos al canal"
-
-#: ../../Zotlabs/Module/Admin.php:1106
-#, php-format
-msgid "%s channel deleted"
-msgid_plural "%s channels deleted"
-msgstr[0] "%s canal esborrat"
-msgstr[1] "%s canals esborrats"
-
-#: ../../Zotlabs/Module/Admin.php:1126
-msgid "Channel not found"
-msgstr "Canal no trobat"
-
-#: ../../Zotlabs/Module/Admin.php:1136
-#, php-format
-msgid "Channel '%s' deleted"
-msgstr "Canal '%s' esborrat"
-
-#: ../../Zotlabs/Module/Admin.php:1148
-#, php-format
-msgid "Channel '%s' censored"
-msgstr "Canal '%s' censurat"
-
-#: ../../Zotlabs/Module/Admin.php:1148
-#, php-format
-msgid "Channel '%s' uncensored"
-msgstr "Canal '%s' no censurat"
-
-#: ../../Zotlabs/Module/Admin.php:1159
-#, php-format
-msgid "Channel '%s' code allowed"
-msgstr "Canal '%s' permet codi"
-
-#: ../../Zotlabs/Module/Admin.php:1159
-#, php-format
-msgid "Channel '%s' code disallowed"
-msgstr "Canal '%s' no permet codi"
-
-#: ../../Zotlabs/Module/Admin.php:1210 ../../include/widgets.php:1384
-msgid "Channels"
-msgstr "Canals"
-
-#: ../../Zotlabs/Module/Admin.php:1214
-msgid "Censor"
-msgstr "Censurat"
-
-#: ../../Zotlabs/Module/Admin.php:1215
-msgid "Uncensor"
-msgstr "No censurat"
-
-#: ../../Zotlabs/Module/Admin.php:1216
-msgid "Allow Code"
-msgstr "Permet Codi"
-
-#: ../../Zotlabs/Module/Admin.php:1217
-msgid "Disallow Code"
-msgstr "No Permet Codi"
-
-#: ../../Zotlabs/Module/Admin.php:1218 ../../include/conversation.php:1611
-msgid "Channel"
-msgstr "Canal"
-
-#: ../../Zotlabs/Module/Admin.php:1222
-msgid "UID"
-msgstr "UID"
-
-#: ../../Zotlabs/Module/Admin.php:1226
-msgid ""
-"Selected channels will be deleted!\\n\\nEverything that was posted in these "
-"channels on this site will be permanently deleted!\\n\\nAre you sure?"
-msgstr "Els canals sel·leccionats s'esborraran!\\n\\nTotes les publicacions d'aquests canals en aquest lloc s'eliminaran de forma permanent!\\n\\nEstàs segur? "
-
-#: ../../Zotlabs/Module/Admin.php:1227
-msgid ""
-"The channel {0} will be deleted!\\n\\nEverything that was posted in this "
-"channel on this site will be permanently deleted!\\n\\nAre you sure?"
-msgstr "El canal {0} serà esborrat!\\n\\nTotes les publicacions d'aquest canal en aquest lloc s'eliminaran de forma permanent!\\n\\nEstàs segur?"
-
-#: ../../Zotlabs/Module/Admin.php:1284
-#, php-format
-msgid "Plugin %s disabled."
-msgstr "Plugin %s desactivat."
-
-#: ../../Zotlabs/Module/Admin.php:1288
-#, php-format
-msgid "Plugin %s enabled."
-msgstr "Plugin %s activat."
-
-#: ../../Zotlabs/Module/Admin.php:1298 ../../Zotlabs/Module/Admin.php:1585
-msgid "Disable"
-msgstr "Desactivat"
-
-#: ../../Zotlabs/Module/Admin.php:1301 ../../Zotlabs/Module/Admin.php:1587
-msgid "Enable"
-msgstr "Activat"
-
-#: ../../Zotlabs/Module/Admin.php:1330 ../../Zotlabs/Module/Admin.php:1420
-#: ../../include/widgets.php:1387
-msgid "Plugins"
-msgstr "Plugins"
-
-#: ../../Zotlabs/Module/Admin.php:1331 ../../Zotlabs/Module/Admin.php:1614
-msgid "Toggle"
-msgstr "Commutar"
-
-#: ../../Zotlabs/Module/Admin.php:1332 ../../Zotlabs/Module/Admin.php:1615
-#: ../../Zotlabs/Lib/Apps.php:215 ../../include/widgets.php:638
-#: ../../include/nav.php:208
-msgid "Settings"
-msgstr "Ajustos"
-
-#: ../../Zotlabs/Module/Admin.php:1339 ../../Zotlabs/Module/Admin.php:1624
-msgid "Author: "
-msgstr "Autor: "
-
-#: ../../Zotlabs/Module/Admin.php:1340 ../../Zotlabs/Module/Admin.php:1625
-msgid "Maintainer: "
-msgstr "Mantenedor:"
-
-#: ../../Zotlabs/Module/Admin.php:1341
-msgid "Minimum project version: "
-msgstr "Versió mínima del projecte:"
-
-#: ../../Zotlabs/Module/Admin.php:1342
-msgid "Maximum project version: "
-msgstr "Versió màxima del projecte:"
-
-#: ../../Zotlabs/Module/Admin.php:1343
-msgid "Minimum PHP version: "
-msgstr "Versió mínima de PHP:"
-
-#: ../../Zotlabs/Module/Admin.php:1344
-msgid "Requires: "
-msgstr "Requereix:"
-
-#: ../../Zotlabs/Module/Admin.php:1345 ../../Zotlabs/Module/Admin.php:1425
-msgid "Disabled - version incompatibility"
-msgstr "Desactiva - incompatibilitat de versió"
-
-#: ../../Zotlabs/Module/Admin.php:1394
-msgid "Enter the public git repository URL of the plugin repo."
-msgstr "Introdueix la URL del repositori git públic del repositori de plugins."
-
-#: ../../Zotlabs/Module/Admin.php:1395
-msgid "Plugin repo git URL"
-msgstr "URL del repositori de plugins."
-
-#: ../../Zotlabs/Module/Admin.php:1396
-msgid "Custom repo name"
-msgstr "Nom del repositori personalitzat"
-
-#: ../../Zotlabs/Module/Admin.php:1396
-msgid "(optional)"
-msgstr "(opcional)"
-
-#: ../../Zotlabs/Module/Admin.php:1397
-msgid "Download Plugin Repo"
-msgstr "Descarrega el Repositori de Plugins"
-
-#: ../../Zotlabs/Module/Admin.php:1404
-msgid "Install new repo"
-msgstr "Instal·la un nou repositori "
-
-#: ../../Zotlabs/Module/Admin.php:1405 ../../Zotlabs/Lib/Apps.php:330
-msgid "Install"
-msgstr "Instal·lar"
-
-#: ../../Zotlabs/Module/Admin.php:1427
-msgid "Manage Repos"
-msgstr "Gestiona Repositoris"
-
-#: ../../Zotlabs/Module/Admin.php:1428
-msgid "Installed Plugin Repositories"
-msgstr "Repositori de Plugins Instal·lat"
-
-#: ../../Zotlabs/Module/Admin.php:1429
-msgid "Install a New Plugin Repository"
-msgstr "Instal·la un Nou Repositori de Plugins"
-
-#: ../../Zotlabs/Module/Admin.php:1435 ../../Zotlabs/Module/Settings.php:77
-#: ../../Zotlabs/Module/Settings.php:616 ../../Zotlabs/Lib/Apps.php:330
-msgid "Update"
-msgstr "Actualització"
-
-#: ../../Zotlabs/Module/Admin.php:1436
-msgid "Switch branch"
-msgstr "Canvia de branca"
-
-#: ../../Zotlabs/Module/Admin.php:1550
-msgid "No themes found."
-msgstr "No s'han trobat temes."
-
-#: ../../Zotlabs/Module/Admin.php:1606
-msgid "Screenshot"
-msgstr "Copia de pantalla"
-
-#: ../../Zotlabs/Module/Admin.php:1613 ../../Zotlabs/Module/Admin.php:1647
-#: ../../include/widgets.php:1388
-msgid "Themes"
-msgstr "Temes"
-
-#: ../../Zotlabs/Module/Admin.php:1652
-msgid "[Experimental]"
-msgstr "[Experimental]"
-
-#: ../../Zotlabs/Module/Admin.php:1653
-msgid "[Unsupported]"
-msgstr "[No soportat]"
-
-#: ../../Zotlabs/Module/Admin.php:1677
-msgid "Log settings updated."
-msgstr "Registre d'ajustos actualitzat."
-
-#: ../../Zotlabs/Module/Admin.php:1732 ../../include/widgets.php:1409
-#: ../../include/widgets.php:1419
-msgid "Logs"
-msgstr "Logs"
-
-#: ../../Zotlabs/Module/Admin.php:1734
-msgid "Clear"
-msgstr "Neteja"
-
-#: ../../Zotlabs/Module/Admin.php:1740
-msgid "Debugging"
-msgstr "Depurant"
-
-#: ../../Zotlabs/Module/Admin.php:1741
-msgid "Log file"
-msgstr "Arxiu de registre"
-
-#: ../../Zotlabs/Module/Admin.php:1741
-msgid ""
-"Must be writable by web server. Relative to your top-level webserver "
-"directory."
-msgstr ""
-
-#: ../../Zotlabs/Module/Admin.php:1742
-msgid "Log level"
-msgstr "Nivell de registre"
-
-#: ../../Zotlabs/Module/Admin.php:2028
-msgid "New Profile Field"
-msgstr "Camp de Perfil Nou"
-
-#: ../../Zotlabs/Module/Admin.php:2029 ../../Zotlabs/Module/Admin.php:2049
-msgid "Field nickname"
-msgstr "Àlies de Camp"
-
-#: ../../Zotlabs/Module/Admin.php:2029 ../../Zotlabs/Module/Admin.php:2049
-msgid "System name of field"
-msgstr "nOM DEL SISTEMA DEL CAMP"
-
-#: ../../Zotlabs/Module/Admin.php:2030 ../../Zotlabs/Module/Admin.php:2050
-msgid "Input type"
-msgstr "Tipus d'entrada"
-
-#: ../../Zotlabs/Module/Admin.php:2031 ../../Zotlabs/Module/Admin.php:2051
-msgid "Field Name"
-msgstr "Nom de Camp"
-
-#: ../../Zotlabs/Module/Admin.php:2031 ../../Zotlabs/Module/Admin.php:2051
-msgid "Label on profile pages"
-msgstr "Etiqueta a les pàgines de perfil"
-
-#: ../../Zotlabs/Module/Admin.php:2032 ../../Zotlabs/Module/Admin.php:2052
-msgid "Help text"
-msgstr "Text d'ajuda"
-
-#: ../../Zotlabs/Module/Admin.php:2032 ../../Zotlabs/Module/Admin.php:2052
-msgid "Additional info (optional)"
-msgstr "Informació adicional (opcional)"
-
-#: ../../Zotlabs/Module/Admin.php:2042
-msgid "Field definition not found"
-msgstr "No es troba la definició del camp"
-
-#: ../../Zotlabs/Module/Admin.php:2048
-msgid "Edit Profile Field"
-msgstr "Camp d'Edició del Perfil"
-
-#: ../../Zotlabs/Module/Admin.php:2106 ../../include/widgets.php:1390
-msgid "Profile Fields"
-msgstr "Camps del Perfil"
-
-#: ../../Zotlabs/Module/Admin.php:2107
-msgid "Basic Profile Fields"
-msgstr "Camps Bàsics del Perfil"
-
-#: ../../Zotlabs/Module/Admin.php:2108
-msgid "Advanced Profile Fields"
-msgstr "Camps Avançats del Perfil"
-
-#: ../../Zotlabs/Module/Admin.php:2108
-msgid "(In addition to basic fields)"
-msgstr "( addicionalment als camps bàsics)"
-
-#: ../../Zotlabs/Module/Admin.php:2110
-msgid "All available fields"
-msgstr "Tots els camps disponibles"
-
-#: ../../Zotlabs/Module/Admin.php:2111
-msgid "Custom Fields"
-msgstr "Camps Personalitzats"
-
-#: ../../Zotlabs/Module/Admin.php:2115
-msgid "Create Custom Field"
-msgstr "Crear un Camp Personalitzat"
-
-#: ../../Zotlabs/Module/Appman.php:37 ../../Zotlabs/Module/Appman.php:53
-msgid "App installed."
-msgstr "Aplicació instal·lada."
-
-#: ../../Zotlabs/Module/Appman.php:46
-msgid "Malformed app."
-msgstr "Aplicació amb errors"
-
-#: ../../Zotlabs/Module/Appman.php:104
-msgid "Embed code"
-msgstr "Codi embegut"
-
-#: ../../Zotlabs/Module/Appman.php:110 ../../include/widgets.php:107
-msgid "Edit App"
-msgstr "Edita l'Aplicació"
-
-#: ../../Zotlabs/Module/Appman.php:110
-msgid "Create App"
-msgstr "Crea l'Aplicació"
-
-#: ../../Zotlabs/Module/Appman.php:115
-msgid "Name of app"
-msgstr "Nom de l'Aplicació"
-
-#: ../../Zotlabs/Module/Appman.php:116
-msgid "Location (URL) of app"
-msgstr "Ubicació (URL) de l'aplicació"
-
-#: ../../Zotlabs/Module/Appman.php:118
-msgid "Photo icon URL"
-msgstr "Foto icona URL"
-
-#: ../../Zotlabs/Module/Appman.php:118
-msgid "80 x 80 pixels - optional"
-msgstr "80 x 80 pixels - opcional"
-
-#: ../../Zotlabs/Module/Appman.php:119
-msgid "Categories (optional, comma separated list)"
-msgstr "Categories (opcional, lista separada per comes)"
-
-#: ../../Zotlabs/Module/Appman.php:120
-msgid "Version ID"
-msgstr "Versió ID"
-
-#: ../../Zotlabs/Module/Appman.php:121
-msgid "Price of app"
-msgstr "Preu de l'aplicació"
-
-#: ../../Zotlabs/Module/Appman.php:122
-msgid "Location (URL) to purchase app"
-msgstr "Ubicació (URL) per comprar l'aplicació"
-
-#: ../../Zotlabs/Module/Rbmark.php:94
-msgid "Select a bookmark folder"
-msgstr "Tria una carpeta d'interès"
-
-#: ../../Zotlabs/Module/Rbmark.php:99
-msgid "Save Bookmark"
-msgstr "Guarda Favorits"
-
-#: ../../Zotlabs/Module/Rbmark.php:100
-msgid "URL of bookmark"
-msgstr "URL de favorit"
-
-#: ../../Zotlabs/Module/Rbmark.php:105
-msgid "Or enter new bookmark folder name"
-msgstr "O entra un nou nom de favorit"
-
-#: ../../Zotlabs/Module/Register.php:49
-msgid "Maximum daily site registrations exceeded. Please try again tomorrow."
-msgstr "Nombre màxim de registres diaris excedit. Si us plau, provau demà."
-
-#: ../../Zotlabs/Module/Register.php:55
-msgid ""
-"Please indicate acceptance of the Terms of Service. Registration failed."
-msgstr "El registre ha fallat. Si et plau, indica que acceptes les Condicions del Servei."
-
-#: ../../Zotlabs/Module/Register.php:89
-msgid "Passwords do not match."
-msgstr "Les contrasenyes no coincideixen."
-
-#: ../../Zotlabs/Module/Register.php:131
-msgid ""
-"Registration successful. Please check your email for validation "
-"instructions."
-msgstr "Registrat amb èxit. Si et plau revisa el teu correu electrònic per a les instruccions de validació."
-
-#: ../../Zotlabs/Module/Register.php:137
-msgid "Your registration is pending approval by the site owner."
-msgstr "El teu registre esta pendent de validació pel propietari del lloc."
-
-#: ../../Zotlabs/Module/Register.php:140
-msgid "Your registration can not be processed."
-msgstr "El teu registre no ha pogut ser processat. "
-
-#: ../../Zotlabs/Module/Register.php:184
-msgid "Registration on this hub is disabled."
-msgstr "El registre en aquest node està deshabilitat."
-
-#: ../../Zotlabs/Module/Register.php:193
-msgid "Registration on this hub is by approval only."
-msgstr "El registre en aquest node es únicament per validació."
-
-#: ../../Zotlabs/Module/Register.php:194
-msgid "<a href=\"pubsites\">Register at another affiliated hub.</a>"
-msgstr "<a href=\"pubsites\">Registre en altre node afiliat</a>"
-
-#: ../../Zotlabs/Module/Register.php:204
-msgid ""
-"This site has exceeded the number of allowed daily account registrations. "
-"Please try again tomorrow."
-msgstr "El lloc ha excedit el límit màxim diari de nous comptes/registres. Provau demà."
-
-#: ../../Zotlabs/Module/Register.php:215
+msgid "%d new introductions"
+msgstr "%d noves presentacions"
+
+#: ../../Zotlabs/Module/Manage.php:181
+msgid "Delegated Channel"
+msgstr "Canal Delegat"
+
+#: ../../Zotlabs/Module/Cards.php:42 ../../Zotlabs/Module/Cards.php:181
+#: ../../Zotlabs/Lib/Apps.php:230 ../../include/conversation.php:1890
+#: ../../include/features.php:114 ../../include/nav.php:458
+msgid "Cards"
+msgstr "Targetes"
+
+#: ../../Zotlabs/Module/Cards.php:99
+msgid "Add Card"
+msgstr "Afegeix una carta"
+
+#: ../../Zotlabs/Module/Dirsearch.php:33
+msgid "This directory server requires an access token"
+msgstr "Aquest servidor de directori requereix un token de accès"
+
+#: ../../Zotlabs/Module/Siteinfo.php:18
+msgid "About this site"
+msgstr "Sobre aquest lloc web"
+
+#: ../../Zotlabs/Module/Siteinfo.php:19
+msgid "Site Name"
+msgstr "Nom del lloc web"
+
+#: ../../Zotlabs/Module/Siteinfo.php:23
+msgid "Administrator"
+msgstr "Administrador"
+
+#: ../../Zotlabs/Module/Siteinfo.php:25 ../../Zotlabs/Module/Register.php:232
 msgid "Terms of Service"
 msgstr "Condicions del Servei"
 
-#: ../../Zotlabs/Module/Register.php:221
-#, php-format
-msgid "I accept the %s for this website"
-msgstr "Accepto el %s per a aquest lloc web"
+#: ../../Zotlabs/Module/Siteinfo.php:26
+msgid "Software and Project information"
+msgstr "Informació del programari i del projecte"
 
-#: ../../Zotlabs/Module/Register.php:223
-#, php-format
-msgid "I am over 13 years of age and accept the %s for this website"
-msgstr "Tinc més de 13 anys i accepto les %s d'aquest lloc web"
+#: ../../Zotlabs/Module/Siteinfo.php:27
+msgid "This site is powered by $Projectname"
+msgstr "Aquest lloc web funciona amb $Projectname"
 
-#: ../../Zotlabs/Module/Register.php:227
-msgid "Your email address"
-msgstr "La teva adreça de correu electrónic"
-
-#: ../../Zotlabs/Module/Register.php:228
-msgid "Choose a password"
-msgstr "Tria una contrasenya"
-
-#: ../../Zotlabs/Module/Register.php:229
-msgid "Please re-enter your password"
-msgstr "Si et plau, re-entra la contrasenya"
-
-#: ../../Zotlabs/Module/Register.php:230
-msgid "Please enter your invitation code"
-msgstr "Si et plau, introdueix el teu codi d'invitació"
-
-#: ../../Zotlabs/Module/Register.php:236
-msgid "no"
-msgstr "no"
-
-#: ../../Zotlabs/Module/Register.php:236
-msgid "yes"
-msgstr "sí"
-
-#: ../../Zotlabs/Module/Register.php:250
-msgid "Membership on this site is by invitation only."
-msgstr "La pertinença en aquest lloc es per invitació exclusivament."
-
-#: ../../Zotlabs/Module/Register.php:262 ../../include/nav.php:147
-#: ../../boot.php:1685
-msgid "Register"
-msgstr "Registre"
-
-#: ../../Zotlabs/Module/Register.php:262
-msgid "Proceed to create your first channel"
-msgstr "Comença a crear el teu primer canal"
-
-#: ../../Zotlabs/Module/Regmod.php:15
-msgid "Please login."
-msgstr "Inicia Sessió."
-
-#: ../../Zotlabs/Module/Removeaccount.php:34
+#: ../../Zotlabs/Module/Siteinfo.php:28
 msgid ""
-"Account removals are not allowed within 48 hours of changing the account "
-"password."
-msgstr "L'esborrat de comptes no està permès fins que transcorren 48 hores des de l'últim canvi de contrasenya."
+"Federated and decentralised networking and identity services provided by Zot"
+msgstr "Els serveis d'identitat i la federació i descentralització de la xarxa funcionen amb Zot"
 
-#: ../../Zotlabs/Module/Removeaccount.php:56
-msgid "Remove This Account"
-msgstr "Esborra el compte"
-
-#: ../../Zotlabs/Module/Removeaccount.php:57
-#: ../../Zotlabs/Module/Removeme.php:59
-msgid "WARNING: "
-msgstr "ALERTA:"
-
-#: ../../Zotlabs/Module/Removeaccount.php:57
-msgid ""
-"This account and all its channels will be completely removed from the "
-"network. "
-msgstr "Aquest compte i tots els seus canals s'estan apunt d'esborrar totalment de la xarxa."
-
-#: ../../Zotlabs/Module/Removeaccount.php:57
-#: ../../Zotlabs/Module/Removeme.php:59
-msgid "This action is permanent and can not be undone!"
-msgstr "Aquesta acció és irreversible!"
-
-#: ../../Zotlabs/Module/Removeaccount.php:58
-#: ../../Zotlabs/Module/Removeme.php:60
-msgid "Please enter your password for verification:"
-msgstr "Aquesta acció requereix tornar a introduir la contrasenya:"
-
-#: ../../Zotlabs/Module/Removeaccount.php:59
-msgid ""
-"Remove this account, all its channels and all its channel clones from the "
-"network"
-msgstr "Esborra de la xarxa aquest compte, tots els seus canals, i tots els seus canals clons."
-
-#: ../../Zotlabs/Module/Removeaccount.php:59
-msgid ""
-"By default only the instances of the channels located on this hub will be "
-"removed from the network"
-msgstr "Per defecte, només les instancies dels canal ubicats en aquest node poden esser esborrades  de la xarxa"
-
-#: ../../Zotlabs/Module/Removeaccount.php:60
-#: ../../Zotlabs/Module/Settings.php:705
-msgid "Remove Account"
-msgstr "Esborra el Compte"
-
-#: ../../Zotlabs/Module/Removeme.php:33
-msgid ""
-"Channel removals are not allowed within 48 hours of changing the account "
-"password."
-msgstr "L'esborrat de canals no està permès fins que transcorren 48 hores des de l'últim canvi de contrasenya."
-
-#: ../../Zotlabs/Module/Removeme.php:58
-msgid "Remove This Channel"
-msgstr "Elimina Aquest Canal"
-
-#: ../../Zotlabs/Module/Removeme.php:59
-msgid "This channel will be completely removed from the network. "
-msgstr "Aquest canal serà completament eliminat de la xarxa."
-
-#: ../../Zotlabs/Module/Removeme.php:61
-msgid "Remove this channel and all its clones from the network"
-msgstr "Elimina aquest canal i els seus clons de la xarxa"
-
-#: ../../Zotlabs/Module/Removeme.php:61
-msgid ""
-"By default only the instance of the channel located on this hub will be "
-"removed from the network"
-msgstr "Per defecte, només la instancia del canal ubicat en aquest node pot esser esborrat  de la xarxa"
-
-#: ../../Zotlabs/Module/Removeme.php:62 ../../Zotlabs/Module/Settings.php:1124
-msgid "Remove Channel"
-msgstr "Elimina el canal"
-
-#: ../../Zotlabs/Module/Rmagic.php:44
-msgid ""
-"We encountered a problem while logging in with the OpenID you provided. "
-"Please check the correct spelling of the ID."
-msgstr "Em trobat un problema durant l'inici de sessió amb el OpenID que has facilitat. verifica l'ortografia correcta de la ID."
-
-#: ../../Zotlabs/Module/Rmagic.php:44
-msgid "The error message was:"
-msgstr "El missatge d'error fou:"
-
-#: ../../Zotlabs/Module/Rmagic.php:48
-msgid "Authentication failed."
-msgstr "Ha fallat l'autentificació."
-
-#: ../../Zotlabs/Module/Rmagic.php:88
-msgid "Remote Authentication"
-msgstr "Autentificació Remota"
-
-#: ../../Zotlabs/Module/Rmagic.php:89
-msgid "Enter your channel address (e.g. channel@example.com)"
-msgstr "Introdueix la teva adreça del canal (eg canal@exemple.com)"
-
-#: ../../Zotlabs/Module/Rmagic.php:90
-msgid "Authenticate"
-msgstr "Autentica't"
-
-#: ../../Zotlabs/Module/Search.php:216
-#, php-format
-msgid "Items tagged with: %s"
-msgstr "Elements etiquetats amb: %s"
-
-#: ../../Zotlabs/Module/Search.php:218
-#, php-format
-msgid "Search results for: %s"
-msgstr "Resultats de cerca per: %s"
-
-#: ../../Zotlabs/Module/Service_limits.php:23
-msgid "No service class restrictions found."
-msgstr "No s'han trobat restriccions de clase."
-
-#: ../../Zotlabs/Module/Settings.php:69
-msgid "Name is required"
-msgstr "Es requereix un Nom"
-
-#: ../../Zotlabs/Module/Settings.php:73
-msgid "Key and Secret are required"
-msgstr "Es requereix Clau (Key) i el Secret (Secret)"
-
-#: ../../Zotlabs/Module/Settings.php:225
-msgid "Not valid email."
-msgstr "E-correu no vàlid."
-
-#: ../../Zotlabs/Module/Settings.php:228
-msgid "Protected email address. Cannot change to that email."
-msgstr "Adreça d'e-correu protegida. No es pot canviar a aquest e-correu."
-
-#: ../../Zotlabs/Module/Settings.php:237
-msgid "System failure storing new email. Please try again."
-msgstr "Fallada del sistema al guardar un nou correu. Si us plau, proba de nou."
-
-#: ../../Zotlabs/Module/Settings.php:254
-msgid "Password verification failed."
-msgstr "La verificació de la contrasenya ha fallat."
-
-#: ../../Zotlabs/Module/Settings.php:261
-msgid "Passwords do not match. Password unchanged."
-msgstr "Les contrasenyes no coincideixen. Contrasenya sense canvis."
-
-#: ../../Zotlabs/Module/Settings.php:265
-msgid "Empty passwords are not allowed. Password unchanged."
-msgstr "Les contrasenyes en blanc no estan permesas. Contrasenya sense canvis."
-
-#: ../../Zotlabs/Module/Settings.php:279
-msgid "Password changed."
-msgstr "Contrasenya canviada."
-
-#: ../../Zotlabs/Module/Settings.php:281
-msgid "Password update failed. Please try again."
-msgstr "L'actualització de la contrasenya va fallar. Si us plau, torneu a intentar-ho."
-
-#: ../../Zotlabs/Module/Settings.php:525
-msgid "Settings updated."
-msgstr "Ajustes actualizados."
-
-#: ../../Zotlabs/Module/Settings.php:589 ../../Zotlabs/Module/Settings.php:615
-#: ../../Zotlabs/Module/Settings.php:651
-msgid "Add application"
-msgstr "Afegir aplicatiu"
-
-#: ../../Zotlabs/Module/Settings.php:592
-msgid "Name of application"
-msgstr "Nom de l'aplicatiu"
-
-#: ../../Zotlabs/Module/Settings.php:593 ../../Zotlabs/Module/Settings.php:619
-msgid "Consumer Key"
-msgstr "Consumer Key"
-
-#: ../../Zotlabs/Module/Settings.php:593 ../../Zotlabs/Module/Settings.php:594
-msgid "Automatically generated - change if desired. Max length 20"
-msgstr "Generat automàticament- Canvia-ho si ho vols. Max. longitud 20"
-
-#: ../../Zotlabs/Module/Settings.php:594 ../../Zotlabs/Module/Settings.php:620
-msgid "Consumer Secret"
-msgstr "Consumer Secret"
-
-#: ../../Zotlabs/Module/Settings.php:595 ../../Zotlabs/Module/Settings.php:621
-msgid "Redirect"
-msgstr "Redirecciona"
-
-#: ../../Zotlabs/Module/Settings.php:595
-msgid ""
-"Redirect URI - leave blank unless your application specifically requires "
-"this"
-msgstr "URI redirigida - No canviar excepte perquè el teu aplicatiu ho requereixi."
-
-#: ../../Zotlabs/Module/Settings.php:596 ../../Zotlabs/Module/Settings.php:622
-msgid "Icon url"
-msgstr "Icona de url"
-
-#: ../../Zotlabs/Module/Settings.php:596 ../../Zotlabs/Module/Sources.php:112
-#: ../../Zotlabs/Module/Sources.php:147
-msgid "Optional"
-msgstr "Opcional"
-
-#: ../../Zotlabs/Module/Settings.php:607
-msgid "Application not found."
-msgstr "Aplicatiu no trobat."
-
-#: ../../Zotlabs/Module/Settings.php:650
-msgid "Connected Apps"
-msgstr "Aplicatius Conectats"
-
-#: ../../Zotlabs/Module/Settings.php:654
-msgid "Client key starts with"
-msgstr "La clau del client comença amb"
-
-#: ../../Zotlabs/Module/Settings.php:655
-msgid "No name"
-msgstr "Sin nombre"
-
-#: ../../Zotlabs/Module/Settings.php:656
-msgid "Remove authorization"
-msgstr "Elimina autorització"
-
-#: ../../Zotlabs/Module/Settings.php:669
-msgid "No feature settings configured"
-msgstr "No hi ha opcions de les funcions configurades"
-
-#: ../../Zotlabs/Module/Settings.php:676
-msgid "Feature/Addon Settings"
-msgstr "Ajustos de Complements"
-
-#: ../../Zotlabs/Module/Settings.php:699
-msgid "Account Settings"
-msgstr "Ajustos de Compte"
-
-#: ../../Zotlabs/Module/Settings.php:700
-msgid "Current Password"
-msgstr "Contrasenya Actual"
-
-#: ../../Zotlabs/Module/Settings.php:701
-msgid "Enter New Password"
-msgstr "Entra la Nova Contrasenya"
-
-#: ../../Zotlabs/Module/Settings.php:702
-msgid "Confirm New Password"
-msgstr "Confirma la Nova Contrasenya"
-
-#: ../../Zotlabs/Module/Settings.php:702
-msgid "Leave password fields blank unless changing"
-msgstr "Deixa els camps de contrasenya en blanc llevat que la vulguis canviar"
-
-#: ../../Zotlabs/Module/Settings.php:704
-#: ../../Zotlabs/Module/Settings.php:1041
-msgid "Email Address:"
-msgstr "Adreça de E-Correu:"
-
-#: ../../Zotlabs/Module/Settings.php:706
-msgid "Remove this account including all its channels"
-msgstr "Esborra aquest compte inclosos tots els seus canals"
-
-#: ../../Zotlabs/Module/Settings.php:729
-msgid "Additional Features"
-msgstr "Característiques Addicionals"
-
-#: ../../Zotlabs/Module/Settings.php:753
-msgid "Connector Settings"
-msgstr "Ajustos de Connector"
-
-#: ../../Zotlabs/Module/Settings.php:792
-msgid "No special theme for mobile devices"
-msgstr "No emprar tema especial per aparells mòbils"
-
-#: ../../Zotlabs/Module/Settings.php:795
-#, php-format
-msgid "%s - (Experimental)"
-msgstr "%s - (Experimental)"
-
-#: ../../Zotlabs/Module/Settings.php:837
-msgid "Display Settings"
-msgstr "Ajustos de Pantalla"
-
-#: ../../Zotlabs/Module/Settings.php:838
-msgid "Theme Settings"
-msgstr "Ajustos de Tema"
-
-#: ../../Zotlabs/Module/Settings.php:839
-msgid "Custom Theme Settings"
-msgstr "Ajustos Personals de Tema"
-
-#: ../../Zotlabs/Module/Settings.php:840
-msgid "Content Settings"
-msgstr "Ajustos de Contingut"
-
-#: ../../Zotlabs/Module/Settings.php:846
-msgid "Display Theme:"
-msgstr "Ajustos de Tema:"
-
-#: ../../Zotlabs/Module/Settings.php:847
-msgid "Mobile Theme:"
-msgstr "Tema Mòbil:"
-
-#: ../../Zotlabs/Module/Settings.php:848
-msgid "Preload images before rendering the page"
-msgstr "Precarrega les imatges abans de dibuixar la pàgina"
-
-#: ../../Zotlabs/Module/Settings.php:848
-msgid ""
-"The subjective page load time will be longer but the page will be ready when"
-" displayed"
-msgstr "El temps subjectiu per carregar la pàgina pot ser llarg però la pàgina estarà preparada quan es mostri"
-
-#: ../../Zotlabs/Module/Settings.php:849
-msgid "Enable user zoom on mobile devices"
-msgstr "Zoom d'usuari en dispositius mòbils"
-
-#: ../../Zotlabs/Module/Settings.php:850
-msgid "Update browser every xx seconds"
-msgstr "Actualitza el navegador cada xx segons"
-
-#: ../../Zotlabs/Module/Settings.php:850
-msgid "Minimum of 10 seconds, no maximum"
-msgstr "Mínim de 10 segons, sense màxim"
-
-#: ../../Zotlabs/Module/Settings.php:851
-msgid "Maximum number of conversations to load at any time:"
-msgstr "Nombre màxim de conversacions a càrregar cada vegada"
-
-#: ../../Zotlabs/Module/Settings.php:851
-msgid "Maximum of 100 items"
-msgstr "Màxim de 100 elements"
-
-#: ../../Zotlabs/Module/Settings.php:852
-msgid "Show emoticons (smilies) as images"
-msgstr "Mostra emoticons (smilies) com a imatges"
-
-#: ../../Zotlabs/Module/Settings.php:853
-msgid "Link post titles to source"
-msgstr "Enllaça a l'origen els títols de l'entrada"
-
-#: ../../Zotlabs/Module/Settings.php:854
-msgid "System Page Layout Editor - (advanced)"
-msgstr "Editor de Disseny de la Pàgina del Sistema - (avançat)"
-
-#: ../../Zotlabs/Module/Settings.php:857
-msgid "Use blog/list mode on channel page"
-msgstr "Empra el mode blog/llista a la pàgina del canal"
-
-#: ../../Zotlabs/Module/Settings.php:857 ../../Zotlabs/Module/Settings.php:858
-msgid "(comments displayed separately)"
-msgstr "(Observacions es mostren per separat)"
-
-#: ../../Zotlabs/Module/Settings.php:858
-msgid "Use blog/list mode on grid page"
-msgstr "Empra el mode de blog/llista a la pàgina de la malla"
-
-#: ../../Zotlabs/Module/Settings.php:859
-msgid "Channel page max height of content (in pixels)"
-msgstr "Alçada màxima de contingut (en píxels) de la pàgina de Canal"
-
-#: ../../Zotlabs/Module/Settings.php:859 ../../Zotlabs/Module/Settings.php:860
-msgid "click to expand content exceeding this height"
-msgstr "Clic per expandir el contingut que excedeixi aquesta alçada"
-
-#: ../../Zotlabs/Module/Settings.php:860
-msgid "Grid page max height of content (in pixels)"
-msgstr "Alçada màxima dels continguts (en píxels) de la Pàgina de Malla "
-
-#: ../../Zotlabs/Module/Settings.php:894
-msgid "Nobody except yourself"
-msgstr "Ningú excepte tú"
-
-#: ../../Zotlabs/Module/Settings.php:895
-msgid "Only those you specifically allow"
-msgstr "Només allò que específicament permetis"
-
-#: ../../Zotlabs/Module/Settings.php:896
-msgid "Approved connections"
-msgstr "Connexions aprovades"
-
-#: ../../Zotlabs/Module/Settings.php:897
-msgid "Any connections"
-msgstr "Qualsevol connexió"
-
-#: ../../Zotlabs/Module/Settings.php:898
-msgid "Anybody on this website"
-msgstr "Qualsevol en aquest lloc"
-
-#: ../../Zotlabs/Module/Settings.php:899
-msgid "Anybody in this network"
-msgstr "Qualsevol en aquesta xarxa"
-
-#: ../../Zotlabs/Module/Settings.php:900
-msgid "Anybody authenticated"
-msgstr "Qualsevol autenticat"
-
-#: ../../Zotlabs/Module/Settings.php:901
-msgid "Anybody on the internet"
-msgstr "Qualsevol a internet"
-
-#: ../../Zotlabs/Module/Settings.php:976
-msgid "Publish your default profile in the network directory"
-msgstr "Publica el teu perfil per defecte al directori de la xarxa"
-
-#: ../../Zotlabs/Module/Settings.php:981
-msgid "Allow us to suggest you as a potential friend to new members?"
-msgstr "Ens permets suggerir-te com a potencial amic als nous membres?"
-
-#: ../../Zotlabs/Module/Settings.php:990
-msgid "Your channel address is"
-msgstr "La teva adreça del canal es"
-
-#: ../../Zotlabs/Module/Settings.php:1032
-msgid "Channel Settings"
-msgstr "Ajustos del Canal"
-
-#: ../../Zotlabs/Module/Settings.php:1039
-msgid "Basic Settings"
-msgstr "Ajustos Bàsics"
-
-#: ../../Zotlabs/Module/Settings.php:1040 ../../include/channel.php:1140
-msgid "Full Name:"
-msgstr "Nom Complet:"
-
-#: ../../Zotlabs/Module/Settings.php:1042
-msgid "Your Timezone:"
-msgstr "La teva Franja Horària"
-
-#: ../../Zotlabs/Module/Settings.php:1043
-msgid "Default Post Location:"
-msgstr "Localització Predeterminada de les Entrades:"
-
-#: ../../Zotlabs/Module/Settings.php:1043
-msgid "Geographical location to display on your posts"
-msgstr "Posició geogràfica a mostrar a les teves entrades"
-
-#: ../../Zotlabs/Module/Settings.php:1044
-msgid "Use Browser Location:"
-msgstr "Empra la Localització del Navegador:"
-
-#: ../../Zotlabs/Module/Settings.php:1046
-msgid "Adult Content"
-msgstr "Contingut per a Adults"
-
-#: ../../Zotlabs/Module/Settings.php:1046
-msgid ""
-"This channel frequently or regularly publishes adult content. (Please tag "
-"any adult material and/or nudity with #NSFW)"
-msgstr "Aquest canal publica freqúentment o amb regularitat contingut per a adults. (Si us plau, etiqueti qualsevol material per a adults amb #NSFW)"
-
-#: ../../Zotlabs/Module/Settings.php:1048
-msgid "Security and Privacy Settings"
-msgstr "Ajustos de Seguretat i Privacitat"
-
-#: ../../Zotlabs/Module/Settings.php:1051
-msgid "Your permissions are already configured. Click to view/adjust"
-msgstr "Els teus permisos estan configurats. Clic per veure/ajustar"
-
-#: ../../Zotlabs/Module/Settings.php:1053
-msgid "Hide my online presence"
-msgstr "Amaga la meva presencia en línia"
-
-#: ../../Zotlabs/Module/Settings.php:1053
-msgid "Prevents displaying in your profile that you are online"
-msgstr "Evita mostrar en el teu perfil, que estàs en línia"
-
-#: ../../Zotlabs/Module/Settings.php:1055
-msgid "Simple Privacy Settings:"
-msgstr "Ajustos simples de privacitat:"
-
-#: ../../Zotlabs/Module/Settings.php:1056
-msgid ""
-"Very Public - <em>extremely permissive (should be used with caution)</em>"
-msgstr "Molt públic - <em>extremadament permissiu (s'ha d'anar en compte)</em>"
-
-#: ../../Zotlabs/Module/Settings.php:1057
-msgid ""
-"Typical - <em>default public, privacy when desired (similar to social "
-"network permissions but with improved privacy)</em>"
-msgstr "Normal - <em>públic per defecte, privat quan es desitgi (similar als permisos de xarxa social, però amb millor privacitat)"
-
-#: ../../Zotlabs/Module/Settings.php:1058
-msgid "Private - <em>default private, never open or public</em>"
-msgstr "Privat - <em>privat per defecte, mai públic o obert</em>"
-
-#: ../../Zotlabs/Module/Settings.php:1059
-msgid "Blocked - <em>default blocked to/from everybody</em>"
-msgstr "Bloquejat - <em>tothom bloquejat per defecte</em>"
-
-#: ../../Zotlabs/Module/Settings.php:1061
-msgid "Allow others to tag your posts"
-msgstr "Permet a altres etiquetar les teves entrades"
-
-#: ../../Zotlabs/Module/Settings.php:1061
-msgid ""
-"Often used by the community to retro-actively flag inappropriate content"
-msgstr "Sovint emprat per la comunitat per marcar retroactivament contingut inapropiat"
-
-#: ../../Zotlabs/Module/Settings.php:1063
-msgid "Advanced Privacy Settings"
-msgstr "Ajustos avançats de privacitat"
-
-#: ../../Zotlabs/Module/Settings.php:1065
-msgid "Expire other channel content after this many days"
-msgstr "El contingut d'altes canals caduca després d'aquests dies"
-
-#: ../../Zotlabs/Module/Settings.php:1065
-msgid "0 or blank to use the website limit."
-msgstr "0 o en blanc per emprar el limit del lloc web."
-
-#: ../../Zotlabs/Module/Settings.php:1065
-#, php-format
-msgid "This website expires after %d days."
-msgstr "Aquest lloc web expira després de %d dies."
-
-#: ../../Zotlabs/Module/Settings.php:1065
-msgid "This website does not expire imported content."
-msgstr "A aquest lloc web no expira el contingut importat"
-
-#: ../../Zotlabs/Module/Settings.php:1065
-msgid "The website limit takes precedence if lower than your limit."
-msgstr "El límit del lloc web pren la preferència si es inferior al teu límit."
-
-#: ../../Zotlabs/Module/Settings.php:1066
-msgid "Maximum Friend Requests/Day:"
-msgstr "Nombre màxim de peticions d'amistat per dia"
-
-#: ../../Zotlabs/Module/Settings.php:1066
-msgid "May reduce spam activity"
-msgstr "Pot reduir l'SPAM"
-
-#: ../../Zotlabs/Module/Settings.php:1067
-msgid "Default Post and Publish Permissions"
-msgstr "Permisos de Entrades i Publicació per defecte"
-
-#: ../../Zotlabs/Module/Settings.php:1069
-msgid "Use my default audience setting for the type of object published"
-msgstr "Empra els meus ajustos per defecte segons el tipus de entrada publicada"
-
-#: ../../Zotlabs/Module/Settings.php:1072
-msgid "Channel permissions category:"
-msgstr "Categoria de permisos de canal:"
-
-#: ../../Zotlabs/Module/Settings.php:1078
-msgid "Maximum private messages per day from unknown people:"
-msgstr "Nombre màxim de missatges privats de desconeguts al dia:"
-
-#: ../../Zotlabs/Module/Settings.php:1078
-msgid "Useful to reduce spamming"
-msgstr "Útil per a reduir l'spam"
-
-#: ../../Zotlabs/Module/Settings.php:1081
-msgid "Notification Settings"
-msgstr "Ajustos de notificacions"
-
-#: ../../Zotlabs/Module/Settings.php:1082
-msgid "By default post a status message when:"
-msgstr "Per defecte envia un missatge d'estat quan:"
-
-#: ../../Zotlabs/Module/Settings.php:1083
-msgid "accepting a friend request"
-msgstr "S'accepta una sol·licitud d'amistat"
-
-#: ../../Zotlabs/Module/Settings.php:1084
-msgid "joining a forum/community"
-msgstr "Apuntar-se a un fòrum o comunitat"
-
-#: ../../Zotlabs/Module/Settings.php:1085
-msgid "making an <em>interesting</em> profile change"
-msgstr "Faci un canvi  <em>interesant</em> al perfil"
-
-#: ../../Zotlabs/Module/Settings.php:1086
-msgid "Send a notification email when:"
-msgstr "Notifica per correu quan:"
-
-#: ../../Zotlabs/Module/Settings.php:1087
-msgid "You receive a connection request"
-msgstr "Rebi una petició de connexió"
-
-#: ../../Zotlabs/Module/Settings.php:1088
-msgid "Your connections are confirmed"
-msgstr "Es confirma una connexió"
-
-#: ../../Zotlabs/Module/Settings.php:1089
-msgid "Someone writes on your profile wall"
-msgstr "Algú ha escrit al mur del teu perfil"
-
-#: ../../Zotlabs/Module/Settings.php:1090
-msgid "Someone writes a followup comment"
-msgstr "Algú ha escrit un comentari de resposta"
-
-#: ../../Zotlabs/Module/Settings.php:1091
-msgid "You receive a private message"
-msgstr "Rebi un missatge privat"
-
-#: ../../Zotlabs/Module/Settings.php:1092
-msgid "You receive a friend suggestion"
-msgstr "Rebi una suggerència d'amistat"
-
-#: ../../Zotlabs/Module/Settings.php:1093
-msgid "You are tagged in a post"
-msgstr "Estàs etiquetat a l'entrada"
-
-#: ../../Zotlabs/Module/Settings.php:1094
-msgid "You are poked/prodded/etc. in a post"
-msgstr "S'enfoten/te piquen/etc. en una entrada"
-
-#: ../../Zotlabs/Module/Settings.php:1097
-msgid "Show visual notifications including:"
-msgstr "Mostra notificacion visuals, com ara:"
-
-#: ../../Zotlabs/Module/Settings.php:1099
-msgid "Unseen grid activity"
-msgstr "Activitat de malla no vista"
-
-#: ../../Zotlabs/Module/Settings.php:1100
-msgid "Unseen channel activity"
-msgstr "Activitat no vista del canal"
-
-#: ../../Zotlabs/Module/Settings.php:1101
-msgid "Unseen private messages"
-msgstr "Missatges privats no llegits"
-
-#: ../../Zotlabs/Module/Settings.php:1101
-#: ../../Zotlabs/Module/Settings.php:1106
-#: ../../Zotlabs/Module/Settings.php:1107
-#: ../../Zotlabs/Module/Settings.php:1108
-msgid "Recommended"
-msgstr "Recomanat"
-
-#: ../../Zotlabs/Module/Settings.php:1102
-msgid "Upcoming events"
-msgstr "Esdeveniments propers"
-
-#: ../../Zotlabs/Module/Settings.php:1103
-msgid "Events today"
-msgstr "Esdeveniments d'avui"
-
-#: ../../Zotlabs/Module/Settings.php:1104
-msgid "Upcoming birthdays"
-msgstr "Aniversaris propers"
-
-#: ../../Zotlabs/Module/Settings.php:1104
-msgid "Not available in all themes"
-msgstr "No està disponible en tots els temes"
-
-#: ../../Zotlabs/Module/Settings.php:1105
-msgid "System (personal) notifications"
-msgstr "Notificacions (personals) del sistema"
-
-#: ../../Zotlabs/Module/Settings.php:1106
-msgid "System info messages"
-msgstr "Missatges d'informació del sistema"
-
-#: ../../Zotlabs/Module/Settings.php:1107
-msgid "System critical alerts"
-msgstr "Alertes crítiques del sistema"
-
-#: ../../Zotlabs/Module/Settings.php:1108
-msgid "New connections"
-msgstr "Noves connexions"
-
-#: ../../Zotlabs/Module/Settings.php:1109
-msgid "System Registrations"
-msgstr "Registres del sistema"
-
-#: ../../Zotlabs/Module/Settings.php:1110
-msgid ""
-"Also show new wall posts, private messages and connections under Notices"
-msgstr "Mostra també les entrades de mur noves, les entrades privades i les connexions a \"Notícies\""
-
-#: ../../Zotlabs/Module/Settings.php:1112
-msgid "Notify me of events this many days in advance"
-msgstr "Notifica'm dels esdeveniments amb aquests dies d'antelació"
-
-#: ../../Zotlabs/Module/Settings.php:1112
-msgid "Must be greater than 0"
-msgstr "Ha de ser més gran que 0"
-
-#: ../../Zotlabs/Module/Settings.php:1114
-msgid "Advanced Account/Page Type Settings"
-msgstr "Ajustos avançats de compte i tipus de pàgina"
-
-#: ../../Zotlabs/Module/Settings.php:1115
-msgid "Change the behaviour of this account for special situations"
-msgstr "Modifica el comportament d'aquest compte en situacions especials"
-
-#: ../../Zotlabs/Module/Settings.php:1118
-msgid ""
-"Please enable expert mode (in <a href=\"settings/features\">Settings > "
-"Additional features</a>) to adjust!"
-msgstr "Activa el mode d'expert (a <a href=\"settings/features\">Ajustos > Més funcions</a>)"
-
-#: ../../Zotlabs/Module/Settings.php:1119
-msgid "Miscellaneous Settings"
-msgstr "Ajustos diversos"
-
-#: ../../Zotlabs/Module/Settings.php:1120
-msgid "Default photo upload folder"
-msgstr "Carpeta per defecte de fotos pujades"
-
-#: ../../Zotlabs/Module/Settings.php:1120
-#: ../../Zotlabs/Module/Settings.php:1121
-msgid "%Y - current year, %m -  current month"
-msgstr "%Y - any en curs, %m -  mes corrent"
-
-#: ../../Zotlabs/Module/Settings.php:1121
-msgid "Default file upload folder"
-msgstr "Carpeta per defecte d'arxius pujats"
-
-#: ../../Zotlabs/Module/Settings.php:1123
-msgid "Personal menu to display in your channel pages"
-msgstr "Menú personal per mostrar en les teves pàgines de canal"
-
-#: ../../Zotlabs/Module/Settings.php:1125
-msgid "Remove this channel."
-msgstr "Elimina aquest canal."
-
-#: ../../Zotlabs/Module/Settings.php:1126
-msgid "Firefox Share $Projectname provider"
-msgstr "Firefox Share $Projectname provider"
-
-#: ../../Zotlabs/Module/Settings.php:1127
-msgid "Start calendar week on monday"
-msgstr "Comença la setmana del calendari el dilluns"
-
-#: ../../Zotlabs/Module/Setup.php:179
-msgid "$Projectname Server - Setup"
-msgstr "Servidor $Projectname - Configuració"
-
-#: ../../Zotlabs/Module/Setup.php:183
-msgid "Could not connect to database."
-msgstr "No puc connectar amb la base de dades"
-
-#: ../../Zotlabs/Module/Setup.php:187
-msgid ""
-"Could not connect to specified site URL. Possible SSL certificate or DNS "
-"issue."
-msgstr "No s'ha pogut connectar a l'URL del lloc especificat. Possible problema amb el certificat SSL o de DNS."
-
-#: ../../Zotlabs/Module/Setup.php:194
-msgid "Could not create table."
-msgstr "No puc crear la taula."
-
-#: ../../Zotlabs/Module/Setup.php:199
-msgid "Your site database has been installed."
-msgstr "La teva base de dades del lloc s'ha instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:203
-msgid ""
-"You may need to import the file \"install/schema_xxx.sql\" manually using a "
-"database client."
-msgstr "Podria ser necessari importar el fitxer \"install / schema_xxx.sql\" manualment utilitzant un client de base de dades."
-
-#: ../../Zotlabs/Module/Setup.php:204 ../../Zotlabs/Module/Setup.php:266
-#: ../../Zotlabs/Module/Setup.php:721
-msgid "Please see the file \"install/INSTALL.txt\"."
-msgstr "Si us plau, consulteu el fitxer \"install / INSTALL.txt\"."
-
-#: ../../Zotlabs/Module/Setup.php:263
-msgid "System check"
-msgstr "Comprovació del sistema"
-
-#: ../../Zotlabs/Module/Setup.php:268
-msgid "Check again"
-msgstr "Comprova de nou"
-
-#: ../../Zotlabs/Module/Setup.php:290
-msgid "Database connection"
-msgstr "Connexió de base de dades"
-
-#: ../../Zotlabs/Module/Setup.php:291
-msgid ""
-"In order to install $Projectname we need to know how to connect to your "
-"database."
-msgstr "Per tal d'instaŀlar $Projectname cal configurar la connexió a la base de dades."
-
-#: ../../Zotlabs/Module/Setup.php:292
-msgid ""
-"Please contact your hosting provider or site administrator if you have "
-"questions about these settings."
-msgstr "Si us plau, poseu-vos en contacte amb el proveïdor de serveis o administrador del lloc si vostè té preguntes sobre aquests paràmetres."
-
-#: ../../Zotlabs/Module/Setup.php:293
-msgid ""
-"The database you specify below should already exist. If it does not, please "
-"create it before continuing."
-msgstr "La base de dades s'especifica a continuació ja ha d'existir. Si no és així, si us plau crear-la abans de continuar."
-
-#: ../../Zotlabs/Module/Setup.php:297
-msgid "Database Server Name"
-msgstr "Base de Dades Nom del Servidor"
-
-#: ../../Zotlabs/Module/Setup.php:297
-msgid "Default is 127.0.0.1"
-msgstr "Per defecte es 127.0.0.1"
-
-#: ../../Zotlabs/Module/Setup.php:298
-msgid "Database Port"
-msgstr "Port per a la Base de Dades"
-
-#: ../../Zotlabs/Module/Setup.php:298
-msgid "Communication port number - use 0 for default"
-msgstr "Numero del port de comunicacions - empra 0 per defecte"
-
-#: ../../Zotlabs/Module/Setup.php:299
-msgid "Database Login Name"
-msgstr "Base de Dades Nom d'Accès"
-
-#: ../../Zotlabs/Module/Setup.php:300
-msgid "Database Login Password"
-msgstr "Base de Dades Contrasenya d'Accès"
-
-#: ../../Zotlabs/Module/Setup.php:301
-msgid "Database Name"
-msgstr "Nom de la Base de Dades"
-
-#: ../../Zotlabs/Module/Setup.php:302
-msgid "Database Type"
-msgstr "Tipus de Base de Dades"
-
-#: ../../Zotlabs/Module/Setup.php:304 ../../Zotlabs/Module/Setup.php:344
-msgid "Site administrator email address"
-msgstr "Adreça de correu de l'administrador del lloc"
-
-#: ../../Zotlabs/Module/Setup.php:304 ../../Zotlabs/Module/Setup.php:344
-msgid ""
-"Your account email address must match this in order to use the web admin "
-"panel."
-msgstr "El teu compte de email ha de coincidir amb això per poder emprar el panel web d'administrador."
-
-#: ../../Zotlabs/Module/Setup.php:305 ../../Zotlabs/Module/Setup.php:346
-msgid "Website URL"
-msgstr "URL del lloc web"
-
-#: ../../Zotlabs/Module/Setup.php:305 ../../Zotlabs/Module/Setup.php:346
-msgid "Please use SSL (https) URL if available."
-msgstr "Si us plau, empra SSL (https) URL si està disponible."
-
-#: ../../Zotlabs/Module/Setup.php:306 ../../Zotlabs/Module/Setup.php:349
-msgid "Please select a default timezone for your website"
-msgstr "Si us plau, tria la zona horària del teu lloc web"
-
-#: ../../Zotlabs/Module/Setup.php:333
-msgid "Site settings"
-msgstr "Ajustos del lloc"
-
-#: ../../Zotlabs/Module/Setup.php:347
-msgid "Enable $Projectname <strong>advanced</strong> features?"
-msgstr "Activar característiques <strong>advanced</strong> de $Projectname?"
-
-#: ../../Zotlabs/Module/Setup.php:347
-msgid ""
-"Some advanced features, while useful - may be best suited for technically "
-"proficient audiences"
-msgstr "Algunes característiques avançades, hauran de ser ajustades per persones tècnicament capaces, per poder emprar-les."
-
-#: ../../Zotlabs/Module/Setup.php:388
-msgid "PHP version 5.5 or greater is required."
-msgstr "PHP version 5.5 or greater is required."
-
-#: ../../Zotlabs/Module/Setup.php:389
-msgid "PHP version"
-msgstr "PHP version"
-
-#: ../../Zotlabs/Module/Setup.php:404
-msgid "Could not find a command line version of PHP in the web server PATH."
-msgstr "No s'ha pogut trobar una versió de línia d'ordres del PHP en el PATH del servidor web."
-
-#: ../../Zotlabs/Module/Setup.php:405
-msgid ""
-"If you don't have a command line version of PHP installed on server, you "
-"will not be able to run background polling via cron."
-msgstr "Si vostè no té una versió de línia d'ordres del PHP instal·lada al servidor, vostè no serà capaç d'executar sondejos en segon pla via cron."
-
-#: ../../Zotlabs/Module/Setup.php:409
-msgid "PHP executable path"
-msgstr "Camí cap l'executable de PHP"
-
-#: ../../Zotlabs/Module/Setup.php:409
-msgid ""
-"Enter full path to php executable. You can leave this blank to continue the "
-"installation."
-msgstr "Introdueix el camí cap l'executable de php. Pots deixa-ho en blanc i continuar l'instal·lació."
-
-#: ../../Zotlabs/Module/Setup.php:414
-msgid "Command line PHP"
-msgstr "Línia d'ordres de PHP"
-
-#: ../../Zotlabs/Module/Setup.php:423
-msgid ""
-"The command line version of PHP on your system does not have "
-"\"register_argc_argv\" enabled."
-msgstr "La versió de línia d'ordres de PHP al teu sistema no te el \"register_argc_argv\" activat."
-
-#: ../../Zotlabs/Module/Setup.php:424
-msgid "This is required for message delivery to work."
-msgstr "Això es requereix per que funcioni l'entrega de missatges."
-
-#: ../../Zotlabs/Module/Setup.php:427
-msgid "PHP register_argc_argv"
-msgstr "PHP register_argc_argv"
-
-#: ../../Zotlabs/Module/Setup.php:445
-#, php-format
-msgid ""
-"Your max allowed total upload size is set to %s. Maximum size of one file to"
-" upload is set to %s. You are allowed to upload up to %d files at once."
-msgstr "La mida màxima que se't permet pujar està establerta en %s. La mida màxima per arxiu pujat es de %s. Se't permet pujar fins a %d arxius d'una vegada."
-
-#: ../../Zotlabs/Module/Setup.php:450
-msgid "You can adjust these settings in the servers php.ini."
-msgstr "Pots ajustar aquests valors a l'arxiu php.ini del servidor"
-
-#: ../../Zotlabs/Module/Setup.php:452
-msgid "PHP upload limits"
-msgstr "Límits de pujada de PHP"
-
-#: ../../Zotlabs/Module/Setup.php:475
-msgid ""
-"Error: the \"openssl_pkey_new\" function on this system is not able to "
-"generate encryption keys"
-msgstr "Error: la funció \"openssl_pkey_new\" en aquest sistema no es capaç de generar claus d'encriptació"
-
-#: ../../Zotlabs/Module/Setup.php:476
-msgid ""
-"If running under Windows, please see "
-"\"http://www.php.net/manual/en/openssl.installation.php\"."
-msgstr "Si esta funcionant sota Windows, per favor, miri \"http://www.php.net/manual/en/openssl.installation.php\"."
-
-#: ../../Zotlabs/Module/Setup.php:479
-msgid "Generate encryption keys"
-msgstr "Generar claus de xifrat"
-
-#: ../../Zotlabs/Module/Setup.php:491
-msgid "libCurl PHP module"
-msgstr "mòdul PHP libCurl "
-
-#: ../../Zotlabs/Module/Setup.php:492
-msgid "GD graphics PHP module"
-msgstr "mòdul PHP GD gràfics"
-
-#: ../../Zotlabs/Module/Setup.php:493
-msgid "OpenSSL PHP module"
-msgstr "mòdul PHP OpenSSL"
-
-#: ../../Zotlabs/Module/Setup.php:494
-msgid "mysqli or postgres PHP module"
-msgstr "mòdul PHP mysqli o postgres"
-
-#: ../../Zotlabs/Module/Setup.php:495
-msgid "mb_string PHP module"
-msgstr "mòdul PHP mb_string"
-
-#: ../../Zotlabs/Module/Setup.php:496
-msgid "mcrypt PHP module"
-msgstr "mòdul PHP mcrypt"
-
-#: ../../Zotlabs/Module/Setup.php:497
-msgid "xml PHP module"
-msgstr "Mòdul xml de PHP"
-
-#: ../../Zotlabs/Module/Setup.php:501 ../../Zotlabs/Module/Setup.php:503
-msgid "Apache mod_rewrite module"
-msgstr "mòdul Apache mod_rewrite"
-
-#: ../../Zotlabs/Module/Setup.php:501
-msgid ""
-"Error: Apache webserver mod-rewrite module is required but not installed."
-msgstr "Error: el mòdul mod-rewrite del servidor web Apache es requereix i no està instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:507 ../../Zotlabs/Module/Setup.php:510
-msgid "proc_open"
-msgstr "proc_open"
-
-#: ../../Zotlabs/Module/Setup.php:507
-msgid ""
-"Error: proc_open is required but is either not installed or has been "
-"disabled in php.ini"
-msgstr "Error: es requereix proc_open però o no està instal·lat o ha estat desactivat a php.ini"
-
-#: ../../Zotlabs/Module/Setup.php:515
-msgid "Error: libCURL PHP module required but not installed."
-msgstr "Error: el mòdul PHP libCURL es requereix però no està instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:519
-msgid ""
-"Error: GD graphics PHP module with JPEG support required but not installed."
-msgstr "Error: el mòdul PHP GD graphics amb support JPEG es requereix però no està instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:523
-msgid "Error: openssl PHP module required but not installed."
-msgstr "Error: el mòdul PHP openssl es requereix però no està instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:527
-msgid ""
-"Error: mysqli or postgres PHP module required but neither are installed."
-msgstr "Error: el mòdul PHO mysqli o postgres es requereix però no està instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:531
-msgid "Error: mb_string PHP module required but not installed."
-msgstr "Error: el mòdul PHP mb_string es requereix però no està instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:535
-msgid "Error: mcrypt PHP module required but not installed."
-msgstr "Error: el mòdul PHP mcrypt es requereix però no està instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:539
-msgid "Error: xml PHP module required for DAV but not installed."
-msgstr "Error: el mòdul xml de PHP es requereix per DAV però no està instal·lat."
-
-#: ../../Zotlabs/Module/Setup.php:557
-msgid ""
-"The web installer needs to be able to create a file called \".htconfig.php\""
-" in the top folder of your web server and it is unable to do so."
-msgstr "L'instaŀlador ha de poder crear i modificar un fitxer anomenat «.htconfig.php» a la carpeta arrel del servidor, però sembla que no ho pot fer."
-
-#: ../../Zotlabs/Module/Setup.php:558
-msgid ""
-"This is most often a permission setting, as the web server may not be able "
-"to write files in your folder - even if you can."
-msgstr "Això sol ser un problema de permisos. Per molt que el teu usuari pugui modificar-lo, és el del servidor web qui necessita els poders de modificació."
-
-#: ../../Zotlabs/Module/Setup.php:559
-msgid ""
-"At the end of this procedure, we will give you a text to save in a file "
-"named .htconfig.php in your Red top folder."
-msgstr "Al final d'aquest procés hauràs de desar un text a l'arxiu «.htconfig.php», que es troba a la carpeta arrel del servidor."
-
-#: ../../Zotlabs/Module/Setup.php:560
-msgid ""
-"You can alternatively skip this procedure and perform a manual installation."
-" Please see the file \"install/INSTALL.txt\" for instructions."
-msgstr "Aquest procés és opcional. Per a fer una instaŀlació manual consulta les instruccions a «install/INSTALL.txt\"."
-
-#: ../../Zotlabs/Module/Setup.php:563
-msgid ".htconfig.php is writable"
-msgstr "L'arxiu «.htconfig.php» es pot modificar"
-
-#: ../../Zotlabs/Module/Setup.php:577
-msgid ""
-"Red uses the Smarty3 template engine to render its web views. Smarty3 "
-"compiles templates to PHP to speed up rendering."
-msgstr "Red fa servir el motor de plantilles Smarty3 per a renderitzar les vistes més ràpidament."
-
-#: ../../Zotlabs/Module/Setup.php:578
-#, php-format
-msgid ""
-"In order to store these compiled templates, the web server needs to have "
-"write access to the directory %s under the top level web folder."
-msgstr "Per tal de guardar aquestes plantilles compilades, el servidor web necessita tenir premis d'escriptura en el directori %s sota la carpeta principal."
-
-#: ../../Zotlabs/Module/Setup.php:579 ../../Zotlabs/Module/Setup.php:600
-msgid ""
-"Please ensure that the user that your web server runs as (e.g. www-data) has"
-" write access to this folder."
-msgstr "Comprova que l'usuari que executa el servidor (www-data en Apache) té permisos d'escriptura en aquesta carpeta."
-
-#: ../../Zotlabs/Module/Setup.php:580
-#, php-format
-msgid ""
-"Note: as a security measure, you should give the web server write access to "
-"%s only--not the template files (.tpl) that it contains."
-msgstr "Nota: com a mesura de seguretat l'usuari del servidor web ha de tenir accés d'escriptura només a %s, i no a les plantilles (.tpl) que conté."
-
-#: ../../Zotlabs/Module/Setup.php:583
-#, php-format
-msgid "%s is writable"
-msgstr "Es pot escriure a %s"
-
-#: ../../Zotlabs/Module/Setup.php:599
-msgid ""
-"Red uses the store directory to save uploaded files. The web server needs to"
-" have write access to the store directory under the Red top level folder"
-msgstr "Red fa servir la carpeta «store» per a desar els fitxers pujats. Per tant, el servidor web necessita tenir permís d'escriptura en aquesta carpeta, que està a l'arrel del servidor web."
-
-#: ../../Zotlabs/Module/Setup.php:603
-msgid "store is writable"
-msgstr "Es pot escriure al magatzem (store)"
-
-#: ../../Zotlabs/Module/Setup.php:636
-msgid ""
-"SSL certificate cannot be validated. Fix certificate or disable https access"
-" to this site."
-msgstr "El certificat SSL no s'ha pogut validar. Arregla-ho o deshabilita l'accés https a aquest lloc"
-
-#: ../../Zotlabs/Module/Setup.php:637
-msgid ""
-"If you have https access to your website or allow connections to TCP port "
-"443 (the https: port), you MUST use a browser-valid certificate. You MUST "
-"NOT use self-signed certificates!"
-msgstr "Si tens accès pet https al teu lloc web o permets connexions pel port TCP 443 (port https), Has d'emprar un certificat VÀLID. NO es poden emprar certificats AUTO-SIGNATS!"
-
-#: ../../Zotlabs/Module/Setup.php:638
-msgid ""
-"This restriction is incorporated because public posts from you may for "
-"example contain references to images on your own hub."
-msgstr "El motiu d'aquesta restricció és que les teves entrades públiques poden contenir referències a imatges del teu propi node."
-
-#: ../../Zotlabs/Module/Setup.php:639
-msgid ""
-"If your certificate is not recognized, members of other sites (who may "
-"themselves have valid certificates) will get a warning message on their own "
-"site complaining about security issues."
-msgstr "Si el teu certificat no és reconegut, llavors el membres d'altres hubs, encara que tinguin certificats vàlids, rebran una advertència de seguretat en carregar contingut teu."
-
-#: ../../Zotlabs/Module/Setup.php:640
-msgid ""
-"This can cause usability issues elsewhere (not just on your own site) so we "
-"must insist on this requirement."
-msgstr "Per tant, com que perjudica la usabilitat més enllà del teu lloc, la restricció de tenir un certificat reconegut és molt important."
-
-#: ../../Zotlabs/Module/Setup.php:641
-msgid ""
-"Providers are available that issue free certificates which are browser-"
-"valid."
-msgstr "Hi ha autoritats de certificació reconegudes que ofereixen certificats gratuïts."
-
-#: ../../Zotlabs/Module/Setup.php:643
-msgid "SSL certificate validation"
-msgstr "Validació del certificat SSL"
-
-#: ../../Zotlabs/Module/Setup.php:649
-msgid ""
-"Url rewrite in .htaccess is not working. Check your server "
-"configuration.Test: "
-msgstr "No es poden reescriure les URL a «.htaccess». Comprova la configuració del servidor:"
-
-#: ../../Zotlabs/Module/Setup.php:652
-msgid "Url rewrite is working"
-msgstr "Es poden reescriure les URL a «.htaccess»"
-
-#: ../../Zotlabs/Module/Setup.php:661
-msgid ""
-"The database configuration file \".htconfig.php\" could not be written. "
-"Please use the enclosed text to create a configuration file in your web "
-"server root."
-msgstr "L'arxiu de configuracio de la base de dades «.htconfig.php» no s'ha pogut modificar. El pots crear tu a l'arrel del servidor web amb el text de la caixa com a contingut."
-
-#: ../../Zotlabs/Module/Setup.php:685
-msgid "Errors encountered creating database tables."
-msgstr "S'han produït errors mentre es creaven taules a la base de dades."
-
-#: ../../Zotlabs/Module/Setup.php:719
-msgid "<h1>What next</h1>"
-msgstr "<h1>I ara què?</h1>"
-
-#: ../../Zotlabs/Module/Setup.php:720
-msgid ""
-"IMPORTANT: You will need to [manually] setup a scheduled task for the "
-"poller."
-msgstr "IMPORTANT! Cal que configuris manualment una execució periòdica del \"poller\"."
-
-#: ../../Zotlabs/Module/Sharedwithme.php:98
-msgid "Files: shared with me"
-msgstr "Arxius: compartits amb jo"
-
-#: ../../Zotlabs/Module/Sharedwithme.php:100
-msgid "NEW"
-msgstr "NOU"
-
-#: ../../Zotlabs/Module/Sharedwithme.php:103
-msgid "Remove all files"
-msgstr "Esborra tots els arxius"
-
-#: ../../Zotlabs/Module/Sharedwithme.php:104
-msgid "Remove this file"
-msgstr "Esborra l'arxiu"
-
-#: ../../Zotlabs/Module/Siteinfo.php:19
+#: ../../Zotlabs/Module/Siteinfo.php:30
 #, php-format
 msgid "Version %s"
 msgstr "Versió %s"
 
-#: ../../Zotlabs/Module/Siteinfo.php:40
-msgid "Installed plugins/addons/apps:"
-msgstr "Plugins/addons/apps Instal·lats:"
+#: ../../Zotlabs/Module/Siteinfo.php:31
+msgid "Project homepage"
+msgstr "Pàgina principal del projecte"
 
-#: ../../Zotlabs/Module/Siteinfo.php:53
-msgid "No installed plugins/addons/apps"
-msgstr "Plugins/addons/apps no instal·lats"
+#: ../../Zotlabs/Module/Siteinfo.php:32
+msgid "Developer homepage"
+msgstr "Pàgina principal de desenvolupament"
 
-#: ../../Zotlabs/Module/Siteinfo.php:66
+#: ../../Zotlabs/Module/Ratings.php:70
+msgid "No ratings"
+msgstr "No valorat"
+
+#: ../../Zotlabs/Module/Ratings.php:97 ../../Zotlabs/Module/Pubsites.php:35
+#: ../../include/conversation.php:1082
+msgid "Ratings"
+msgstr "Valoracions"
+
+#: ../../Zotlabs/Module/Ratings.php:98
+msgid "Rating: "
+msgstr "Valoració:"
+
+#: ../../Zotlabs/Module/Ratings.php:99
+msgid "Website: "
+msgstr "Lloc web:"
+
+#: ../../Zotlabs/Module/Ratings.php:101
+msgid "Description: "
+msgstr "Descripció:"
+
+#: ../../Zotlabs/Module/Webpages.php:54
+msgid "Import Webpage Elements"
+msgstr "Importa elements de pàgina web"
+
+#: ../../Zotlabs/Module/Webpages.php:55
+msgid "Import selected"
+msgstr "Importa la selecció"
+
+#: ../../Zotlabs/Module/Webpages.php:78
+msgid "Export Webpage Elements"
+msgstr "Exporta elements de pàgina web"
+
+#: ../../Zotlabs/Module/Webpages.php:79
+msgid "Export selected"
+msgstr "Exporta la selecció"
+
+#: ../../Zotlabs/Module/Webpages.php:237 ../../Zotlabs/Lib/Apps.php:244
+#: ../../include/conversation.php:1912 ../../include/nav.php:481
+msgid "Webpages"
+msgstr "Pàgines web"
+
+#: ../../Zotlabs/Module/Webpages.php:248
+msgid "Actions"
+msgstr "Accions"
+
+#: ../../Zotlabs/Module/Webpages.php:249
+msgid "Page Link"
+msgstr "Enllaç a Pàgina"
+
+#: ../../Zotlabs/Module/Webpages.php:250
+msgid "Page Title"
+msgstr "Títol de la pàgina"
+
+#: ../../Zotlabs/Module/Webpages.php:280
+msgid "Invalid file type."
+msgstr "El tipus de fitxer és invàlid."
+
+#: ../../Zotlabs/Module/Webpages.php:292
+msgid "Error opening zip file"
+msgstr "Hi ha hagut un error descomprimint"
+
+#: ../../Zotlabs/Module/Webpages.php:303
+msgid "Invalid folder path."
+msgstr "El camí de carpeta és invàlid."
+
+#: ../../Zotlabs/Module/Webpages.php:330
+msgid "No webpage elements detected."
+msgstr "No s'ha detectat cap element de pàgina web."
+
+#: ../../Zotlabs/Module/Webpages.php:405
+msgid "Import complete."
+msgstr "S'ha completat la importació."
+
+#: ../../Zotlabs/Module/Changeaddr.php:35
 msgid ""
-"This is a hub of $Projectname - a global cooperative network of "
-"decentralized privacy enhanced websites."
-msgstr "Aquest és un node de $Projectname, una xarxa cooperativa mundial de llocs web descentralitzats amb gran control de la privacitat."
+"Channel name changes are not allowed within 48 hours of changing the account"
+" password."
+msgstr "No es permet canviar el nom d'un canal fins a 48 hores més tard d'haver canviant la contrasenya del compte al que pertany."
 
-#: ../../Zotlabs/Module/Siteinfo.php:68
-msgid "Tag: "
-msgstr "Etiqueta:"
+#: ../../Zotlabs/Module/Changeaddr.php:46 ../../include/channel.php:214
+#: ../../include/channel.php:599
+msgid "Reserved nickname. Please choose another."
+msgstr "Àlies reservat. Tria un altre."
 
-#: ../../Zotlabs/Module/Siteinfo.php:70
-msgid "Last background fetch: "
-msgstr "Última actualització en rerefons:"
-
-#: ../../Zotlabs/Module/Siteinfo.php:72
-msgid "Current load average: "
-msgstr "Càrrega actual mitja:"
-
-#: ../../Zotlabs/Module/Siteinfo.php:75
-msgid "Running at web location"
-msgstr "Correguent en el lloc web"
-
-#: ../../Zotlabs/Module/Siteinfo.php:76
+#: ../../Zotlabs/Module/Changeaddr.php:51 ../../include/channel.php:219
+#: ../../include/channel.php:604
 msgid ""
-"Please visit <a href=\"http://hubzilla.org\">hubzilla.org</a> to learn more "
-"about $Projectname."
-msgstr "Visita <a href=\"http://hubzilla.org\">hubzilla.org</a> per saber-ne més de $Projectname."
+"Nickname has unsupported characters or is already being used on this site."
+msgstr "L'álies te caracters no soportats o ja esta en ús en aquest lloc"
 
-#: ../../Zotlabs/Module/Siteinfo.php:77
-msgid "Bug reports and issues: please visit"
-msgstr "Per informar d'errors o problemes ves a"
+#: ../../Zotlabs/Module/Changeaddr.php:77
+msgid "Change channel nickname/address"
+msgstr "Canvia el nom o adreça del canal"
 
-#: ../../Zotlabs/Module/Siteinfo.php:79
-msgid "$projectname issues"
-msgstr "$projectname qüestions"
+#: ../../Zotlabs/Module/Changeaddr.php:78
+msgid "Any/all connections on other networks will be lost!"
+msgstr "Es perdran totes les connexions amb xarxes externes!"
 
-#: ../../Zotlabs/Module/Siteinfo.php:80
-msgid ""
-"Suggestions, praise, etc. - please email \"redmatrix\" at librelist - dot "
-"com"
-msgstr "Per suggerències, felicitacions i altres, envia'ns un mail a «redmatrix» [arroba] librelist [punt] com"
+#: ../../Zotlabs/Module/Changeaddr.php:80
+msgid "New channel address"
+msgstr "Adreça de canal nova"
 
-#: ../../Zotlabs/Module/Siteinfo.php:82
-msgid "Site Administrators"
-msgstr "Administradors del lloc"
+#: ../../Zotlabs/Module/Changeaddr.php:81
+msgid "Rename Channel"
+msgstr "Canvia el nom del canal"
+
+#: ../../Zotlabs/Module/Editpost.php:38 ../../Zotlabs/Module/Editpost.php:43
+msgid "Item is not editable"
+msgstr "Article no editable"
+
+#: ../../Zotlabs/Module/Editpost.php:108 ../../Zotlabs/Module/Rpost.php:178
+msgid "Edit post"
+msgstr "Modifica l'entrada"
+
+#: ../../Zotlabs/Module/Dreport.php:45
+msgid "Invalid message"
+msgstr "Missatge invàlid."
+
+#: ../../Zotlabs/Module/Dreport.php:78
+msgid "no results"
+msgstr "sense resultats"
+
+#: ../../Zotlabs/Module/Dreport.php:93
+msgid "channel sync processed"
+msgstr "sincronització del canal processada"
+
+#: ../../Zotlabs/Module/Dreport.php:97
+msgid "queued"
+msgstr "Posat en cua"
+
+#: ../../Zotlabs/Module/Dreport.php:101
+msgid "posted"
+msgstr "enviat"
+
+#: ../../Zotlabs/Module/Dreport.php:105
+msgid "accepted for delivery"
+msgstr "acceptat per entregar"
+
+#: ../../Zotlabs/Module/Dreport.php:109
+msgid "updated"
+msgstr "actualitzat"
+
+#: ../../Zotlabs/Module/Dreport.php:112
+msgid "update ignored"
+msgstr "actualització ignorada"
+
+#: ../../Zotlabs/Module/Dreport.php:115
+msgid "permission denied"
+msgstr "permís denegat"
+
+#: ../../Zotlabs/Module/Dreport.php:119
+msgid "recipient not found"
+msgstr "Contenidor no trobat"
+
+#: ../../Zotlabs/Module/Dreport.php:122
+msgid "mail recalled"
+msgstr "Recupera el correu"
+
+#: ../../Zotlabs/Module/Dreport.php:125
+msgid "duplicate mail received"
+msgstr "rebut correu duplicat"
+
+#: ../../Zotlabs/Module/Dreport.php:128
+msgid "mail delivered"
+msgstr "correu entregat"
+
+#: ../../Zotlabs/Module/Dreport.php:148
+#, php-format
+msgid "Delivery report for %1$s"
+msgstr "Informe de lliurament per %1$s"
+
+#: ../../Zotlabs/Module/Dreport.php:151 ../../Zotlabs/Widget/Wiki_pages.php:39
+#: ../../Zotlabs/Widget/Wiki_pages.php:96
+msgid "Options"
+msgstr "Opcions"
+
+#: ../../Zotlabs/Module/Dreport.php:152
+msgid "Redeliver"
+msgstr "Tornar a lliurar"
 
 #: ../../Zotlabs/Module/Sources.php:37
 msgid "Failed to create source. No channel selected."
@@ -6006,8 +6653,8 @@ msgstr "Origen actualitzat."
 msgid "*"
 msgstr "*"
 
-#: ../../Zotlabs/Module/Sources.php:96 ../../include/widgets.php:630
-#: ../../include/features.php:71
+#: ../../Zotlabs/Module/Sources.php:96
+#: ../../Zotlabs/Widget/Settings_menu.php:125 ../../include/features.php:274
 msgid "Channel Sources"
 msgstr "Canal Origen"
 
@@ -6063,15 +6710,210 @@ msgstr "S'ha esborrat la font"
 msgid "Unable to remove source."
 msgstr "No s'ha pogut esborrar la font."
 
-#: ../../Zotlabs/Module/Subthread.php:118
-#, php-format
-msgid "%1$s is following %2$s's %3$s"
-msgstr "%1$s esta seguint %2$s de %3$s"
+#: ../../Zotlabs/Module/Like.php:54
+msgid "Like/Dislike"
+msgstr "M'agrada / No m'agrada"
 
-#: ../../Zotlabs/Module/Subthread.php:120
+#: ../../Zotlabs/Module/Like.php:59
+msgid "This action is restricted to members."
+msgstr "Aquesta acció està restringida als membres."
+
+#: ../../Zotlabs/Module/Like.php:60
+msgid ""
+"Please <a href=\"rmagic\">login with your $Projectname ID</a> or <a "
+"href=\"register\">register as a new $Projectname member</a> to continue."
+msgstr "<a href=\"rmagic\">Entra amb la teva identitat $Projectname</a> o <a href=\"register\">registra't a $Projectname</a> per continuar."
+
+#: ../../Zotlabs/Module/Like.php:109 ../../Zotlabs/Module/Like.php:135
+#: ../../Zotlabs/Module/Like.php:173
+msgid "Invalid request."
+msgstr "Sol·licitud invàlida."
+
+#: ../../Zotlabs/Module/Like.php:121 ../../include/conversation.php:122
+msgid "channel"
+msgstr "canal"
+
+#: ../../Zotlabs/Module/Like.php:150
+msgid "thing"
+msgstr "cosa"
+
+#: ../../Zotlabs/Module/Like.php:196
+msgid "Channel unavailable."
+msgstr "El canal està inactiu."
+
+#: ../../Zotlabs/Module/Like.php:244
+msgid "Previous action reversed."
+msgstr "S'ha desfet l'acció anterior."
+
+#: ../../Zotlabs/Module/Like.php:436 ../../addon/diaspora/Receiver.php:1547
+#: ../../addon/pubcrawl/as.php:1394 ../../include/conversation.php:160
 #, php-format
-msgid "%1$s stopped following %2$s's %3$s"
-msgstr "%1$s abandona el seguiment %2$s de %3$s"
+msgid "%1$s likes %2$s's %3$s"
+msgstr "%1$s agrada %2$s de %3$s"
+
+#: ../../Zotlabs/Module/Like.php:438 ../../addon/pubcrawl/as.php:1396
+#: ../../include/conversation.php:163
+#, php-format
+msgid "%1$s doesn't like %2$s's %3$s"
+msgstr "%1$s no agrada %2$s de %3$s"
+
+#: ../../Zotlabs/Module/Like.php:440
+#, php-format
+msgid "%1$s agrees with %2$s's %3$s"
+msgstr "%1$s està d'acord amb %3$s de %2$s"
+
+#: ../../Zotlabs/Module/Like.php:442
+#, php-format
+msgid "%1$s doesn't agree with %2$s's %3$s"
+msgstr "%1$s no està d'acord amb %3$s de %2$s"
+
+#: ../../Zotlabs/Module/Like.php:444
+#, php-format
+msgid "%1$s abstains from a decision on %2$s's %3$s"
+msgstr "%1$s s'abstén en %3$s de %2$s"
+
+#: ../../Zotlabs/Module/Like.php:446 ../../addon/diaspora/Receiver.php:2031
+#, php-format
+msgid "%1$s is attending %2$s's %3$s"
+msgstr "%1$s assistirà a %3$s de %2$s"
+
+#: ../../Zotlabs/Module/Like.php:448 ../../addon/diaspora/Receiver.php:2033
+#, php-format
+msgid "%1$s is not attending %2$s's %3$s"
+msgstr "%1$s no assistirà a %3$s de %2$s"
+
+#: ../../Zotlabs/Module/Like.php:450 ../../addon/diaspora/Receiver.php:2035
+#, php-format
+msgid "%1$s may attend %2$s's %3$s"
+msgstr "%1$s potser assistirà a %3$s de %2$s"
+
+#: ../../Zotlabs/Module/Like.php:562
+msgid "Action completed."
+msgstr "S'ha completat l'acció."
+
+#: ../../Zotlabs/Module/Like.php:563
+msgid "Thank you."
+msgstr "Gràcies."
+
+#: ../../Zotlabs/Module/Directory.php:250
+#, php-format
+msgid "%d rating"
+msgid_plural "%d ratings"
+msgstr[0] "%d valoració"
+msgstr[1] "%d valoracions"
+
+#: ../../Zotlabs/Module/Directory.php:261
+msgid "Gender: "
+msgstr "Gènere:"
+
+#: ../../Zotlabs/Module/Directory.php:263
+msgid "Status: "
+msgstr "Estatus:"
+
+#: ../../Zotlabs/Module/Directory.php:265
+msgid "Homepage: "
+msgstr "Pàgina Personal:"
+
+#: ../../Zotlabs/Module/Directory.php:314 ../../include/channel.php:1565
+msgid "Age:"
+msgstr "Edat:"
+
+#: ../../Zotlabs/Module/Directory.php:319 ../../include/channel.php:1392
+#: ../../include/event.php:54 ../../include/event.php:86
+msgid "Location:"
+msgstr "Localització:"
+
+#: ../../Zotlabs/Module/Directory.php:325
+msgid "Description:"
+msgstr "Descripció:"
+
+#: ../../Zotlabs/Module/Directory.php:330 ../../include/channel.php:1581
+msgid "Hometown:"
+msgstr "Ciutat Natal:"
+
+#: ../../Zotlabs/Module/Directory.php:332 ../../include/channel.php:1589
+msgid "About:"
+msgstr "Sobre:"
+
+#: ../../Zotlabs/Module/Directory.php:333 ../../Zotlabs/Module/Suggest.php:56
+#: ../../Zotlabs/Widget/Follow.php:32 ../../Zotlabs/Widget/Suggestions.php:44
+#: ../../include/conversation.php:1052 ../../include/channel.php:1377
+#: ../../include/connections.php:111
+msgid "Connect"
+msgstr "Connecta "
+
+#: ../../Zotlabs/Module/Directory.php:334
+msgid "Public Forum:"
+msgstr "Forum Públic:"
+
+#: ../../Zotlabs/Module/Directory.php:337
+msgid "Keywords: "
+msgstr "Paraules Clau:"
+
+#: ../../Zotlabs/Module/Directory.php:340
+msgid "Don't suggest"
+msgstr "No suggerir"
+
+#: ../../Zotlabs/Module/Directory.php:342
+msgid "Common connections (estimated):"
+msgstr "Connexions en comú (aproximades):"
+
+#: ../../Zotlabs/Module/Directory.php:391
+msgid "Global Directory"
+msgstr "Directori Global"
+
+#: ../../Zotlabs/Module/Directory.php:391
+msgid "Local Directory"
+msgstr "Directori Local"
+
+#: ../../Zotlabs/Module/Directory.php:397
+msgid "Finding:"
+msgstr "Cercant:"
+
+#: ../../Zotlabs/Module/Directory.php:400 ../../Zotlabs/Module/Suggest.php:64
+#: ../../include/contact_widgets.php:24
+msgid "Channel Suggestions"
+msgstr "Canals Suggerits"
+
+#: ../../Zotlabs/Module/Directory.php:402
+msgid "next page"
+msgstr "pàgina següent"
+
+#: ../../Zotlabs/Module/Directory.php:402
+msgid "previous page"
+msgstr "pàgina anterior"
+
+#: ../../Zotlabs/Module/Directory.php:403
+msgid "Sort options"
+msgstr "Opcions per ordenar"
+
+#: ../../Zotlabs/Module/Directory.php:404
+msgid "Alphabetic"
+msgstr "Alfabètic"
+
+#: ../../Zotlabs/Module/Directory.php:405
+msgid "Reverse Alphabetic"
+msgstr "Alfabètic Invers"
+
+#: ../../Zotlabs/Module/Directory.php:406
+msgid "Newest to Oldest"
+msgstr "De més Nou a més Vell"
+
+#: ../../Zotlabs/Module/Directory.php:407
+msgid "Oldest to Newest"
+msgstr "De més Antic a més Nou"
+
+#: ../../Zotlabs/Module/Directory.php:424
+msgid "No entries (some entries may be hidden)."
+msgstr "Sense entrades (algunes podrien estar amagades)."
+
+#: ../../Zotlabs/Module/Xchan.php:10
+msgid "Xchan Lookup"
+msgstr "Cerca a xchan"
+
+#: ../../Zotlabs/Module/Xchan.php:13
+msgid "Lookup xchan beginning with (or webbie): "
+msgstr "Cerca a xchan començant per (o webbie)"
 
 #: ../../Zotlabs/Module/Suggest.php:39
 msgid ""
@@ -6079,23 +6921,385 @@ msgid ""
 "hours."
 msgstr "No hi ha suggerencies. Si es un lloc nou, espera 24 hores i proba de nou."
 
-#: ../../Zotlabs/Module/Suggest.php:58 ../../include/widgets.php:149
+#: ../../Zotlabs/Module/Suggest.php:58 ../../Zotlabs/Widget/Suggestions.php:46
 msgid "Ignore/Hide"
 msgstr "Ignora/Amaga"
 
-#: ../../Zotlabs/Module/Tagger.php:55 ../../include/bbcode.php:256
-msgid "post"
-msgstr "entrada"
+#: ../../Zotlabs/Module/Oexchange.php:27
+msgid "Unable to find your hub."
+msgstr "No es possible trobar el node"
 
-#: ../../Zotlabs/Module/Tagger.php:57 ../../include/text.php:1948
-#: ../../include/conversation.php:150
-msgid "comment"
-msgstr "comentari"
+#: ../../Zotlabs/Module/Oexchange.php:41
+msgid "Post successful."
+msgstr "Entrada realitzada amb èxit. "
 
-#: ../../Zotlabs/Module/Tagger.php:100
+#: ../../Zotlabs/Module/Mail.php:73
+msgid "Unable to lookup recipient."
+msgstr "Incapaç de trobar el destinatari."
+
+#: ../../Zotlabs/Module/Mail.php:80
+msgid "Unable to communicate with requested channel."
+msgstr "Incapaç de comunicar amb el canal demanat."
+
+#: ../../Zotlabs/Module/Mail.php:87
+msgid "Cannot verify requested channel."
+msgstr "No puc verificar el canal demanat."
+
+#: ../../Zotlabs/Module/Mail.php:105
+msgid "Selected channel has private message restrictions. Send failed."
+msgstr "El canal seleccionat te restriccions sobre els missatges privats. L'enviament ha fallat."
+
+#: ../../Zotlabs/Module/Mail.php:160
+msgid "Messages"
+msgstr "Missatges"
+
+#: ../../Zotlabs/Module/Mail.php:173
+msgid "message"
+msgstr "missatge"
+
+#: ../../Zotlabs/Module/Mail.php:214
+msgid "Message recalled."
+msgstr "Recupera el missatge."
+
+#: ../../Zotlabs/Module/Mail.php:227
+msgid "Conversation removed."
+msgstr "Conversació eliminada."
+
+#: ../../Zotlabs/Module/Mail.php:242 ../../Zotlabs/Module/Mail.php:363
+msgid "Expires YYYY-MM-DD HH:MM"
+msgstr "Expira YYYY-MM-DD HH:MM"
+
+#: ../../Zotlabs/Module/Mail.php:270
+msgid "Requested channel is not in this network"
+msgstr "El canal demanat no hi es en questa xarxa"
+
+#: ../../Zotlabs/Module/Mail.php:278
+msgid "Send Private Message"
+msgstr "Envia Missatge Privat"
+
+#: ../../Zotlabs/Module/Mail.php:279 ../../Zotlabs/Module/Mail.php:421
+msgid "To:"
+msgstr "Per:"
+
+#: ../../Zotlabs/Module/Mail.php:282 ../../Zotlabs/Module/Mail.php:423
+msgid "Subject:"
+msgstr "Assumpte:"
+
+#: ../../Zotlabs/Module/Mail.php:287 ../../Zotlabs/Module/Mail.php:429
+#: ../../include/conversation.php:1382
+msgid "Attach file"
+msgstr "Adjunta arxiu"
+
+#: ../../Zotlabs/Module/Mail.php:289
+msgid "Send"
+msgstr "Envia"
+
+#: ../../Zotlabs/Module/Mail.php:292 ../../Zotlabs/Module/Mail.php:434
+#: ../../include/conversation.php:1427
+msgid "Set expiration date"
+msgstr "Ajusta la data d'expiració"
+
+#: ../../Zotlabs/Module/Mail.php:393
+msgid "Delete message"
+msgstr "Elimina el missatge"
+
+#: ../../Zotlabs/Module/Mail.php:394
+msgid "Delivery report"
+msgstr "Informe d'entrega"
+
+#: ../../Zotlabs/Module/Mail.php:395
+msgid "Recall message"
+msgstr "Recupera el missatge"
+
+#: ../../Zotlabs/Module/Mail.php:397
+msgid "Message has been recalled."
+msgstr "El missatge s'ha recuperat."
+
+#: ../../Zotlabs/Module/Mail.php:414
+msgid "Delete Conversation"
+msgstr "Conversació esborrada"
+
+#: ../../Zotlabs/Module/Mail.php:416
+msgid ""
+"No secure communications available. You <strong>may</strong> be able to "
+"respond from the sender's profile page."
+msgstr "Comunicació segura no disponible. Pots respondre des de la pàgina de perfil del remitent."
+
+#: ../../Zotlabs/Module/Mail.php:420
+msgid "Send Reply"
+msgstr "Envia Resposta"
+
+#: ../../Zotlabs/Module/Mail.php:425
 #, php-format
-msgid "%1$s tagged %2$s's %3$s with %4$s"
-msgstr "%1$s ha etiquetat %3$s de %2$s amb %4$s"
+msgid "Your message for %s (%s):"
+msgstr "El teu missatge per %s (%s):"
+
+#: ../../Zotlabs/Module/Pubsites.php:24 ../../Zotlabs/Widget/Pubsites.php:12
+msgid "Public Hubs"
+msgstr "Nodes Públics"
+
+#: ../../Zotlabs/Module/Pubsites.php:27
+msgid ""
+"The listed hubs allow public registration for the $Projectname network. All "
+"hubs in the network are interlinked so membership on any of them conveys "
+"membership in the network as a whole. Some hubs may require subscription or "
+"provide tiered service plans. The hub itself <strong>may</strong> provide "
+"additional details."
+msgstr "Els nodes llistats permeten registrar usuaris de la xarxa $Projectname. Com que tots els nodes estan enllaçats entre ells, la identitat és vàlida a tota la xarxa. Alguns nodes poden demanar subscripció o oferir serveis addicional de pagament. Per a més detalls, <strong>proveu</strong> de seguir els enllaços dels proveïdors."
+
+#: ../../Zotlabs/Module/Pubsites.php:33
+msgid "Hub URL"
+msgstr "URL del Node"
+
+#: ../../Zotlabs/Module/Pubsites.php:33
+msgid "Access Type"
+msgstr "Tipus d'accés"
+
+#: ../../Zotlabs/Module/Pubsites.php:33
+msgid "Registration Policy"
+msgstr "Condicions d'inscripció"
+
+#: ../../Zotlabs/Module/Pubsites.php:33
+msgid "Stats"
+msgstr "Estadístiques"
+
+#: ../../Zotlabs/Module/Pubsites.php:33
+msgid "Software"
+msgstr "Programari"
+
+#: ../../Zotlabs/Module/Pubsites.php:49
+msgid "Rate"
+msgstr "Puntua"
+
+#: ../../Zotlabs/Module/Impel.php:43 ../../include/bbcode.php:267
+msgid "webpage"
+msgstr "pàgina web"
+
+#: ../../Zotlabs/Module/Impel.php:48 ../../include/bbcode.php:273
+msgid "block"
+msgstr "bloc"
+
+#: ../../Zotlabs/Module/Impel.php:53 ../../include/bbcode.php:270
+msgid "layout"
+msgstr "disposició"
+
+#: ../../Zotlabs/Module/Impel.php:60 ../../include/bbcode.php:276
+msgid "menu"
+msgstr "menú"
+
+#: ../../Zotlabs/Module/Impel.php:183
+#, php-format
+msgid "%s element installed"
+msgstr "%s element instal·lat"
+
+#: ../../Zotlabs/Module/Impel.php:186
+#, php-format
+msgid "%s element installation failed"
+msgstr "%s instal·lació d'element va fallar"
+
+#: ../../Zotlabs/Module/Rbmark.php:94
+msgid "Select a bookmark folder"
+msgstr "Tria una carpeta d'interès"
+
+#: ../../Zotlabs/Module/Rbmark.php:99
+msgid "Save Bookmark"
+msgstr "Guarda Favorits"
+
+#: ../../Zotlabs/Module/Rbmark.php:100
+msgid "URL of bookmark"
+msgstr "URL de favorit"
+
+#: ../../Zotlabs/Module/Rbmark.php:105
+msgid "Or enter new bookmark folder name"
+msgstr "O entra un nou nom de favorit"
+
+#: ../../Zotlabs/Module/Filer.php:52
+msgid "Enter a folder name"
+msgstr "Escriu el nom de la carpeta"
+
+#: ../../Zotlabs/Module/Filer.php:52
+msgid "or select an existing folder (doubleclick)"
+msgstr "o escull-ne una d'existent amb doble clic"
+
+#: ../../Zotlabs/Module/Filer.php:54 ../../Zotlabs/Lib/ThreadItem.php:151
+msgid "Save to Folder"
+msgstr "Guardar en la Carpeta"
+
+#: ../../Zotlabs/Module/Probe.php:30 ../../Zotlabs/Module/Probe.php:34
+#, php-format
+msgid "Fetching URL returns error: %1$s"
+msgstr "URL sol·licitada retorna error: %1$s"
+
+#: ../../Zotlabs/Module/Register.php:49
+msgid "Maximum daily site registrations exceeded. Please try again tomorrow."
+msgstr "Nombre màxim d'inscripcions diaris excedit. Si us plau, provau demà."
+
+#: ../../Zotlabs/Module/Register.php:55
+msgid ""
+"Please indicate acceptance of the Terms of Service. Registration failed."
+msgstr "L'inscripció ha fallat. Si et plau, indica que acceptes les Condicions del Servei."
+
+#: ../../Zotlabs/Module/Register.php:89
+msgid "Passwords do not match."
+msgstr "Les contrasenyes no coincideixen."
+
+#: ../../Zotlabs/Module/Register.php:132
+msgid "Registration successful. Continue to create your first channel..."
+msgstr "S'ha registrat el compte amb èxit. Ara pots crear el teu primer canal..."
+
+#: ../../Zotlabs/Module/Register.php:135
+msgid ""
+"Registration successful. Please check your email for validation "
+"instructions."
+msgstr "Registrat amb èxit. Si et plau revisa el teu correu electrònic per a les instruccions de validació."
+
+#: ../../Zotlabs/Module/Register.php:142
+msgid "Your registration is pending approval by the site owner."
+msgstr "La teva inscripció esta pendent de validació pel propietari del lloc."
+
+#: ../../Zotlabs/Module/Register.php:145
+msgid "Your registration can not be processed."
+msgstr "La teva inscripció no ha pogut ser processat. "
+
+#: ../../Zotlabs/Module/Register.php:192
+msgid "Registration on this hub is disabled."
+msgstr "L'inscripció en aquest node està deshabilitat."
+
+#: ../../Zotlabs/Module/Register.php:201
+msgid "Registration on this hub is by approval only."
+msgstr "L'inscripció en aquest node es únicament per validació."
+
+#: ../../Zotlabs/Module/Register.php:202
+msgid "<a href=\"pubsites\">Register at another affiliated hub.</a>"
+msgstr "<a href=\"pubsites\">Inscripció en altre node afiliat</a>"
+
+#: ../../Zotlabs/Module/Register.php:212
+msgid ""
+"This site has exceeded the number of allowed daily account registrations. "
+"Please try again tomorrow."
+msgstr "El lloc ha excedit el límit màxim diari de nous comptes/inscripció. Provau demà."
+
+#: ../../Zotlabs/Module/Register.php:238
+#, php-format
+msgid "I accept the %s for this website"
+msgstr "Accepto el %s per a aquest lloc web"
+
+#: ../../Zotlabs/Module/Register.php:245
+#, php-format
+msgid "I am over %s years of age and accept the %s for this website"
+msgstr "Tinc més de %s anys i accepto les %s"
+
+#: ../../Zotlabs/Module/Register.php:250
+msgid "Your email address"
+msgstr "La teva adreça de correu electrónic"
+
+#: ../../Zotlabs/Module/Register.php:251
+msgid "Choose a password"
+msgstr "Tria una contrasenya"
+
+#: ../../Zotlabs/Module/Register.php:252
+msgid "Please re-enter your password"
+msgstr "Si et plau, re-entra la contrasenya"
+
+#: ../../Zotlabs/Module/Register.php:253
+msgid "Please enter your invitation code"
+msgstr "Si et plau, introdueix el teu codi d'invitació"
+
+#: ../../Zotlabs/Module/Register.php:258
+msgid "no"
+msgstr "no"
+
+#: ../../Zotlabs/Module/Register.php:258
+msgid "yes"
+msgstr "sí"
+
+#: ../../Zotlabs/Module/Register.php:274
+msgid "Membership on this site is by invitation only."
+msgstr "La pertinença en aquest lloc es per invitació exclusivament."
+
+#: ../../Zotlabs/Module/Register.php:286 ../../boot.php:1563
+#: ../../include/nav.php:164
+msgid "Register"
+msgstr "Inscripció"
+
+#: ../../Zotlabs/Module/Register.php:287
+msgid ""
+"This site requires email verification. After completing this form, please "
+"check your email for further instructions."
+msgstr "Aquest node demana que es verifiquin els comptes de correu. Un cop completat el formulari, comprova la teva safata d'entrada i segueix les instruccions que hi trobaràs."
+
+#: ../../Zotlabs/Module/Cover_photo.php:136
+#: ../../Zotlabs/Module/Cover_photo.php:186
+msgid "Cover Photos"
+msgstr "Fotos de Portada"
+
+#: ../../Zotlabs/Module/Cover_photo.php:237 ../../include/items.php:4508
+msgid "female"
+msgstr "femení"
+
+#: ../../Zotlabs/Module/Cover_photo.php:238 ../../include/items.php:4509
+#, php-format
+msgid "%1$s updated her %2$s"
+msgstr "%1$s actualitzà el seu %2$s"
+
+#: ../../Zotlabs/Module/Cover_photo.php:239 ../../include/items.php:4510
+msgid "male"
+msgstr "masculí"
+
+#: ../../Zotlabs/Module/Cover_photo.php:240 ../../include/items.php:4511
+#, php-format
+msgid "%1$s updated his %2$s"
+msgstr "%1$s actualitzà el seu %2$s"
+
+#: ../../Zotlabs/Module/Cover_photo.php:242 ../../include/items.php:4513
+#, php-format
+msgid "%1$s updated their %2$s"
+msgstr "%1$s actualitzà els seus %2$s"
+
+#: ../../Zotlabs/Module/Cover_photo.php:244 ../../include/channel.php:2059
+msgid "cover photo"
+msgstr "Foto de la portada"
+
+#: ../../Zotlabs/Module/Cover_photo.php:360
+msgid "Change Cover Photo"
+msgstr "Canvia la foto de portada"
+
+#: ../../Zotlabs/Module/Help.php:23
+msgid "Documentation Search"
+msgstr "Cerca de Documentació"
+
+#: ../../Zotlabs/Module/Help.php:80 ../../include/conversation.php:1821
+#: ../../include/nav.php:391
+msgid "About"
+msgstr "El Meu Perfil"
+
+#: ../../Zotlabs/Module/Help.php:82
+msgid "Administrators"
+msgstr "Administradors"
+
+#: ../../Zotlabs/Module/Help.php:83
+msgid "Developers"
+msgstr "Desenvolupadors"
+
+#: ../../Zotlabs/Module/Help.php:84
+msgid "Tutorials"
+msgstr "Tutorials"
+
+#: ../../Zotlabs/Module/Help.php:95
+msgid "$Projectname Documentation"
+msgstr "$Projectname Documentació"
+
+#: ../../Zotlabs/Module/Help.php:96
+msgid "Contents"
+msgstr "Continguts"
+
+#: ../../Zotlabs/Module/Display.php:351
+msgid "Article"
+msgstr "Article"
+
+#: ../../Zotlabs/Module/Display.php:403
+msgid "Item has been removed."
+msgstr "S'ha esborrat l'element."
 
 #: ../../Zotlabs/Module/Tagrm.php:48 ../../Zotlabs/Module/Tagrm.php:98
 msgid "Tag removed"
@@ -6109,1967 +7313,4265 @@ msgstr "Elimina l'etiqueta d'element"
 msgid "Select a tag to remove: "
 msgstr "Tria l'etiqueta a eliminar:"
 
-#: ../../Zotlabs/Module/Thing.php:114
-msgid "Thing updated"
-msgstr "S'ha actualitzat la cosa"
+#: ../../Zotlabs/Module/Network.php:100
+msgid "No such group"
+msgstr "No existeix el grup"
 
-#: ../../Zotlabs/Module/Thing.php:166
-msgid "Object store: failed"
-msgstr "No s'ha pogut emmagatzemar l'objecte"
+#: ../../Zotlabs/Module/Network.php:142
+msgid "No such channel"
+msgstr "No existeix el canal"
 
-#: ../../Zotlabs/Module/Thing.php:170
-msgid "Thing added"
-msgstr "S'ha afegit la cosa"
+#: ../../Zotlabs/Module/Network.php:147
+msgid "forum"
+msgstr "fòrum"
 
-#: ../../Zotlabs/Module/Thing.php:196
+#: ../../Zotlabs/Module/Network.php:159
+msgid "Search Results For:"
+msgstr "Cerca resultats per:"
+
+#: ../../Zotlabs/Module/Network.php:230
+msgid "Privacy group is empty"
+msgstr "el grup privat està vuit"
+
+#: ../../Zotlabs/Module/Network.php:240
+msgid "Privacy group: "
+msgstr "Grup privat:"
+
+#: ../../Zotlabs/Module/Network.php:268
+msgid "Invalid connection."
+msgstr "La connexió és invàlida."
+
+#: ../../Zotlabs/Module/Network.php:289 ../../addon/redred/redred.php:65
+msgid "Invalid channel."
+msgstr "El canal no és vàlid."
+
+#: ../../Zotlabs/Module/Acl.php:361
+msgid "network"
+msgstr "xarxa"
+
+#: ../../Zotlabs/Module/Home.php:74 ../../Zotlabs/Module/Home.php:82
+#: ../../Zotlabs/Lib/Enotify.php:66 ../../addon/opensearch/opensearch.php:42
+msgid "$Projectname"
+msgstr "$Projectname"
+
+#: ../../Zotlabs/Module/Home.php:92
 #, php-format
-msgid "OBJ: %1$s %2$s %3$s"
-msgstr "OBJ: %1$s %2$s %3$s"
+msgid "Welcome to %s"
+msgstr "Benvingut a %s"
 
-#: ../../Zotlabs/Module/Thing.php:259
-msgid "Show Thing"
-msgstr "Mostra la cosa"
+#: ../../Zotlabs/Module/Filestorage.php:79
+msgid "Permission Denied."
+msgstr "Permisos Denegats."
 
-#: ../../Zotlabs/Module/Thing.php:266
-msgid "item not found."
-msgstr "no s'ha trobat l'element."
+#: ../../Zotlabs/Module/Filestorage.php:95
+msgid "File not found."
+msgstr "Arxiu no torbat."
 
-#: ../../Zotlabs/Module/Thing.php:299
-msgid "Edit Thing"
-msgstr "Edita la cosa"
+#: ../../Zotlabs/Module/Filestorage.php:142
+msgid "Edit file permissions"
+msgstr "Edita els permisos d'arxiu"
 
-#: ../../Zotlabs/Module/Thing.php:301 ../../Zotlabs/Module/Thing.php:351
-msgid "Select a profile"
-msgstr "Tria un perfil"
+#: ../../Zotlabs/Module/Filestorage.php:154
+msgid "Set/edit permissions"
+msgstr "Canvia/edita permisos"
 
-#: ../../Zotlabs/Module/Thing.php:305 ../../Zotlabs/Module/Thing.php:354
-msgid "Post an activity"
-msgstr "Publica una activitat"
+#: ../../Zotlabs/Module/Filestorage.php:155
+msgid "Include all files and sub folders"
+msgstr "Inclou tots als arxius i subdirectoris"
 
-#: ../../Zotlabs/Module/Thing.php:305 ../../Zotlabs/Module/Thing.php:354
-msgid "Only sends to viewers of the applicable profile"
-msgstr "S'envia només a visitants del perfil corresponent"
+#: ../../Zotlabs/Module/Filestorage.php:156
+msgid "Return to file list"
+msgstr "Tornar al llistat d'arxius"
 
-#: ../../Zotlabs/Module/Thing.php:307 ../../Zotlabs/Module/Thing.php:356
-msgid "Name of thing e.g. something"
-msgstr "Nom de la cosa. Exemple: patata"
+#: ../../Zotlabs/Module/Filestorage.php:158
+msgid "Copy/paste this code to attach file to a post"
+msgstr "Copia/enganxa aquest codi per a adjuntar un arxiu a l'entrada"
 
-#: ../../Zotlabs/Module/Thing.php:309 ../../Zotlabs/Module/Thing.php:357
-msgid "URL of thing (optional)"
-msgstr "Adreça URL de la cosa (opcional)"
+#: ../../Zotlabs/Module/Filestorage.php:159
+msgid "Copy/paste this URL to link file from a web page"
+msgstr "Copia/enganxa aquesta URL per a enllaçar l'arxiu d'una pàgina web"
 
-#: ../../Zotlabs/Module/Thing.php:311 ../../Zotlabs/Module/Thing.php:358
-msgid "URL for photo of thing (optional)"
-msgstr "Adreça URL de la foto d'una cosa (opcional)"
+#: ../../Zotlabs/Module/Filestorage.php:161
+msgid "Share this file"
+msgstr "Comparteix l'arxiu"
 
-#: ../../Zotlabs/Module/Thing.php:349
-msgid "Add Thing to your Profile"
-msgstr "Afegeix una cosa al teu perfil"
+#: ../../Zotlabs/Module/Filestorage.php:162
+msgid "Show URL to this file"
+msgstr "Mostra la URL d'aquest arxiu"
 
-#: ../../Zotlabs/Module/Uexport.php:55 ../../Zotlabs/Module/Uexport.php:56
-msgid "Export Channel"
-msgstr "Exportar Canal"
+#: ../../Zotlabs/Module/Filestorage.php:163
+#: ../../Zotlabs/Storage/Browser.php:397
+msgid "Show in your contacts shared folder"
+msgstr "Mostra les carpetes compartides dels teus contactes"
 
-#: ../../Zotlabs/Module/Uexport.php:57
-msgid ""
-"Export your basic channel information to a file.  This acts as a backup of "
-"your connections, permissions, profile and basic data, which can be used to "
-"import your data to a new server hub, but does not contain your content."
-msgstr "Exporta la informació bàsica del canal a un arxiu. Això actua com a còpia de recolzament de les teves connexions, permisos, perfil i dades bàsiques, les quals pots emprar per traslladar aquestes dades a una altre lloc/node, però no conté el contingut del canal."
+#: ../../Zotlabs/Module/Common.php:14
+msgid "No channel."
+msgstr "No s'ha trobat el canal"
 
-#: ../../Zotlabs/Module/Uexport.php:58
-msgid "Export Content"
-msgstr "Exportar el Contingut"
+#: ../../Zotlabs/Module/Common.php:45
+msgid "No connections in common."
+msgstr "No hi ha connexions en comú."
 
-#: ../../Zotlabs/Module/Uexport.php:59
-msgid ""
-"Export your channel information and recent content to a JSON backup that can"
-" be restored or imported to another server hub. This backs up all of your "
-"connections, permissions, profile data and several months of posts. This "
-"file may be VERY large.  Please be patient - it may take several minutes for"
-" this download to begin."
-msgstr "Exporta la informació del canal i tot el contingut recent a un arxiu de recolzament JSON que por ser restaurat o importat en altre lloc/node. Això còpia totes les teves connexions, permisos, perfil i dades i mesos de entrades. L'arxiu pot ser MOLT gran. Si et plau, sigues pacient ja que pot trigar uns minuts a començar a baixar."
+#: ../../Zotlabs/Module/Common.php:65
+msgid "View Common Connections"
+msgstr "Mostra les connexions en comú"
 
-#: ../../Zotlabs/Module/Uexport.php:60
-msgid "Export your posts from a given year."
-msgstr "Exporta les teves entrades d'un any donat."
+#: ../../Zotlabs/Module/Email_resend.php:30
+msgid "Email verification resent"
+msgstr "S'ha tornat a enviar la verificació de orreu"
 
-#: ../../Zotlabs/Module/Uexport.php:62
-msgid ""
-"You may also export your posts and conversations for a particular year or "
-"month. Adjust the date in your browser location bar to select other dates. "
-"If the export fails (possibly due to memory exhaustion on your server hub), "
-"please try again selecting a more limited date range."
-msgstr "Pots també exportar les teves entrades i conversacions d'un any o un mes en particular. Ajusta la data a la barra de direccions del navegador per seleccionar altres dates. Si la exportació falla (possiblement degut al esgotament de la memòria del node servidor), si et plau, intenta de nou la selecció d'un rang de dates més limitat."
+#: ../../Zotlabs/Module/Email_resend.php:33
+msgid "Unable to resend email verification message."
+msgstr "No s'ha pogut tornar a enviar el correu de verificació."
 
-#: ../../Zotlabs/Module/Uexport.php:63
-#, php-format
-msgid ""
-"To select all posts for a given year, such as this year, visit <a "
-"href=\"%1$s\">%2$s</a>"
-msgstr "Per seleccionar tots els missatges per a un any determinat, com aquest any, visiteu <a href=\"%1$s\">%2$s</a>"
-
-#: ../../Zotlabs/Module/Uexport.php:64
-#, php-format
-msgid ""
-"To select all posts for a given month, such as January of this year, visit "
-"<a href=\"%1$s\">%2$s</a>"
-msgstr "Per seleccionar tots els missatges per a un mes determinat, com el de gener d'aquest any, visiteu <a href=\"%1$s\">%2$s</a>"
-
-#: ../../Zotlabs/Module/Uexport.php:65
-#, php-format
-msgid ""
-"These content files may be imported or restored by visiting <a "
-"href=\"%1$s\">%2$s</a> on any site containing your channel. For best results"
-" please import or restore these in date order (oldest first)."
-msgstr "Aquests arxius de contingut poden ser importats o restaurats per visitar  <a href=\"%1$s\">%2$s</a> en qualsevol lloc que conté el teu canal. Per obtenir els millors resultats si us plau, importar o restaurar aquests en ordre de data (la més antiga primer)."
-
-#: ../../Zotlabs/Module/Viewconnections.php:62
+#: ../../Zotlabs/Module/Viewconnections.php:65
 msgid "No connections."
 msgstr "Sense connexions."
 
-#: ../../Zotlabs/Module/Viewconnections.php:75
+#: ../../Zotlabs/Module/Viewconnections.php:83
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr "Visita el perfil [%s] de %s"
 
-#: ../../Zotlabs/Module/Viewconnections.php:104
+#: ../../Zotlabs/Module/Viewconnections.php:113
 msgid "View Connections"
 msgstr "Veure Connexions"
 
-#: ../../Zotlabs/Module/Viewsrc.php:44
-msgid "Source of Item"
-msgstr "Origen de l'article"
+#: ../../Zotlabs/Module/Admin.php:97
+msgid "Blocked accounts"
+msgstr "Comptes bloquejats"
 
-#: ../../Zotlabs/Module/Webpages.php:184 ../../Zotlabs/Lib/Apps.php:217
-#: ../../include/nav.php:106 ../../include/conversation.php:1685
-msgid "Webpages"
-msgstr "Pàgines web"
+#: ../../Zotlabs/Module/Admin.php:98
+msgid "Expired accounts"
+msgstr "Comptes caducats"
 
-#: ../../Zotlabs/Module/Webpages.php:195 ../../include/page_widgets.php:41
-msgid "Actions"
-msgstr "Accions"
+#: ../../Zotlabs/Module/Admin.php:99
+msgid "Expiring accounts"
+msgstr "Comptes a punt de caducar"
 
-#: ../../Zotlabs/Module/Webpages.php:196 ../../include/page_widgets.php:42
-msgid "Page Link"
-msgstr "Enllaç a Pàgina"
+#: ../../Zotlabs/Module/Admin.php:112
+msgid "Clones"
+msgstr "Clons"
 
-#: ../../Zotlabs/Module/Webpages.php:197
-msgid "Page Title"
-msgstr "Títol de la pàgina"
+#: ../../Zotlabs/Module/Admin.php:118
+msgid "Message queues"
+msgstr "Cues de missatges"
 
-#: ../../Zotlabs/Module/Xchan.php:10
-msgid "Xchan Lookup"
-msgstr "Cerca a xchan"
+#: ../../Zotlabs/Module/Admin.php:132
+msgid "Your software should be updated"
+msgstr "El teu programari cal que s'actualitzi"
 
-#: ../../Zotlabs/Module/Xchan.php:13
-msgid "Lookup xchan beginning with (or webbie): "
-msgstr "Cerca a xchan començant per (o webbie)"
+#: ../../Zotlabs/Module/Admin.php:137
+msgid "Summary"
+msgstr "Sumari"
 
-#: ../../Zotlabs/Lib/Apps.php:204
+#: ../../Zotlabs/Module/Admin.php:140
+msgid "Registered accounts"
+msgstr "Comptes registrades"
+
+#: ../../Zotlabs/Module/Admin.php:141
+msgid "Pending registrations"
+msgstr "Comptes pendents d'inscripció"
+
+#: ../../Zotlabs/Module/Admin.php:142
+msgid "Registered channels"
+msgstr "Canals registrats"
+
+#: ../../Zotlabs/Module/Admin.php:143
+msgid "Active plugins"
+msgstr "Plugins actius"
+
+#: ../../Zotlabs/Module/Admin.php:144
+msgid "Version"
+msgstr "Versió"
+
+#: ../../Zotlabs/Module/Admin.php:145
+msgid "Repository version (master)"
+msgstr "Versió (master) del repositori"
+
+#: ../../Zotlabs/Module/Admin.php:146
+msgid "Repository version (dev)"
+msgstr "Versió (desenvolupament) del repositori"
+
+#: ../../Zotlabs/Module/Service_limits.php:23
+msgid "No service class restrictions found."
+msgstr "No s'han trobat restriccions de clase."
+
+#: ../../Zotlabs/Module/Rate.php:156
+msgid "Website:"
+msgstr "Lloc web:"
+
+#: ../../Zotlabs/Module/Rate.php:159
+#, php-format
+msgid "Remote Channel [%s] (not yet known on this site)"
+msgstr "Canal Remot [%s] (encara no es coneix en aquest lloc)"
+
+#: ../../Zotlabs/Module/Rate.php:160
+msgid "Rating (this information is public)"
+msgstr "Valoració (aquesta informació és pública)"
+
+#: ../../Zotlabs/Module/Rate.php:161
+msgid "Optionally explain your rating (this information is public)"
+msgstr "Opcionalment pots explicar la teva qualificació (aquesta informació és pública)"
+
+#: ../../Zotlabs/Module/Card_edit.php:128
+msgid "Edit Card"
+msgstr "Edita la targeta"
+
+#: ../../Zotlabs/Module/Lostpass.php:19
+msgid "No valid account found."
+msgstr "No es troba un compte vàlid."
+
+#: ../../Zotlabs/Module/Lostpass.php:33
+msgid "Password reset request issued. Check your email."
+msgstr "Sol·licitud de restabliment de contrasenya emesa. Consulta el teu correu electrònic."
+
+#: ../../Zotlabs/Module/Lostpass.php:39 ../../Zotlabs/Module/Lostpass.php:108
+#, php-format
+msgid "Site Member (%s)"
+msgstr "Lloc d'Usuari (%s)"
+
+#: ../../Zotlabs/Module/Lostpass.php:44 ../../Zotlabs/Module/Lostpass.php:49
+#, php-format
+msgid "Password reset requested at %s"
+msgstr "S'ha soŀlicitat restablir la contrasenya al hub %s"
+
+#: ../../Zotlabs/Module/Lostpass.php:68
+msgid ""
+"Request could not be verified. (You may have previously submitted it.) "
+"Password reset failed."
+msgstr "Ha fallat el restabliment de contrasenya perquè la no s'ha pogut verificar soŀlicitud. Pot ser que ja ho hàgiu soŀlicitat abans."
+
+#: ../../Zotlabs/Module/Lostpass.php:91 ../../boot.php:1591
+msgid "Password Reset"
+msgstr "Restabliment de contrasenya"
+
+#: ../../Zotlabs/Module/Lostpass.php:92
+msgid "Your password has been reset as requested."
+msgstr "S'ha restablert la vostra contrasenya."
+
+#: ../../Zotlabs/Module/Lostpass.php:93
+msgid "Your new password is"
+msgstr "La nova contrasenya és"
+
+#: ../../Zotlabs/Module/Lostpass.php:94
+msgid "Save or copy your new password - and then"
+msgstr "Desa o copia la nova contrasenya, i després"
+
+#: ../../Zotlabs/Module/Lostpass.php:95
+msgid "click here to login"
+msgstr "fes clic aquí per iniciar sessió"
+
+#: ../../Zotlabs/Module/Lostpass.php:96
+msgid ""
+"Your password may be changed from the <em>Settings</em> page after "
+"successful login."
+msgstr "Pots canviar la contrasenya a la pàgina <em>Paràmetres</em>, un cop iniciada la sessió."
+
+#: ../../Zotlabs/Module/Lostpass.php:117
+#, php-format
+msgid "Your password has changed at %s"
+msgstr "La teva contrasenya a %s ha canviat"
+
+#: ../../Zotlabs/Module/Lostpass.php:130
+msgid "Forgot your Password?"
+msgstr "No recordes la contrasenya?"
+
+#: ../../Zotlabs/Module/Lostpass.php:131
+msgid ""
+"Enter your email address and submit to have your password reset. Then check "
+"your email for further instructions."
+msgstr "Escriu la teva adreça de correu electrònic i envia per restablir la contrasenya. Després revisa el seu correu electrònic per obtenir més instruccions."
+
+#: ../../Zotlabs/Module/Lostpass.php:132
+msgid "Email Address"
+msgstr "Adreça electrònica"
+
+#: ../../Zotlabs/Module/Notifications.php:62
+#: ../../Zotlabs/Lib/ThreadItem.php:408
+msgid "Mark all seen"
+msgstr "Marca tot com ja vist"
+
+#: ../../Zotlabs/Lib/Techlevels.php:10
+msgid "0. Beginner/Basic"
+msgstr "0. Bàsic, principiant"
+
+#: ../../Zotlabs/Lib/Techlevels.php:11
+msgid "1. Novice - not skilled but willing to learn"
+msgstr "1. Novell - amb pocs coneixements però amb ganes d'aprendre"
+
+#: ../../Zotlabs/Lib/Techlevels.php:12
+msgid "2. Intermediate - somewhat comfortable"
+msgstr "2. Intermedi - més o menys còmode"
+
+#: ../../Zotlabs/Lib/Techlevels.php:13
+msgid "3. Advanced - very comfortable"
+msgstr "3. Avançat - molt còmode"
+
+#: ../../Zotlabs/Lib/Techlevels.php:14
+msgid "4. Expert - I can write computer code"
+msgstr "4. Expert - puc escriure codi en algun llenguatge de programació"
+
+#: ../../Zotlabs/Lib/Techlevels.php:15
+msgid "5. Wizard - I probably know more than you do"
+msgstr "5. Ninja - probablement en sé més que tu"
+
+#: ../../Zotlabs/Lib/Apps.php:231
 msgid "Site Admin"
 msgstr "Administració"
 
-#: ../../Zotlabs/Lib/Apps.php:205
-msgid "Bug Report"
-msgstr "Informe d'Errors"
+#: ../../Zotlabs/Lib/Apps.php:232 ../../addon/buglink/buglink.php:16
+msgid "Report Bug"
+msgstr "Informa d'errors"
 
-#: ../../Zotlabs/Lib/Apps.php:206
+#: ../../Zotlabs/Lib/Apps.php:233
 msgid "View Bookmarks"
 msgstr "Veure Marcadors"
 
-#: ../../Zotlabs/Lib/Apps.php:207
+#: ../../Zotlabs/Lib/Apps.php:234
 msgid "My Chatrooms"
 msgstr "Les meves Sales de Xat"
 
-#: ../../Zotlabs/Lib/Apps.php:209
+#: ../../Zotlabs/Lib/Apps.php:236
 msgid "Firefox Share"
 msgstr "Compartir amb Firefox"
 
-#: ../../Zotlabs/Lib/Apps.php:210
+#: ../../Zotlabs/Lib/Apps.php:237
 msgid "Remote Diagnostics"
 msgstr "Diagnòstics Remots"
 
-#: ../../Zotlabs/Lib/Apps.php:211 ../../include/features.php:89
+#: ../../Zotlabs/Lib/Apps.php:238 ../../include/features.php:390
 msgid "Suggest Channels"
 msgstr "Suggerir Canals"
 
-#: ../../Zotlabs/Lib/Apps.php:212 ../../include/nav.php:110
-#: ../../boot.php:1703
+#: ../../Zotlabs/Lib/Apps.php:239 ../../boot.php:1582
+#: ../../include/nav.php:126 ../../include/nav.php:130
 msgid "Login"
 msgstr "Identifica't"
 
-#: ../../Zotlabs/Lib/Apps.php:214 ../../include/nav.php:179
-msgid "Grid"
-msgstr "Malla"
+#: ../../Zotlabs/Lib/Apps.php:241
+msgid "Activity"
+msgstr "Activitat"
 
-#: ../../Zotlabs/Lib/Apps.php:218 ../../include/nav.php:182
+#: ../../Zotlabs/Lib/Apps.php:245 ../../include/conversation.php:1928
+#: ../../include/features.php:87 ../../include/nav.php:497
+msgid "Wiki"
+msgstr "Wiki"
+
+#: ../../Zotlabs/Lib/Apps.php:246
 msgid "Channel Home"
 msgstr "Canal Personal"
 
-#: ../../Zotlabs/Lib/Apps.php:221 ../../include/nav.php:201
-#: ../../include/conversation.php:1649 ../../include/conversation.php:1652
+#: ../../Zotlabs/Lib/Apps.php:249 ../../include/conversation.php:1850
+#: ../../include/conversation.php:1853
 msgid "Events"
 msgstr "Esdeveniments"
 
-#: ../../Zotlabs/Lib/Apps.php:222 ../../include/nav.php:167
+#: ../../Zotlabs/Lib/Apps.php:250
 msgid "Directory"
 msgstr "Directori"
 
-#: ../../Zotlabs/Lib/Apps.php:224 ../../include/nav.php:193
+#: ../../Zotlabs/Lib/Apps.php:252
 msgid "Mail"
 msgstr "Correu"
 
-#: ../../Zotlabs/Lib/Apps.php:227 ../../include/nav.php:96
+#: ../../Zotlabs/Lib/Apps.php:255
 msgid "Chat"
 msgstr "Xerrar"
 
-#: ../../Zotlabs/Lib/Apps.php:229
+#: ../../Zotlabs/Lib/Apps.php:257
 msgid "Probe"
 msgstr "Sondeig"
 
-#: ../../Zotlabs/Lib/Apps.php:230
+#: ../../Zotlabs/Lib/Apps.php:258
 msgid "Suggest"
 msgstr "Suggeriment"
 
-#: ../../Zotlabs/Lib/Apps.php:231
+#: ../../Zotlabs/Lib/Apps.php:259
 msgid "Random Channel"
 msgstr "Canal Aleatori"
 
-#: ../../Zotlabs/Lib/Apps.php:232
+#: ../../Zotlabs/Lib/Apps.php:260
 msgid "Invite"
 msgstr "Convida"
 
-#: ../../Zotlabs/Lib/Apps.php:233 ../../include/widgets.php:1386
+#: ../../Zotlabs/Lib/Apps.php:261 ../../Zotlabs/Widget/Admin.php:26
 msgid "Features"
 msgstr "Funcionalitats"
 
-#: ../../Zotlabs/Lib/Apps.php:235
+#: ../../Zotlabs/Lib/Apps.php:262 ../../addon/openid/MysqlProvider.php:69
+msgid "Language"
+msgstr "Idioma"
+
+#: ../../Zotlabs/Lib/Apps.php:263
 msgid "Post"
 msgstr "Entrada"
 
-#: ../../Zotlabs/Lib/Apps.php:335
+#: ../../Zotlabs/Lib/Apps.php:264 ../../addon/openid/MysqlProvider.php:58
+#: ../../addon/openid/MysqlProvider.php:59
+#: ../../addon/openid/MysqlProvider.php:60
+msgid "Profile Photo"
+msgstr "Foto del Perfil"
+
+#: ../../Zotlabs/Lib/Apps.php:407
 msgid "Purchase"
 msgstr "Compra"
 
-#: ../../Zotlabs/Lib/Chatroom.php:27
+#: ../../Zotlabs/Lib/Apps.php:411
+msgid "Undelete"
+msgstr "Desfés l'operació d'esborrar"
+
+#: ../../Zotlabs/Lib/Apps.php:419
+msgid "Add to app-tray"
+msgstr "Afegeix a la safata d'aplicacions"
+
+#: ../../Zotlabs/Lib/Apps.php:420
+msgid "Remove from app-tray"
+msgstr "Esborra de la safata d'aplicacions"
+
+#: ../../Zotlabs/Lib/Apps.php:421
+msgid "Pin to navbar"
+msgstr "Fixa a la barra de navegació"
+
+#: ../../Zotlabs/Lib/Apps.php:422
+msgid "Unpin from navbar"
+msgstr "Treu de la barra de navegació"
+
+#: ../../Zotlabs/Lib/Permcat.php:82
+msgctxt "permcat"
+msgid "default"
+msgstr "per defecte"
+
+#: ../../Zotlabs/Lib/Permcat.php:133
+msgctxt "permcat"
+msgid "follower"
+msgstr "seguidor"
+
+#: ../../Zotlabs/Lib/Permcat.php:137
+msgctxt "permcat"
+msgid "contributor"
+msgstr "contribuïdor"
+
+#: ../../Zotlabs/Lib/Permcat.php:141
+msgctxt "permcat"
+msgid "publisher"
+msgstr "publicador"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:42
+#: ../../Zotlabs/Lib/NativeWikiPage.php:93
+msgid "(No Title)"
+msgstr "(sense títol)"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:107
+msgid "Wiki page create failed."
+msgstr "No s'ha pogut crear la pàgina a la wiki."
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:120
+msgid "Wiki not found."
+msgstr "No s'ha trobat la wiki."
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:131
+msgid "Destination name already exists"
+msgstr "El nom de destí ja existeix"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:163
+#: ../../Zotlabs/Lib/NativeWikiPage.php:359
+msgid "Page not found"
+msgstr "No s'ha trobat la pàgina"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:194
+msgid "Error reading page content"
+msgstr "S'ha produït un error en carregar el contingut de la pàgina"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:350
+#: ../../Zotlabs/Lib/NativeWikiPage.php:400
+#: ../../Zotlabs/Lib/NativeWikiPage.php:467
+#: ../../Zotlabs/Lib/NativeWikiPage.php:508
+msgid "Error reading wiki"
+msgstr "S'ha produït un error en carregar la wiki"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:388
+msgid "Page update failed."
+msgstr "No s'ha pogut actualitzar la pàgina."
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:422
+msgid "Nothing deleted"
+msgstr "No s'ha esborrat res"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:488
+msgid "Compare: object not found."
+msgstr "S'ha produït un error en comparar la pàgina."
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:494
+msgid "Page updated"
+msgstr "S'ha actualitzat la pàgina"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:497
+msgid "Untitled"
+msgstr "Sense títol"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:503
+msgid "Wiki resource_id required for git commit"
+msgstr "Per a fer el git commit cal el resource_id de la wiki"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:559
+#: ../../Zotlabs/Widget/Wiki_page_history.php:23
+msgctxt "wiki_history"
+msgid "Message"
+msgstr "Missatge"
+
+#: ../../Zotlabs/Lib/NativeWikiPage.php:597
+#: ../../addon/gitwiki/gitwiki_backend.php:579 ../../include/bbcode.php:706
+#: ../../include/bbcode.php:865
+msgid "Different viewers will see this text differently"
+msgstr "Diferents observadors veuran aquest text de diferents formes"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:34
+#: ../../include/acl_selectors.php:33
+msgid "Visible to your default audience"
+msgstr "Visible per a la teva audiència "
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:107
+#: ../../include/acl_selectors.php:106
+msgid "Only me"
+msgstr "Només jo"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:108
+msgid "Public"
+msgstr "Públic"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:109
+msgid "Anybody in the $Projectname network"
+msgstr "Ningú a la xarxa $Projectname"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:110
+#, php-format
+msgid "Any account on %s"
+msgstr "Qualsevol compte a %s"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:111
+msgid "Any of my connections"
+msgstr "Qualsevol de les meves connexions"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:112
+msgid "Only connections I specifically allow"
+msgstr "Només les connexions que permeto específicament"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:113
+msgid "Anybody authenticated (could include visitors from other networks)"
+msgstr "Qualsevol persona autenticada (podria incloure als usuaris d'altres xarxes)"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:114
+msgid "Any connections including those who haven't yet been approved"
+msgstr "Qualsevol connexió incloent aquells que encara no han estat aprovats"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:150
+msgid ""
+"This is your default setting for the audience of your normal stream, and "
+"posts."
+msgstr "Aquest és l'ajust per defecte per al públic del seu flux normal i entrades."
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:151
+msgid ""
+"This is your default setting for who can view your default channel profile"
+msgstr "Aquesta és la configuració per defecte per a qui pugui veure el teu perfil per defecte del canal"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:152
+msgid "This is your default setting for who can view your connections"
+msgstr "Aquesta és la configuració per defecte per a qui pugui veure les teves connexions"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:153
+msgid ""
+"This is your default setting for who can view your file storage and photos"
+msgstr "Aquesta és la configuració per defecte per a qui pugui veure els teus arxius i fotos"
+
+#: ../../Zotlabs/Lib/PermissionDescription.php:154
+msgid "This is your default setting for the audience of your webpages"
+msgstr "Aquests son els ajustos per defecte de l'audiència de les teves pàgines web"
+
+#: ../../Zotlabs/Lib/Chatroom.php:23
 msgid "Missing room name"
 msgstr "Perdut el nom de la sala"
 
-#: ../../Zotlabs/Lib/Chatroom.php:36
+#: ../../Zotlabs/Lib/Chatroom.php:32
 msgid "Duplicate room name"
 msgstr "Nom de la sala duplicat"
 
-#: ../../Zotlabs/Lib/Chatroom.php:86 ../../Zotlabs/Lib/Chatroom.php:94
+#: ../../Zotlabs/Lib/Chatroom.php:82 ../../Zotlabs/Lib/Chatroom.php:90
 msgid "Invalid room specifier."
 msgstr "Especificació de la sala invàlida."
 
-#: ../../Zotlabs/Lib/Chatroom.php:126
+#: ../../Zotlabs/Lib/Chatroom.php:122
 msgid "Room not found."
 msgstr "Sala no trobada."
 
-#: ../../Zotlabs/Lib/Chatroom.php:147
+#: ../../Zotlabs/Lib/Chatroom.php:143
 msgid "Room is full"
 msgstr "La sala es plena"
 
-#: ../../Zotlabs/Lib/Enotify.php:60 ../../include/network.php:1823
+#: ../../Zotlabs/Lib/Enotify.php:60
 msgid "$Projectname Notification"
 msgstr "Notificació de $Projectname"
 
-#: ../../Zotlabs/Lib/Enotify.php:61 ../../include/network.php:1824
+#: ../../Zotlabs/Lib/Enotify.php:61 ../../addon/diaspora/util.php:308
+#: ../../addon/diaspora/util.php:321 ../../addon/diaspora/p.php:48
 msgid "$projectname"
 msgstr "$projectname"
 
-#: ../../Zotlabs/Lib/Enotify.php:63 ../../include/network.php:1826
+#: ../../Zotlabs/Lib/Enotify.php:63
 msgid "Thank You,"
 msgstr "Gràcies,"
 
-#: ../../Zotlabs/Lib/Enotify.php:65 ../../include/network.php:1828
+#: ../../Zotlabs/Lib/Enotify.php:65 ../../addon/hubwall/hubwall.php:33
 #, php-format
 msgid "%s Administrator"
 msgstr "%s Administrador"
 
-#: ../../Zotlabs/Lib/Enotify.php:100
+#: ../../Zotlabs/Lib/Enotify.php:66
+#, php-format
+msgid "This email was sent by %1$s at %2$s."
+msgstr "Aquest correu ha estat enviat per %1$s a %2$s."
+
+#: ../../Zotlabs/Lib/Enotify.php:67
+#, php-format
+msgid ""
+"To stop receiving these messages, please adjust your Notification Settings "
+"at %s"
+msgstr "Per deixar de rebre aquests missatges, modifica la configuració de notificacions a %s"
+
+#: ../../Zotlabs/Lib/Enotify.php:68
+#, php-format
+msgid "To stop receiving these messages, please adjust your %s."
+msgstr "Per deixar de rebre aquests missatges, modifica la teva %s."
+
+#: ../../Zotlabs/Lib/Enotify.php:120
 #, php-format
 msgid "%s <!item_type!>"
 msgstr "%s <!item_type!>"
 
-#: ../../Zotlabs/Lib/Enotify.php:104
+#: ../../Zotlabs/Lib/Enotify.php:124
 #, php-format
-msgid "[Hubzilla:Notify] New mail received at %s"
-msgstr "[Hubzilla:Notify] Nou corrreu rebut en %s"
+msgid "[$Projectname:Notify] New mail received at %s"
+msgstr "[$Projectname:Avís] S'ha rebut correu nou a %s"
 
-#: ../../Zotlabs/Lib/Enotify.php:106
+#: ../../Zotlabs/Lib/Enotify.php:126
 #, php-format
 msgid "%1$s, %2$s sent you a new private message at %3$s."
 msgstr "%1$s, %2$s t'ha enviat un nou missatge privat a %3$s."
 
-#: ../../Zotlabs/Lib/Enotify.php:107
+#: ../../Zotlabs/Lib/Enotify.php:127
 #, php-format
 msgid "%1$s sent you %2$s."
 msgstr "%1$s t'ha enviat %2$s."
 
-#: ../../Zotlabs/Lib/Enotify.php:107
+#: ../../Zotlabs/Lib/Enotify.php:127
 msgid "a private message"
 msgstr "un missatge privat"
 
-#: ../../Zotlabs/Lib/Enotify.php:108
+#: ../../Zotlabs/Lib/Enotify.php:128
 #, php-format
 msgid "Please visit %s to view and/or reply to your private messages."
 msgstr "Per favor, visita %s per a veure i/o respondre els teus missatges privats."
 
-#: ../../Zotlabs/Lib/Enotify.php:164
-#, php-format
-msgid "%1$s, %2$s commented on [zrl=%3$s]a %4$s[/zrl]"
-msgstr "%1$s, %2$s comentat en [zrl=%3$s]a %4$s[/zrl]"
+#: ../../Zotlabs/Lib/Enotify.php:141
+msgid "commented on"
+msgstr "ha comentat"
 
-#: ../../Zotlabs/Lib/Enotify.php:172
-#, php-format
-msgid "%1$s, %2$s commented on [zrl=%3$s]%4$s's %5$s[/zrl]"
-msgstr "%1$s, %2$s comentat en [zrl=%3$s]%4$s de %5$s[/zrl]"
+#: ../../Zotlabs/Lib/Enotify.php:152
+msgid "liked"
+msgstr "li ha agradat"
 
-#: ../../Zotlabs/Lib/Enotify.php:181
-#, php-format
-msgid "%1$s, %2$s commented on [zrl=%3$s]your %4$s[/zrl]"
-msgstr "%1$s, %2$s comentat en [zrl=%3$s]el teu %4$s[/zrl]"
+#: ../../Zotlabs/Lib/Enotify.php:155
+msgid "disliked"
+msgstr "no li ha agradat"
 
-#: ../../Zotlabs/Lib/Enotify.php:192
+#: ../../Zotlabs/Lib/Enotify.php:198
 #, php-format
-msgid "[Hubzilla:Notify] Comment to conversation #%1$d by %2$s"
-msgstr "[Hubzilla:Notify] Comentari sobre una conversació #%1$d per %2$s"
+msgid "%1$s, %2$s %3$s [zrl=%4$s]a %5$s[/zrl]"
+msgstr "%1$s, %2$s %3$s [zrl=%4$s]una %5$s[/zrl]"
 
-#: ../../Zotlabs/Lib/Enotify.php:193
+#: ../../Zotlabs/Lib/Enotify.php:207
+#, php-format
+msgid "%1$s, %2$s %3$s [zrl=%4$s]%5$s's %6$s[/zrl]"
+msgstr "%1$s, %2$s %3$s [zrl=%4$s]%6$s de %5$s[/zrl]"
+
+#: ../../Zotlabs/Lib/Enotify.php:217
+#, php-format
+msgid "%1$s, %2$s %3$s [zrl=%4$s]your %5$s[/zrl]"
+msgstr "%1$s, %2$s %3$s [zrl=%4$s]la teva %5$s[/zrl]"
+
+#: ../../Zotlabs/Lib/Enotify.php:230
+#, php-format
+msgid "[$Projectname:Notify] Moderated Comment to conversation #%1$d by %2$s"
+msgstr "[$Projectname:Avís] S'ha moderat el comentari de %2$s a la conversa #%1$d"
+
+#: ../../Zotlabs/Lib/Enotify.php:232
+#, php-format
+msgid "[$Projectname:Notify] Comment to conversation #%1$d by %2$s"
+msgstr "[$Projectname:Avís] Comentari de %2$s a la conversa #%1$d"
+
+#: ../../Zotlabs/Lib/Enotify.php:233
 #, php-format
 msgid "%1$s, %2$s commented on an item/conversation you have been following."
 msgstr "%1$s, %2$s comentat en un article/conversa que havies estat seguint."
 
-#: ../../Zotlabs/Lib/Enotify.php:196 ../../Zotlabs/Lib/Enotify.php:211
-#: ../../Zotlabs/Lib/Enotify.php:237 ../../Zotlabs/Lib/Enotify.php:255
-#: ../../Zotlabs/Lib/Enotify.php:269
+#: ../../Zotlabs/Lib/Enotify.php:236 ../../Zotlabs/Lib/Enotify.php:318
+#: ../../Zotlabs/Lib/Enotify.php:335 ../../Zotlabs/Lib/Enotify.php:361
+#: ../../Zotlabs/Lib/Enotify.php:379 ../../Zotlabs/Lib/Enotify.php:393
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr "Si us plau visita %s per veure i/o contestar a la conversa"
 
-#: ../../Zotlabs/Lib/Enotify.php:202
+#: ../../Zotlabs/Lib/Enotify.php:240 ../../Zotlabs/Lib/Enotify.php:241
 #, php-format
-msgid "[Hubzilla:Notify] %s posted to your profile wall"
-msgstr "[Hubzilla:Avís] %s ha escrit una entrada al teu mur"
+msgid "Please visit %s to approve or reject this comment."
+msgstr "Vés a %s per a aprovar o rebutjar el comentari."
 
-#: ../../Zotlabs/Lib/Enotify.php:204
+#: ../../Zotlabs/Lib/Enotify.php:299
+#, php-format
+msgid "%1$s, %2$s liked [zrl=%3$s]your %4$s[/zrl]"
+msgstr "%1$s, a %2$s li ha agradat [zrl=%3$s]la teva %4$s[/zrl]"
+
+#: ../../Zotlabs/Lib/Enotify.php:314
+#, php-format
+msgid "[$Projectname:Notify] Like received to conversation #%1$d by %2$s"
+msgstr "[$Projectname:Avís] Un \"m'agrada\" a la conversa #%1$d de %2$s"
+
+#: ../../Zotlabs/Lib/Enotify.php:315
+#, php-format
+msgid "%1$s, %2$s liked an item/conversation you created."
+msgstr "%1$s, a %2$s li ha agradat una conversa que has creat."
+
+#: ../../Zotlabs/Lib/Enotify.php:326
+#, php-format
+msgid "[$Projectname:Notify] %s posted to your profile wall"
+msgstr "[$Projectname:Avís] %s ha penjat una entrada al teu mur"
+
+#: ../../Zotlabs/Lib/Enotify.php:328
 #, php-format
 msgid "%1$s, %2$s posted to your profile wall at %3$s"
 msgstr "%1$s, %2$s ha escrit una entrada al teu mur en  %3$s"
 
-#: ../../Zotlabs/Lib/Enotify.php:206
+#: ../../Zotlabs/Lib/Enotify.php:330
 #, php-format
 msgid "%1$s, %2$s posted to [zrl=%3$s]your wall[/zrl]"
 msgstr "%1$s, %2$s enviat correu a [zrl=%3$s]el teu mur[/zrl]"
 
-#: ../../Zotlabs/Lib/Enotify.php:230
+#: ../../Zotlabs/Lib/Enotify.php:354
 #, php-format
-msgid "[Hubzilla:Notify] %s tagged you"
-msgstr "[Hubzilla:Notificació] %s t'ha etiquetat"
+msgid "[$Projectname:Notify] %s tagged you"
+msgstr "[$Projectname:Avís] %s t'ha etiquetat"
 
-#: ../../Zotlabs/Lib/Enotify.php:231
+#: ../../Zotlabs/Lib/Enotify.php:355
 #, php-format
 msgid "%1$s, %2$s tagged you at %3$s"
 msgstr "%1$s, %2$s t'ha etiquetat a %3$s"
 
-#: ../../Zotlabs/Lib/Enotify.php:232
+#: ../../Zotlabs/Lib/Enotify.php:356
 #, php-format
 msgid "%1$s, %2$s [zrl=%3$s]tagged you[/zrl]."
 msgstr "%1$s, %2$s [zrl=%3$s]t'ha etiquetat[/zrl]."
 
-#: ../../Zotlabs/Lib/Enotify.php:244
+#: ../../Zotlabs/Lib/Enotify.php:368
 #, php-format
-msgid "[Hubzilla:Notify] %1$s poked you"
-msgstr "[Hubzilla:Avís] %1$s s'en fot de tu"
+msgid "[$Projectname:Notify] %1$s poked you"
+msgstr "[$Projectname:Avís] %1$s t'ha fet un toc"
 
-#: ../../Zotlabs/Lib/Enotify.php:245
+#: ../../Zotlabs/Lib/Enotify.php:369
 #, php-format
 msgid "%1$s, %2$s poked you at %3$s"
 msgstr "%1$s, %2$s s'en fot de tú a %3$s"
 
-#: ../../Zotlabs/Lib/Enotify.php:246
+#: ../../Zotlabs/Lib/Enotify.php:370
 #, php-format
 msgid "%1$s, %2$s [zrl=%2$s]poked you[/zrl]."
 msgstr "%1$s, %2$s [zrl=%2$s]s'en fot de tú[/zrl]."
 
-#: ../../Zotlabs/Lib/Enotify.php:262
+#: ../../Zotlabs/Lib/Enotify.php:386
 #, php-format
-msgid "[Hubzilla:Notify] %s tagged your post"
-msgstr "[Hubzilla:Avís] %s ha etiquetat la teva entrada"
+msgid "[$Projectname:Notify] %s tagged your post"
+msgstr "[$Projectname:Avís] %s t'ha etiquetat una entrada"
 
-#: ../../Zotlabs/Lib/Enotify.php:263
+#: ../../Zotlabs/Lib/Enotify.php:387
 #, php-format
 msgid "%1$s, %2$s tagged your post at %3$s"
 msgstr "%1$s, %2$s ha etiquetat la teva entrada a %3$s"
 
-#: ../../Zotlabs/Lib/Enotify.php:264
+#: ../../Zotlabs/Lib/Enotify.php:388
 #, php-format
 msgid "%1$s, %2$s tagged [zrl=%3$s]your post[/zrl]"
 msgstr "%1$s, %2$s etiquetat [zrl=%3$s]la teva entrada[/zrl]"
 
-#: ../../Zotlabs/Lib/Enotify.php:276
-msgid "[Hubzilla:Notify] Introduction received"
-msgstr "[Hubzilla:Avís] Presentació rebuda"
+#: ../../Zotlabs/Lib/Enotify.php:400
+msgid "[$Projectname:Notify] Introduction received"
+msgstr "[$Projectname:Avís] S'ha rebut una sol·licitud de connexió"
 
-#: ../../Zotlabs/Lib/Enotify.php:277
+#: ../../Zotlabs/Lib/Enotify.php:401
 #, php-format
 msgid "%1$s, you've received an new connection request from '%2$s' at %3$s"
 msgstr "%1$s, has rebut una nova petició de connexió de '%2$s' a %3$s"
 
-#: ../../Zotlabs/Lib/Enotify.php:278
+#: ../../Zotlabs/Lib/Enotify.php:402
 #, php-format
 msgid ""
 "%1$s, you've received [zrl=%2$s]a new connection request[/zrl] from %3$s."
 msgstr "%1$s, has rebut [zrl=%2$s]una nova petició de connexió[/zrl] de %3$s."
 
-#: ../../Zotlabs/Lib/Enotify.php:282 ../../Zotlabs/Lib/Enotify.php:301
+#: ../../Zotlabs/Lib/Enotify.php:406 ../../Zotlabs/Lib/Enotify.php:425
 #, php-format
 msgid "You may visit their profile at %s"
 msgstr "Pots visitar el seu perfil a %s"
 
-#: ../../Zotlabs/Lib/Enotify.php:284
+#: ../../Zotlabs/Lib/Enotify.php:408
 #, php-format
 msgid "Please visit %s to approve or reject the connection request."
 msgstr "Si us plau, visita %s per aprovar o rebutjar la petició de connexió."
 
-#: ../../Zotlabs/Lib/Enotify.php:291
-msgid "[Hubzilla:Notify] Friend suggestion received"
-msgstr "[Hubzilla:Notificació] Rebuda suggerencia d'amistat"
+#: ../../Zotlabs/Lib/Enotify.php:415
+msgid "[$Projectname:Notify] Friend suggestion received"
+msgstr "[$Projectname:Avís] S'ha rebut una suggerència d'amistat"
 
-#: ../../Zotlabs/Lib/Enotify.php:292
+#: ../../Zotlabs/Lib/Enotify.php:416
 #, php-format
 msgid "%1$s, you've received a friend suggestion from '%2$s' at %3$s"
 msgstr "%1$s, has rebut una suggerència d'amistat de '%2$s' a %3$s"
 
-#: ../../Zotlabs/Lib/Enotify.php:293
+#: ../../Zotlabs/Lib/Enotify.php:417
 #, php-format
 msgid ""
 "%1$s, you've received [zrl=%2$s]a friend suggestion[/zrl] for %3$s from "
 "%4$s."
 msgstr "%1$s, has rebut [zrl=%2$s]una suggerència d'amistat[/zrl] per %3$s de %4$s."
 
-#: ../../Zotlabs/Lib/Enotify.php:299
+#: ../../Zotlabs/Lib/Enotify.php:423
 msgid "Name:"
 msgstr "Nom:"
 
-#: ../../Zotlabs/Lib/Enotify.php:300
+#: ../../Zotlabs/Lib/Enotify.php:424
 msgid "Photo:"
 msgstr "Foto:"
 
-#: ../../Zotlabs/Lib/Enotify.php:303
+#: ../../Zotlabs/Lib/Enotify.php:427
 #, php-format
 msgid "Please visit %s to approve or reject the suggestion."
 msgstr "Per favor, visita %s per a aprovar o rebutjar la suggerencia."
 
-#: ../../Zotlabs/Lib/Enotify.php:518
-msgid "[Hubzilla:Notify]"
-msgstr "[Hubzilla:Notificació]"
+#: ../../Zotlabs/Lib/Enotify.php:647
+msgid "[$Projectname:Notify]"
+msgstr "[$Projectname:Avís]"
 
-#: ../../Zotlabs/Lib/Enotify.php:667
+#: ../../Zotlabs/Lib/Enotify.php:815
 msgid "created a new post"
 msgstr "Creada una nova entrada"
 
-#: ../../Zotlabs/Lib/Enotify.php:668
+#: ../../Zotlabs/Lib/Enotify.php:816
 #, php-format
 msgid "commented on %s's post"
 msgstr "comentat a l'entrada de %s"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:95 ../../include/conversation.php:664
+#: ../../Zotlabs/Lib/Enotify.php:823
+#, php-format
+msgid "edited a post dated %s"
+msgstr "ha editat una entrada amb data de %s"
+
+#: ../../Zotlabs/Lib/Enotify.php:827
+#, php-format
+msgid "edited a comment dated %s"
+msgstr "ha editat un comentari amb data de %s"
+
+#: ../../Zotlabs/Lib/NativeWiki.php:151
+msgid "Wiki updated successfully"
+msgstr "S'ha actualitzat la wiki amb èxit"
+
+#: ../../Zotlabs/Lib/NativeWiki.php:198
+msgid "Wiki files deleted successfully"
+msgstr "S'han esborrat els fitxers de la wiki amb èxit"
+
+#: ../../Zotlabs/Lib/DB_Upgrade.php:83
+#, php-format
+msgid "Update Error at %s"
+msgstr "Error d'Actualització a %s"
+
+#: ../../Zotlabs/Lib/DB_Upgrade.php:89
+#, php-format
+msgid "Update %s failed. See error logs."
+msgstr "L'actualització %s ha fallat. Mira el registre d'errors."
+
+#: ../../Zotlabs/Lib/ThreadItem.php:97 ../../include/conversation.php:697
 msgid "Private Message"
 msgstr "Missatge Privat"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:132 ../../include/conversation.php:656
+#: ../../Zotlabs/Lib/ThreadItem.php:147 ../../include/conversation.php:689
 msgid "Select"
 msgstr "Selecciona"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:136
-msgid "Save to Folder"
-msgstr "Guardar en la Carpeta"
-
-#: ../../Zotlabs/Lib/ThreadItem.php:157
+#: ../../Zotlabs/Lib/ThreadItem.php:172
 msgid "I will attend"
 msgstr "Assistiré"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:157
+#: ../../Zotlabs/Lib/ThreadItem.php:172
 msgid "I will not attend"
 msgstr "No assistiré"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:157
+#: ../../Zotlabs/Lib/ThreadItem.php:172
 msgid "I might attend"
 msgstr "Podria assistir"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:167
+#: ../../Zotlabs/Lib/ThreadItem.php:182
 msgid "I agree"
 msgstr "D'acord"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:167
+#: ../../Zotlabs/Lib/ThreadItem.php:182
 msgid "I disagree"
 msgstr "En desacord"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:167
+#: ../../Zotlabs/Lib/ThreadItem.php:182
 msgid "I abstain"
 msgstr "M'abstinc"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:218
+#: ../../Zotlabs/Lib/ThreadItem.php:238
 msgid "Add Star"
 msgstr "Fes-lo Preferit"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:219
+#: ../../Zotlabs/Lib/ThreadItem.php:239
 msgid "Remove Star"
 msgstr "Treu-lo de Preferits"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:220
+#: ../../Zotlabs/Lib/ThreadItem.php:240
 msgid "Toggle Star Status"
 msgstr "Canvia el Estat de la Preferència"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:224
+#: ../../Zotlabs/Lib/ThreadItem.php:244
 msgid "starred"
 msgstr "preferit"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:234 ../../include/conversation.php:671
+#: ../../Zotlabs/Lib/ThreadItem.php:254 ../../include/conversation.php:704
 msgid "Message signature validated"
 msgstr "Validada la signatura del missatge"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:235 ../../include/conversation.php:672
+#: ../../Zotlabs/Lib/ThreadItem.php:255 ../../include/conversation.php:705
 msgid "Message signature incorrect"
 msgstr "Signatura del missatge incorrecta"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:243
+#: ../../Zotlabs/Lib/ThreadItem.php:263
 msgid "Add Tag"
 msgstr "Afegeix Etiqueta"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:261 ../../include/taxonomy.php:316
+#: ../../Zotlabs/Lib/ThreadItem.php:281 ../../include/taxonomy.php:510
 msgid "like"
 msgstr "agrada"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:262 ../../include/taxonomy.php:317
+#: ../../Zotlabs/Lib/ThreadItem.php:282 ../../include/taxonomy.php:511
 msgid "dislike"
 msgstr "desagrada"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:266
+#: ../../Zotlabs/Lib/ThreadItem.php:286
 msgid "Share This"
 msgstr "Comparteix Això"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:266
+#: ../../Zotlabs/Lib/ThreadItem.php:286
 msgid "share"
 msgstr "comparteix"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:275
+#: ../../Zotlabs/Lib/ThreadItem.php:295
 msgid "Delivery Report"
 msgstr "Informe de Lliurament"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:293
+#: ../../Zotlabs/Lib/ThreadItem.php:313
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] "%d commentari"
 msgstr[1] "%d commentaris"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:322 ../../Zotlabs/Lib/ThreadItem.php:323
+#: ../../Zotlabs/Lib/ThreadItem.php:343 ../../Zotlabs/Lib/ThreadItem.php:344
 #, php-format
 msgid "View %s's profile - %s"
 msgstr "Veure perfil de %s  - %s"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:326
+#: ../../Zotlabs/Lib/ThreadItem.php:347
 msgid "to"
 msgstr "a"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:327
+#: ../../Zotlabs/Lib/ThreadItem.php:348
 msgid "via"
 msgstr "via"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:328
+#: ../../Zotlabs/Lib/ThreadItem.php:349
 msgid "Wall-to-Wall"
 msgstr "Mur-a-Mur"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:329
+#: ../../Zotlabs/Lib/ThreadItem.php:350
 msgid "via Wall-To-Wall:"
 msgstr "via Mur-a-Mur:"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:341 ../../include/conversation.php:719
+#: ../../Zotlabs/Lib/ThreadItem.php:363 ../../include/conversation.php:763
 #, php-format
 msgid "from %s"
 msgstr "De %s"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:344 ../../include/conversation.php:722
+#: ../../Zotlabs/Lib/ThreadItem.php:366 ../../include/conversation.php:766
 #, php-format
 msgid "last edited: %s"
 msgstr "últim editat: %s"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:345 ../../include/conversation.php:723
+#: ../../Zotlabs/Lib/ThreadItem.php:367 ../../include/conversation.php:767
 #, php-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:370
+#: ../../Zotlabs/Lib/ThreadItem.php:374
+msgid "Attend"
+msgstr "Assistir-hi"
+
+#: ../../Zotlabs/Lib/ThreadItem.php:375
+msgid "Attendance Options"
+msgstr "Opcions d'assistència"
+
+#: ../../Zotlabs/Lib/ThreadItem.php:376
+msgid "Vote"
+msgstr "Votar"
+
+#: ../../Zotlabs/Lib/ThreadItem.php:377
+msgid "Voting Options"
+msgstr "Opcions de votació"
+
+#: ../../Zotlabs/Lib/ThreadItem.php:398
+#: ../../addon/bookmarker/bookmarker.php:38
 msgid "Save Bookmarks"
 msgstr "Guarda Favorits"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:371
+#: ../../Zotlabs/Lib/ThreadItem.php:399
 msgid "Add to Calendar"
 msgstr "Afegeix al Calendari"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:380
-msgid "Mark all seen"
-msgstr "Marca tot com ja vist"
+#: ../../Zotlabs/Lib/ThreadItem.php:426 ../../include/conversation.php:483
+msgid "This is an unsaved preview"
+msgstr "Això només és una vista prèvia, no està desada"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:421 ../../include/js_strings.php:7
-msgid "[+] show all"
-msgstr "[+] mostra tot"
+#: ../../Zotlabs/Lib/ThreadItem.php:458 ../../include/js_strings.php:7
+#, php-format
+msgid "%s show all"
+msgstr "%s mostra-ho tot"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:711 ../../include/conversation.php:1215
+#: ../../Zotlabs/Lib/ThreadItem.php:751 ../../include/conversation.php:1377
 msgid "Bold"
 msgstr "Negreta"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:712 ../../include/conversation.php:1216
+#: ../../Zotlabs/Lib/ThreadItem.php:752 ../../include/conversation.php:1378
 msgid "Italic"
 msgstr "Italica"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:713 ../../include/conversation.php:1217
+#: ../../Zotlabs/Lib/ThreadItem.php:753 ../../include/conversation.php:1379
 msgid "Underline"
 msgstr "Subratllat"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:714 ../../include/conversation.php:1218
+#: ../../Zotlabs/Lib/ThreadItem.php:754 ../../include/conversation.php:1380
 msgid "Quote"
 msgstr "Cometes"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:715 ../../include/conversation.php:1219
+#: ../../Zotlabs/Lib/ThreadItem.php:755 ../../include/conversation.php:1381
 msgid "Code"
 msgstr "Codi"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:716
+#: ../../Zotlabs/Lib/ThreadItem.php:756
 msgid "Image"
 msgstr "Imatge"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:717
+#: ../../Zotlabs/Lib/ThreadItem.php:757
+msgid "Attach File"
+msgstr "Adjunta un fitxer"
+
+#: ../../Zotlabs/Lib/ThreadItem.php:758
 msgid "Insert Link"
 msgstr "Insereix Enllaç"
 
-#: ../../Zotlabs/Lib/ThreadItem.php:718
+#: ../../Zotlabs/Lib/ThreadItem.php:759
 msgid "Video"
 msgstr "Video"
 
-#: ../../include/Import/import_diaspora.php:16
-msgid "No username found in import file."
-msgstr "No s'ha trobat nom d'usuari a l'arxiu d'importació."
+#: ../../Zotlabs/Lib/ThreadItem.php:769
+msgid "Your full name (required)"
+msgstr "Nom complet (obligatori)"
 
-#: ../../include/Import/import_diaspora.php:41 ../../include/import.php:50
-msgid "Unable to create a unique channel address. Import failed."
-msgstr "No s'ha pogut importar el canal perquè l'adreça única de canal no s'ha pogut crear."
+#: ../../Zotlabs/Lib/ThreadItem.php:770
+msgid "Your email address (required)"
+msgstr "Adreça de correu (obligatòria)"
 
-#: ../../include/dba/dba_driver.php:171
+#: ../../Zotlabs/Lib/ThreadItem.php:771
+msgid "Your website URL (optional)"
+msgstr "Adreça web (opcional)"
+
+#: ../../Zotlabs/Zot/Auth.php:152
+msgid ""
+"Remote authentication blocked. You are logged into this site locally. Please"
+" logout and retry."
+msgstr "Autenticació remota bloquejada. Ha iniciat sessió en aquest lloc a nivell local. Si us plau, tanca la sessió i torna-ho a intentar."
+
+#: ../../Zotlabs/Zot/Auth.php:264 ../../addon/openid/Mod_Openid.php:76
+#: ../../addon/openid/Mod_Openid.php:178
 #, php-format
-msgid "Cannot locate DNS info for database server '%s'"
-msgstr "No s'ha trobat informació de DNS pel servidor de base de dades '%s'"
+msgid "Welcome %s. Remote authentication successful."
+msgstr "Benvingut %s. Autenticació remota reeixida."
 
-#: ../../include/taxonomy.php:188 ../../include/taxonomy.php:270
-#: ../../include/widgets.php:46 ../../include/widgets.php:429
-#: ../../include/contact_widgets.php:91
+#: ../../Zotlabs/Storage/Browser.php:107 ../../Zotlabs/Storage/Browser.php:287
+msgid "parent"
+msgstr "amunt"
+
+#: ../../Zotlabs/Storage/Browser.php:131 ../../include/text.php:2821
+msgid "Collection"
+msgstr "Col·lecció"
+
+#: ../../Zotlabs/Storage/Browser.php:134
+msgid "Principal"
+msgstr "Principal"
+
+#: ../../Zotlabs/Storage/Browser.php:137
+msgid "Addressbook"
+msgstr "Llista d'Adreçes"
+
+#: ../../Zotlabs/Storage/Browser.php:140 ../../include/nav.php:420
+#: ../../include/nav.php:423
+msgid "Calendar"
+msgstr "Calendari"
+
+#: ../../Zotlabs/Storage/Browser.php:143
+msgid "Schedule Inbox"
+msgstr "Programació de la bústia d'entrada"
+
+#: ../../Zotlabs/Storage/Browser.php:146
+msgid "Schedule Outbox"
+msgstr "Programació de la bústia de sortida"
+
+#: ../../Zotlabs/Storage/Browser.php:273
+msgid "Total"
+msgstr "Total"
+
+#: ../../Zotlabs/Storage/Browser.php:275
+msgid "Shared"
+msgstr "Compartit"
+
+#: ../../Zotlabs/Storage/Browser.php:353
+#, php-format
+msgid "You are using %1$s of your available file storage."
+msgstr "Estàs emprant el %1$s de l'espai d'emmagatzematge disponible"
+
+#: ../../Zotlabs/Storage/Browser.php:358
+#, php-format
+msgid "You are using %1$s of %2$s available file storage. (%3$s&#37;)"
+msgstr "Estàs emprant %1$s de %2$s d'emmagatzematge d'arxius disponible.\n(%3$s&#37;)"
+
+#: ../../Zotlabs/Storage/Browser.php:369
+msgid "WARNING:"
+msgstr "ALERTA:"
+
+#: ../../Zotlabs/Storage/Browser.php:381
+msgid "Create new folder"
+msgstr "Crea una nova carpeta"
+
+#: ../../Zotlabs/Storage/Browser.php:383
+msgid "Upload file"
+msgstr "Puja arxiu"
+
+#: ../../Zotlabs/Storage/Browser.php:396
+msgid "Drop files here to immediately upload"
+msgstr "Deixa anar fitxers aquí per a pujar-los immediatament"
+
+#: ../../Zotlabs/Widget/Forums.php:100
+msgid "Forums"
+msgstr "Forums"
+
+#: ../../Zotlabs/Widget/Cdav.php:37
+msgid "Select Channel"
+msgstr "Escull canal"
+
+#: ../../Zotlabs/Widget/Cdav.php:42
+msgid "Read-write"
+msgstr "Llegir i escriure"
+
+#: ../../Zotlabs/Widget/Cdav.php:43
+msgid "Read-only"
+msgstr "Només lectura"
+
+#: ../../Zotlabs/Widget/Cdav.php:117
+msgid "My Calendars"
+msgstr "Els meus calendaris"
+
+#: ../../Zotlabs/Widget/Cdav.php:119
+msgid "Shared Calendars"
+msgstr "Calendaris compartits"
+
+#: ../../Zotlabs/Widget/Cdav.php:123
+msgid "Share this calendar"
+msgstr "Comparteix aquest calendari"
+
+#: ../../Zotlabs/Widget/Cdav.php:125
+msgid "Calendar name and color"
+msgstr "Nom i color del calendari"
+
+#: ../../Zotlabs/Widget/Cdav.php:127
+msgid "Create new calendar"
+msgstr "Crea un nou calendari"
+
+#: ../../Zotlabs/Widget/Cdav.php:129
+msgid "Calendar Name"
+msgstr "Nom del calendari"
+
+#: ../../Zotlabs/Widget/Cdav.php:130
+msgid "Calendar Tools"
+msgstr "Eines de calendari"
+
+#: ../../Zotlabs/Widget/Cdav.php:131
+msgid "Import calendar"
+msgstr "Importa un calendari"
+
+#: ../../Zotlabs/Widget/Cdav.php:132
+msgid "Select a calendar to import to"
+msgstr "Escull el calendari a on importar"
+
+#: ../../Zotlabs/Widget/Cdav.php:159
+msgid "Addressbooks"
+msgstr "Llibretes d'adreces"
+
+#: ../../Zotlabs/Widget/Cdav.php:161
+msgid "Addressbook name"
+msgstr "Nom de llibreta d'adreces"
+
+#: ../../Zotlabs/Widget/Cdav.php:163
+msgid "Create new addressbook"
+msgstr "Crea una nova llibreta d'adreces"
+
+#: ../../Zotlabs/Widget/Cdav.php:164
+msgid "Addressbook Name"
+msgstr "Nom de llibreta d'adreces"
+
+#: ../../Zotlabs/Widget/Cdav.php:166
+msgid "Addressbook Tools"
+msgstr "Eines de llibreta d'adreces"
+
+#: ../../Zotlabs/Widget/Cdav.php:167
+msgid "Import addressbook"
+msgstr "Importa una llibreta d'adreces"
+
+#: ../../Zotlabs/Widget/Cdav.php:168
+msgid "Select an addressbook to import to"
+msgstr "Escull la llibreta d'adreces a on importar"
+
+#: ../../Zotlabs/Widget/Appcategories.php:40
+#: ../../Zotlabs/Widget/Tagcloud.php:25 ../../include/contact_widgets.php:97
+#: ../../include/contact_widgets.php:141 ../../include/contact_widgets.php:186
+#: ../../include/taxonomy.php:344 ../../include/taxonomy.php:426
+#: ../../include/taxonomy.php:446 ../../include/taxonomy.php:467
 msgid "Categories"
 msgstr "Categories"
 
-#: ../../include/taxonomy.php:228 ../../include/taxonomy.php:249
-msgid "Tags"
-msgstr "Etiquetes"
-
-#: ../../include/taxonomy.php:293
-msgid "Keywords"
-msgstr "Paraules clau"
-
-#: ../../include/taxonomy.php:314
-msgid "have"
-msgstr "tinc"
-
-#: ../../include/taxonomy.php:314
-msgid "has"
-msgstr "tens"
-
-#: ../../include/taxonomy.php:315
-msgid "want"
-msgstr "vull"
-
-#: ../../include/taxonomy.php:315
-msgid "wants"
-msgstr "vols"
-
-#: ../../include/taxonomy.php:316
-msgid "likes"
-msgstr "agrada"
-
-#: ../../include/taxonomy.php:317
-msgid "dislikes"
-msgstr "desagrada"
-
-#: ../../include/event.php:22 ../../include/event.php:69
-#: ../../include/bb2diaspora.php:485
-msgid "l F d, Y \\@ g:i A"
-msgstr "l F d, Y \\@ g:i A"
-
-#: ../../include/event.php:30 ../../include/event.php:73
-#: ../../include/bb2diaspora.php:491
-msgid "Starts:"
-msgstr "Inicia:"
-
-#: ../../include/event.php:40 ../../include/event.php:77
-#: ../../include/bb2diaspora.php:499
-msgid "Finishes:"
-msgstr "Acaba:"
-
-#: ../../include/event.php:812
-msgid "This event has been added to your calendar."
-msgstr "Aquest succés ha estat afegit al teu calendari."
-
-#: ../../include/event.php:1012
-msgid "Not specified"
-msgstr "Sense especificar"
-
-#: ../../include/event.php:1013
-msgid "Needs Action"
-msgstr "Necessita una Acció"
-
-#: ../../include/event.php:1014
-msgid "Completed"
-msgstr "Completat"
-
-#: ../../include/event.php:1015
-msgid "In Process"
-msgstr "En Procès"
-
-#: ../../include/event.php:1016
-msgid "Cancelled"
-msgstr "Cancel·lat"
-
-#: ../../include/import.php:29
-msgid ""
-"Cannot create a duplicate channel identifier on this system. Import failed."
-msgstr "No s'ha pogut importar el canal perquè l'identificador del canal no s'ha pogut duplicar en aquest servidor."
-
-#: ../../include/import.php:76
-msgid "Channel clone failed. Import failed."
-msgstr "No s'ha pogut importar el canal perquè el canal no s'ha pogut clonar."
-
-#: ../../include/items.php:892 ../../include/items.php:937
-msgid "(Unknown)"
-msgstr "(Desconegut)"
-
-#: ../../include/items.php:1136
-msgid "Visible to anybody on the internet."
-msgstr "Visible per tothom a la Internet"
-
-#: ../../include/items.php:1138
-msgid "Visible to you only."
-msgstr "Visible només per tú."
-
-#: ../../include/items.php:1140
-msgid "Visible to anybody in this network."
-msgstr "Visible per tothom en aquesta xarxa."
-
-#: ../../include/items.php:1142
-msgid "Visible to anybody authenticated."
-msgstr "Visible per tothom autenticat."
-
-#: ../../include/items.php:1144
-#, php-format
-msgid "Visible to anybody on %s."
-msgstr "Visible per a tothom a %s."
-
-#: ../../include/items.php:1146
-msgid "Visible to all connections."
-msgstr "Visible per a totes les connexions."
-
-#: ../../include/items.php:1148
-msgid "Visible to approved connections."
-msgstr "Visible per a les connexions aprovades."
-
-#: ../../include/items.php:1150
-msgid "Visible to specific connections."
-msgstr "Visible per a específiques connexions."
-
-#: ../../include/items.php:3909
-msgid "Privacy group is empty."
-msgstr "El grup privat està vuit."
-
-#: ../../include/items.php:3916
-#, php-format
-msgid "Privacy group: %s"
-msgstr "Grup privat: %s"
-
-#: ../../include/items.php:3928
-msgid "Connection not found."
-msgstr "Connexió no trobada."
-
-#: ../../include/items.php:4277
-msgid "profile photo"
-msgstr "foto del perfil"
-
-#: ../../include/message.php:20
-msgid "No recipient provided."
-msgstr "No s'ha proporcionat bústia."
-
-#: ../../include/message.php:25
-msgid "[no subject]"
-msgstr "[no subject]"
-
-#: ../../include/message.php:45
-msgid "Unable to determine sender."
-msgstr "incapaç de determinar el remitent"
-
-#: ../../include/message.php:222
-msgid "Stored post could not be verified."
-msgstr "L'entrada guardada no pot ser verificada"
-
-#: ../../include/text.php:428
-msgid "prev"
-msgstr "prev"
-
-#: ../../include/text.php:430
-msgid "first"
-msgstr "primer"
-
-#: ../../include/text.php:459
-msgid "last"
-msgstr "últim"
-
-#: ../../include/text.php:462
-msgid "next"
-msgstr "pròxim"
-
-#: ../../include/text.php:472
-msgid "older"
-msgstr "el més antic"
-
-#: ../../include/text.php:474
-msgid "newer"
-msgstr "El més nou"
-
-#: ../../include/text.php:863
-msgid "No connections"
-msgstr "Sense Connexions"
-
-#: ../../include/text.php:888
-#, php-format
-msgid "View all %s connections"
-msgstr "Veure totes les connexions de %s"
-
-#: ../../include/text.php:1033 ../../include/text.php:1038
-msgid "poke"
-msgstr "esperona"
-
-#: ../../include/text.php:1033 ../../include/text.php:1038
-#: ../../include/conversation.php:243
-msgid "poked"
-msgstr "esperonat"
-
-#: ../../include/text.php:1039
-msgid "ping"
-msgstr "coloca"
-
-#: ../../include/text.php:1039
-msgid "pinged"
-msgstr "colocat"
-
-#: ../../include/text.php:1040
-msgid "prod"
-msgstr "picar"
-
-#: ../../include/text.php:1040
-msgid "prodded"
-msgstr "picat"
-
-#: ../../include/text.php:1041
-msgid "slap"
-msgstr "bufetada"
-
-#: ../../include/text.php:1041
-msgid "slapped"
-msgstr "bufetejat"
-
-#: ../../include/text.php:1042
-msgid "finger"
-msgstr "senyal"
-
-#: ../../include/text.php:1042
-msgid "fingered"
-msgstr "senyalat"
-
-#: ../../include/text.php:1043
-msgid "rebuff"
-msgstr "menyspreu"
-
-#: ../../include/text.php:1043
-msgid "rebuffed"
-msgstr "menyspreuat"
-
-#: ../../include/text.php:1055
-msgid "happy"
-msgstr "feliç"
-
-#: ../../include/text.php:1056
-msgid "sad"
-msgstr "trist"
-
-#: ../../include/text.php:1057
-msgid "mellow"
-msgstr "melós"
-
-#: ../../include/text.php:1058
-msgid "tired"
-msgstr "cansat"
-
-#: ../../include/text.php:1059
-msgid "perky"
-msgstr "turgent"
-
-#: ../../include/text.php:1060
-msgid "angry"
-msgstr "enfadat"
-
-#: ../../include/text.php:1061
-msgid "stupefied"
-msgstr "estupefacte"
-
-#: ../../include/text.php:1062
-msgid "puzzled"
-msgstr "perplexe"
-
-#: ../../include/text.php:1063
-msgid "interested"
-msgstr "Interessat"
-
-#: ../../include/text.php:1064
-msgid "bitter"
-msgstr "amargat"
-
-#: ../../include/text.php:1065
-msgid "cheerful"
-msgstr "feliç"
-
-#: ../../include/text.php:1066
-msgid "alive"
-msgstr "viu"
-
-#: ../../include/text.php:1067
-msgid "annoyed"
-msgstr "molest"
-
-#: ../../include/text.php:1068
-msgid "anxious"
-msgstr "ansiós"
-
-#: ../../include/text.php:1069
-msgid "cranky"
-msgstr "malagaitós"
-
-#: ../../include/text.php:1070
-msgid "disturbed"
-msgstr "transtornat"
-
-#: ../../include/text.php:1071
-msgid "frustrated"
-msgstr "frustrat"
-
-#: ../../include/text.php:1072
-msgid "depressed"
-msgstr "deprimit"
-
-#: ../../include/text.php:1073
-msgid "motivated"
-msgstr "motivat"
-
-#: ../../include/text.php:1074
-msgid "relaxed"
-msgstr "relaxat"
-
-#: ../../include/text.php:1075
-msgid "surprised"
-msgstr "sorprès"
-
-#: ../../include/text.php:1257 ../../include/js_strings.php:70
-msgid "Monday"
-msgstr "Dilluns"
-
-#: ../../include/text.php:1257 ../../include/js_strings.php:71
-msgid "Tuesday"
-msgstr "Dimarts"
-
-#: ../../include/text.php:1257 ../../include/js_strings.php:72
-msgid "Wednesday"
-msgstr "Dimecres"
-
-#: ../../include/text.php:1257 ../../include/js_strings.php:73
-msgid "Thursday"
-msgstr "Dijous"
-
-#: ../../include/text.php:1257 ../../include/js_strings.php:74
-msgid "Friday"
-msgstr "Divendres"
-
-#: ../../include/text.php:1257 ../../include/js_strings.php:75
-msgid "Saturday"
-msgstr "Dissabte"
-
-#: ../../include/text.php:1257 ../../include/js_strings.php:69
-msgid "Sunday"
-msgstr "Diumenge"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:45
-msgid "January"
-msgstr "Gener"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:46
-msgid "February"
-msgstr "Febrer"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:47
-msgid "March"
-msgstr "Març"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:48
-msgid "April"
-msgstr "Abril"
-
-#: ../../include/text.php:1261
-msgid "May"
-msgstr "Maig"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:50
-msgid "June"
-msgstr "Juny"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:51
-msgid "July"
-msgstr "Juliol"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:52
-msgid "August"
-msgstr "Agost"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:53
-msgid "September"
-msgstr "Setembre"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:54
-msgid "October"
-msgstr "Octubre"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:55
-msgid "November"
-msgstr "Novembre"
-
-#: ../../include/text.php:1261 ../../include/js_strings.php:56
-msgid "December"
-msgstr "Desembre"
-
-#: ../../include/text.php:1338 ../../include/text.php:1342
-msgid "Unknown Attachment"
-msgstr "Adjunt Desconegut"
-
-#: ../../include/text.php:1344
-msgid "unknown"
-msgstr "desconegut"
-
-#: ../../include/text.php:1380
-msgid "remove category"
-msgstr "elimina categoria"
-
-#: ../../include/text.php:1457
-msgid "remove from file"
-msgstr "elimina del arxiu"
-
-#: ../../include/text.php:1753 ../../include/text.php:1824
-msgid "default"
-msgstr "per defecte"
-
-#: ../../include/text.php:1761
-msgid "Page layout"
-msgstr "Format de la pàgina"
-
-#: ../../include/text.php:1761
-msgid "You can create your own with the layouts tool"
-msgstr "Pots crear el teu propi amb l'editor de format de pàgina."
-
-#: ../../include/text.php:1803
-msgid "Page content type"
-msgstr "Tipus de contingut de la pàgina"
-
-#: ../../include/text.php:1836
-msgid "Select an alternate language"
-msgstr "Tria un idioma alternatiu"
-
-#: ../../include/text.php:1953
-msgid "activity"
-msgstr "activitat"
-
-#: ../../include/text.php:2262
-msgid "Design Tools"
-msgstr "Eines de disseny"
-
-#: ../../include/text.php:2268
-msgid "Pages"
-msgstr "Pàgines"
-
-#: ../../include/widgets.php:103
-msgid "System"
-msgstr "Sistema"
-
-#: ../../include/widgets.php:106
-msgid "New App"
-msgstr "Nova App"
-
-#: ../../include/widgets.php:154
-msgid "Suggestions"
-msgstr "Suggerencies"
-
-#: ../../include/widgets.php:155
-msgid "See more..."
-msgstr "Veure més....."
-
-#: ../../include/widgets.php:175
+#: ../../Zotlabs/Widget/Appcategories.php:43 ../../Zotlabs/Widget/Filer.php:31
+#: ../../include/contact_widgets.php:56 ../../include/contact_widgets.php:100
+#: ../../include/contact_widgets.php:144 ../../include/contact_widgets.php:189
+msgid "Everything"
+msgstr "Tot"
+
+#: ../../Zotlabs/Widget/Eventstools.php:13
+msgid "Events Tools"
+msgstr "Eina d'Esdeveniments"
+
+#: ../../Zotlabs/Widget/Eventstools.php:14
+msgid "Export Calendar"
+msgstr "Exportar Calendari"
+
+#: ../../Zotlabs/Widget/Eventstools.php:15
+msgid "Import Calendar"
+msgstr "Importar Calendari"
+
+#: ../../Zotlabs/Widget/Suggestedchats.php:32
+msgid "Suggested Chatrooms"
+msgstr "Sales de Xat Suggerides"
+
+#: ../../Zotlabs/Widget/Hq_controls.php:14
+msgid "HQ Control Panel"
+msgstr "Panell de control"
+
+#: ../../Zotlabs/Widget/Hq_controls.php:17
+msgid "Create a new post"
+msgstr "Crea una nova entrada"
+
+#: ../../Zotlabs/Widget/Mailmenu.php:13
+msgid "Private Mail Menu"
+msgstr "Menú de Correu Privat"
+
+#: ../../Zotlabs/Widget/Mailmenu.php:15
+msgid "Combined View"
+msgstr "Vista Combinada"
+
+#: ../../Zotlabs/Widget/Mailmenu.php:20
+msgid "Inbox"
+msgstr "Safata d'entrada"
+
+#: ../../Zotlabs/Widget/Mailmenu.php:25
+msgid "Outbox"
+msgstr "Safata de sortida"
+
+#: ../../Zotlabs/Widget/Mailmenu.php:30
+msgid "New Message"
+msgstr "Nou Missatge"
+
+#: ../../Zotlabs/Widget/Chatroom_list.php:16
+#: ../../include/conversation.php:1864 ../../include/conversation.php:1867
+#: ../../include/nav.php:434 ../../include/nav.php:437
+msgid "Chatrooms"
+msgstr "Sala per Xerrar"
+
+#: ../../Zotlabs/Widget/Chatroom_list.php:20
+msgid "Overview"
+msgstr "Visió General"
+
+#: ../../Zotlabs/Widget/Rating.php:51
+msgid "Rating Tools"
+msgstr "Eines de Valoració"
+
+#: ../../Zotlabs/Widget/Rating.php:55 ../../Zotlabs/Widget/Rating.php:57
+msgid "Rate Me"
+msgstr "Valora'm"
+
+#: ../../Zotlabs/Widget/Rating.php:60
+msgid "View Ratings"
+msgstr "Veure Valoracions"
+
+#: ../../Zotlabs/Widget/Activity.php:50
+msgctxt "widget"
+msgid "Activity"
+msgstr "Activitat"
+
+#: ../../Zotlabs/Widget/Follow.php:22
 #, php-format
 msgid "You have %1$.0f of %2$.0f allowed connections."
 msgstr "Tens %1$.0f de %2$.0f connexions permeses."
 
-#: ../../include/widgets.php:181
+#: ../../Zotlabs/Widget/Follow.php:29
 msgid "Add New Connection"
 msgstr "Afegeix una Nova Connexió"
 
-#: ../../include/widgets.php:182
+#: ../../Zotlabs/Widget/Follow.php:30
 msgid "Enter channel address"
 msgstr "Introdueix l'adreça del canal"
 
-#: ../../include/widgets.php:183
+#: ../../Zotlabs/Widget/Follow.php:31
 msgid "Examples: bob@example.com, https://example.com/barbara"
 msgstr "Exemples: bob@example.com, https://exemple.com/barbara"
 
-#: ../../include/widgets.php:199
-msgid "Notes"
-msgstr "Notes"
+#: ../../Zotlabs/Widget/Wiki_list.php:15 ../../addon/gitwiki/gitwiki.php:95
+msgid "Wiki List"
+msgstr "Llista de Wikis"
 
-#: ../../include/widgets.php:273
-msgid "Remove term"
-msgstr "Plaç de remoció"
-
-#: ../../include/widgets.php:281 ../../include/features.php:84
-msgid "Saved Searches"
-msgstr "Cerques Guardades"
-
-#: ../../include/widgets.php:282 ../../include/group.php:316
-msgid "add"
-msgstr "afegeix"
-
-#: ../../include/widgets.php:310 ../../include/contact_widgets.php:53
-#: ../../include/features.php:98
-msgid "Saved Folders"
-msgstr "Carpetes Guardades"
-
-#: ../../include/widgets.php:313 ../../include/widgets.php:432
-#: ../../include/contact_widgets.php:56 ../../include/contact_widgets.php:94
-msgid "Everything"
-msgstr "Tot"
-
-#: ../../include/widgets.php:354
+#: ../../Zotlabs/Widget/Archive.php:43
 msgid "Archives"
 msgstr "Arxius"
 
-#: ../../include/widgets.php:516
-msgid "Refresh"
-msgstr "Refresc"
-
-#: ../../include/widgets.php:556
-msgid "Account settings"
-msgstr "Ajustos de Compte"
-
-#: ../../include/widgets.php:562
-msgid "Channel settings"
-msgstr "Ajustos de Canal"
-
-#: ../../include/widgets.php:571
-msgid "Additional features"
-msgstr "Característiques addicionals"
-
-#: ../../include/widgets.php:578
-msgid "Feature/Addon settings"
-msgstr "Ajustos de Complements"
-
-#: ../../include/widgets.php:584
-msgid "Display settings"
-msgstr "Ajustos de pantalla"
-
-#: ../../include/widgets.php:591
-msgid "Manage locations"
-msgstr "Gestiona ubicacions"
-
-#: ../../include/widgets.php:600
-msgid "Export channel"
-msgstr "Exportat canal"
-
-#: ../../include/widgets.php:607
-msgid "Connected apps"
-msgstr "Apps connectades"
-
-#: ../../include/widgets.php:622
-msgid "Premium Channel Settings"
-msgstr "Ajustos Premium de Canal"
-
-#: ../../include/widgets.php:651
-msgid "Private Mail Menu"
-msgstr "Menú de Correu Privat"
-
-#: ../../include/widgets.php:653
-msgid "Combined View"
-msgstr "Vista Combinada"
-
-#: ../../include/widgets.php:658 ../../include/nav.php:196
-msgid "Inbox"
-msgstr "Safata d'entrada"
-
-#: ../../include/widgets.php:663 ../../include/nav.php:197
-msgid "Outbox"
-msgstr "Safata de sortida"
-
-#: ../../include/widgets.php:668 ../../include/nav.php:198
-msgid "New Message"
-msgstr "Nou Missatge"
-
-#: ../../include/widgets.php:685 ../../include/widgets.php:697
-msgid "Conversations"
-msgstr "Conversacions"
-
-#: ../../include/widgets.php:689
+#: ../../Zotlabs/Widget/Conversations.php:17
 msgid "Received Messages"
 msgstr "Missatges Rebuts"
 
-#: ../../include/widgets.php:693
+#: ../../Zotlabs/Widget/Conversations.php:21
 msgid "Sent Messages"
 msgstr "Missatges Enviats"
 
-#: ../../include/widgets.php:707
+#: ../../Zotlabs/Widget/Conversations.php:25
+msgid "Conversations"
+msgstr "Conversacions"
+
+#: ../../Zotlabs/Widget/Conversations.php:37
 msgid "No messages."
 msgstr "Sense missatges."
 
-#: ../../include/widgets.php:725
+#: ../../Zotlabs/Widget/Conversations.php:57
 msgid "Delete conversation"
 msgstr "Conversació esborrada"
 
-#: ../../include/widgets.php:751
-msgid "Events Menu"
-msgstr "Menú d'Esdeveniments"
-
-#: ../../include/widgets.php:752
-msgid "Day View"
-msgstr "Vista de Dia"
-
-#: ../../include/widgets.php:753
-msgid "Week View"
-msgstr "Vista de Setmana"
-
-#: ../../include/widgets.php:754
-msgid "Month View"
-msgstr "Vista de Mes"
-
-#: ../../include/widgets.php:766
-msgid "Events Tools"
-msgstr "Eina d'Esdeveniments"
-
-#: ../../include/widgets.php:767
-msgid "Export Calendar"
-msgstr "Exportar Calendari"
-
-#: ../../include/widgets.php:768
-msgid "Import Calendar"
-msgstr "Importar Calendari"
-
-#: ../../include/widgets.php:842 ../../include/conversation.php:1662
-#: ../../include/conversation.php:1665
-msgid "Chatrooms"
-msgstr "Sala per Xerrar"
-
-#: ../../include/widgets.php:846
-msgid "Overview"
-msgstr "Visió General"
-
-#: ../../include/widgets.php:853
+#: ../../Zotlabs/Widget/Chatroom_members.php:11
 msgid "Chat Members"
 msgstr "Membres de la Sala de Xat"
 
-#: ../../include/widgets.php:876
-msgid "Bookmarked Chatrooms"
-msgstr "Sales de Xat Favorites"
-
-#: ../../include/widgets.php:899
-msgid "Suggested Chatrooms"
-msgstr "Sales de Xat Suggerides"
-
-#: ../../include/widgets.php:1044 ../../include/widgets.php:1156
+#: ../../Zotlabs/Widget/Photo.php:48 ../../Zotlabs/Widget/Photo_rand.php:58
 msgid "photo/image"
 msgstr "foto/imatge"
 
-#: ../../include/widgets.php:1099
-msgid "Click to show more"
-msgstr "Fes clic per veure més"
+#: ../../Zotlabs/Widget/Savedsearch.php:75
+msgid "Remove term"
+msgstr "Plaç de remoció"
 
-#: ../../include/widgets.php:1250
-msgid "Rating Tools"
-msgstr "Eines de Valoració"
+#: ../../Zotlabs/Widget/Savedsearch.php:83 ../../include/features.php:354
+msgid "Saved Searches"
+msgstr "Cerques Guardades"
 
-#: ../../include/widgets.php:1254 ../../include/widgets.php:1256
-msgid "Rate Me"
-msgstr "Valora'm"
+#: ../../Zotlabs/Widget/Savedsearch.php:84 ../../include/group.php:333
+msgid "add"
+msgstr "afegeix"
 
-#: ../../include/widgets.php:1259
-msgid "View Ratings"
-msgstr "Veure Valoracions"
+#: ../../Zotlabs/Widget/Notes.php:16
+msgid "Notes"
+msgstr "Notes"
 
-#: ../../include/widgets.php:1316
-msgid "Forums"
-msgstr "Forums"
+#: ../../Zotlabs/Widget/Wiki_pages.php:32
+#: ../../Zotlabs/Widget/Wiki_pages.php:89 ../../addon/gitwiki/gitwiki.php:81
+msgid "Add new page"
+msgstr "Afegeix una pàgina nova"
 
-#: ../../include/widgets.php:1345
+#: ../../Zotlabs/Widget/Wiki_pages.php:83 ../../addon/gitwiki/gitwiki.php:76
+msgid "Wiki Pages"
+msgstr "Pàgines de Wikis"
+
+#: ../../Zotlabs/Widget/Wiki_pages.php:94 ../../addon/gitwiki/gitwiki.php:82
+msgid "Page name"
+msgstr "Canvia el nom de la pàgina"
+
+#: ../../Zotlabs/Widget/Affinity.php:45
+msgid "Refresh"
+msgstr "Refresc"
+
+#: ../../Zotlabs/Widget/Tasklist.php:23
 msgid "Tasks"
 msgstr "Tasques"
 
-#: ../../include/widgets.php:1354
-msgid "Documentation"
-msgstr "Documentació"
+#: ../../Zotlabs/Widget/Suggestions.php:51
+msgid "Suggestions"
+msgstr "Suggerencies"
 
-#: ../../include/widgets.php:1356
-msgid "Project/Site Information"
-msgstr "Informació del Projecte/Lloc"
+#: ../../Zotlabs/Widget/Suggestions.php:52
+msgid "See more..."
+msgstr "Veure més....."
 
-#: ../../include/widgets.php:1357
-msgid "For Members"
-msgstr "Per Membres"
+#: ../../Zotlabs/Widget/Filer.php:28 ../../include/contact_widgets.php:53
+#: ../../include/features.php:443
+msgid "Saved Folders"
+msgstr "Carpetes Guardades"
 
-#: ../../include/widgets.php:1358
-msgid "For Administrators"
-msgstr "Per Administradors"
+#: ../../Zotlabs/Widget/Cover_photo.php:54
+msgid "Click to show more"
+msgstr "Fes clic per veure més"
 
-#: ../../include/widgets.php:1359
-msgid "For Developers"
-msgstr "Per Desenvolupadors"
+#: ../../Zotlabs/Widget/Newmember.php:33
+msgid "Profile Creation"
+msgstr "Creació de perfils"
 
-#: ../../include/widgets.php:1383 ../../include/widgets.php:1421
-msgid "Member registrations waiting for confirmation"
-msgstr "Una inscripció per a ser membre està esperant confirmació"
+#: ../../Zotlabs/Widget/Newmember.php:35
+msgid "Upload profile photo"
+msgstr "Puja una foto de perfil"
 
-#: ../../include/widgets.php:1389
-msgid "Inspect queue"
-msgstr "Revisa cua"
+#: ../../Zotlabs/Widget/Newmember.php:36
+msgid "Upload cover photo"
+msgstr "Puja una foto de portada"
 
-#: ../../include/widgets.php:1391
-msgid "DB updates"
-msgstr "Actualitzacions de Base de Dades"
-
-#: ../../include/widgets.php:1416 ../../include/nav.php:216
-msgid "Admin"
-msgstr "Admin"
-
-#: ../../include/widgets.php:1417
-msgid "Plugin Features"
-msgstr "Característiques del Plugin"
-
-#: ../../include/follow.php:27
-msgid "Channel is blocked on this site."
-msgstr "El canal està bloquejat en aquest lloc."
-
-#: ../../include/follow.php:32
-msgid "Channel location missing."
-msgstr "Ubicació del canal perduda."
-
-#: ../../include/follow.php:81
-msgid "Response from remote channel was incomplete."
-msgstr "La resposta del canal remot fou incompleta."
-
-#: ../../include/follow.php:98
-msgid "Channel was deleted and no longer exists."
-msgstr "El canal fou esborrat i actualment no existeix."
-
-#: ../../include/follow.php:154 ../../include/follow.php:190
-msgid "Protocol disabled."
-msgstr "Protocol desactivat."
-
-#: ../../include/follow.php:178
-msgid "Channel discovery failed."
-msgstr "Descobriment de canal fallit."
-
-#: ../../include/follow.php:216
-msgid "Cannot connect to yourself."
-msgstr "No pots connectar amb tu mateix."
-
-#: ../../include/bookmarks.php:35
-#, php-format
-msgid "%1$s's bookmarks"
-msgstr "%1$s de marcadors"
-
-#: ../../include/api.php:1336
-msgid "Public Timeline"
-msgstr "Línia de Temps Pública"
-
-#: ../../include/bbcode.php:123 ../../include/bbcode.php:844
-#: ../../include/bbcode.php:847 ../../include/bbcode.php:852
-#: ../../include/bbcode.php:855 ../../include/bbcode.php:858
-#: ../../include/bbcode.php:861 ../../include/bbcode.php:866
-#: ../../include/bbcode.php:869 ../../include/bbcode.php:874
-#: ../../include/bbcode.php:877 ../../include/bbcode.php:880
-#: ../../include/bbcode.php:883
-msgid "Image/photo"
-msgstr "Imatge/foto"
-
-#: ../../include/bbcode.php:162 ../../include/bbcode.php:894
-msgid "Encrypted content"
-msgstr "Contingut encriptat"
-
-#: ../../include/bbcode.php:178
-#, php-format
-msgid "Install %s element: "
-msgstr "Instal·la l'element %s:"
-
-#: ../../include/bbcode.php:182
-#, php-format
-msgid ""
-"This post contains an installable %s element, however you lack permissions "
-"to install it on this site."
-msgstr "Aquesta entrada contè un element %s instal·lable, potser manques de permissos per instal·lar-lo en aquest lloc."
-
-#: ../../include/bbcode.php:254
-#, php-format
-msgid "%1$s wrote the following %2$s %3$s"
-msgstr "%1$s va escriure el següent %2$s %3$s"
-
-#: ../../include/bbcode.php:331 ../../include/bbcode.php:339
-msgid "Click to open/close"
-msgstr "Clic per obrir/tancar"
-
-#: ../../include/bbcode.php:339
-msgid "spoiler"
-msgstr "xafa guitarres"
-
-#: ../../include/bbcode.php:585
-msgid "Different viewers will see this text differently"
-msgstr "Diferents observadors veuran aquest text de diferents formes"
-
-#: ../../include/bbcode.php:832
-msgid "$1 wrote:"
-msgstr "$1 va escriure:"
-
-#: ../../include/dir_fns.php:141
-msgid "Directory Options"
-msgstr "Opcions de Directori"
-
-#: ../../include/dir_fns.php:143
-msgid "Safe Mode"
-msgstr "Manera Segura"
-
-#: ../../include/dir_fns.php:144
-msgid "Public Forums Only"
-msgstr "Només Fòrums Públics"
-
-#: ../../include/dir_fns.php:145
-msgid "This Website Only"
-msgstr "Només Aquest Lloc Web"
-
-#: ../../include/security.php:383
-msgid ""
-"The form security token was not correct. This probably happened because the "
-"form has been opened for too long (>3 hours) before submitting it."
-msgstr "El formulario de la cadena de seguridad no era correcto. Esto probablemente ocurrió porque el formulario se ha abierto durante demasiado tiempo (> 3 horas) antes de enviarlo."
-
-#: ../../include/nav.php:82 ../../include/nav.php:113 ../../boot.php:1702
-msgid "Logout"
-msgstr "Desconectar"
-
-#: ../../include/nav.php:82 ../../include/nav.php:113
-msgid "End this session"
-msgstr "Finalitza aquesta sessió"
-
-#: ../../include/nav.php:85 ../../include/nav.php:144
-msgid "Home"
-msgstr "Inici"
-
-#: ../../include/nav.php:85
-msgid "Your posts and conversations"
-msgstr "Les teves entrades i converses"
-
-#: ../../include/nav.php:86
-msgid "Your profile page"
-msgstr "La teva pàgina de perfil"
-
-#: ../../include/nav.php:88
-msgid "Manage/Edit profiles"
-msgstr "Gestiona/Edita perfils"
-
-#: ../../include/nav.php:90 ../../include/channel.php:941
-msgid "Edit Profile"
-msgstr "Edita Perfil"
-
-#: ../../include/nav.php:90
+#: ../../Zotlabs/Widget/Newmember.php:37 ../../include/nav.php:119
 msgid "Edit your profile"
 msgstr "Edita el teu perfil"
 
-#: ../../include/nav.php:92
-msgid "Your photos"
-msgstr "Les Teves Fotos"
+#: ../../Zotlabs/Widget/Newmember.php:40
+msgid "Find and Connect with others"
+msgstr "Cerca altres canals i connecta-t'hi"
 
-#: ../../include/nav.php:93
-msgid "Your files"
-msgstr "Els teus arxius"
+#: ../../Zotlabs/Widget/Newmember.php:44
+msgid "Manage your connections"
+msgstr "Gestiona les teves conexions"
 
-#: ../../include/nav.php:96
-msgid "Your chatrooms"
-msgstr "Les teves sales de xerrar"
+#: ../../Zotlabs/Widget/Newmember.php:47
+msgid "Communicate"
+msgstr "Communica't"
 
-#: ../../include/nav.php:102 ../../include/conversation.php:1675
-msgid "Bookmarks"
-msgstr "Marcadors"
+#: ../../Zotlabs/Widget/Newmember.php:49
+msgid "View your channel homepage"
+msgstr "Mostra el teu canal"
 
-#: ../../include/nav.php:102
-msgid "Your bookmarks"
-msgstr "Els teus marcadors"
+#: ../../Zotlabs/Widget/Newmember.php:50
+msgid "View your network stream"
+msgstr "Mostra el teu flux de xarxa"
 
-#: ../../include/nav.php:106
-msgid "Your webpages"
-msgstr "Les teves pàgines web"
+#: ../../Zotlabs/Widget/Newmember.php:56
+msgid "Documentation"
+msgstr "Documentació"
 
-#: ../../include/nav.php:110
-msgid "Sign in"
-msgstr "Signatura"
+#: ../../Zotlabs/Widget/Newmember.php:67
+msgid "View public stream. Warning: not moderated"
+msgstr "Mostra el flux públic. Avís: no està moderat"
 
-#: ../../include/nav.php:127
-#, php-format
-msgid "%s - click to logout"
-msgstr "%s - click per desconectar"
+#: ../../Zotlabs/Widget/Newmember.php:71
+msgid "New Member Links"
+msgstr "Enllaços de membres nous"
 
-#: ../../include/nav.php:130
-msgid "Remote authentication"
-msgstr "Autenticació remota"
+#: ../../Zotlabs/Widget/Admin.php:23 ../../Zotlabs/Widget/Admin.php:60
+msgid "Member registrations waiting for confirmation"
+msgstr "Una inscripció per a ser membre està esperant confirmació"
 
-#: ../../include/nav.php:130
-msgid "Click to authenticate to your home hub"
-msgstr "Clica per autentificar-te en el teu node"
+#: ../../Zotlabs/Widget/Admin.php:29
+msgid "Inspect queue"
+msgstr "Revisa cua"
 
-#: ../../include/nav.php:144
-msgid "Home Page"
-msgstr "Pàgina Personal"
+#: ../../Zotlabs/Widget/Admin.php:31
+msgid "DB updates"
+msgstr "Actualitzacions de Base de Dades"
 
-#: ../../include/nav.php:147
-msgid "Create an account"
-msgstr "Crear un compte"
+#: ../../Zotlabs/Widget/Admin.php:55 ../../include/nav.php:199
+msgid "Admin"
+msgstr "Admin"
 
-#: ../../include/nav.php:159
-msgid "Help and documentation"
-msgstr "Ajuda i documentació"
+#: ../../Zotlabs/Widget/Admin.php:56
+msgid "Plugin Features"
+msgstr "Característiques del Plugin"
 
-#: ../../include/nav.php:163
-msgid "Applications, utilities, links, games"
-msgstr "Aplicacions, utilitats, enllaços, jocs"
+#: ../../Zotlabs/Widget/Settings_menu.php:35
+msgid "Account settings"
+msgstr "Ajustos de Compte"
 
-#: ../../include/nav.php:165
-msgid "Search site @name, #tag, ?docs, content"
-msgstr "Cerca pel lloc @name, #tag, ?docs, contingut"
+#: ../../Zotlabs/Widget/Settings_menu.php:41
+msgid "Channel settings"
+msgstr "Ajustos de Canal"
 
-#: ../../include/nav.php:167
-msgid "Channel Directory"
-msgstr "Directori de Canals"
+#: ../../Zotlabs/Widget/Settings_menu.php:50
+msgid "Additional features"
+msgstr "Característiques addicionals"
 
-#: ../../include/nav.php:179
-msgid "Your grid"
-msgstr "La teva malla"
+#: ../../Zotlabs/Widget/Settings_menu.php:57
+msgid "Addon settings"
+msgstr "Configuració de les extensions"
 
-#: ../../include/nav.php:180
-msgid "Mark all grid notifications seen"
-msgstr "Marca totes les notificacions de la malla vistes"
+#: ../../Zotlabs/Widget/Settings_menu.php:63
+msgid "Display settings"
+msgstr "Ajustos de pantalla"
 
-#: ../../include/nav.php:182
-msgid "Channel home"
-msgstr "Canal personal"
+#: ../../Zotlabs/Widget/Settings_menu.php:70
+msgid "Manage locations"
+msgstr "Gestiona ubicacions"
 
-#: ../../include/nav.php:183
-msgid "Mark all channel notifications seen"
-msgstr "Marca totes les notificacions de canal vistes"
+#: ../../Zotlabs/Widget/Settings_menu.php:77
+msgid "Export channel"
+msgstr "Exportat canal"
 
-#: ../../include/nav.php:189
-msgid "Notices"
-msgstr "Noticies"
+#: ../../Zotlabs/Widget/Settings_menu.php:84
+msgid "Connected apps"
+msgstr "Apps connectades"
 
-#: ../../include/nav.php:189
-msgid "Notifications"
-msgstr "Notificacions"
+#: ../../Zotlabs/Widget/Settings_menu.php:100 ../../include/features.php:231
+msgid "Permission Groups"
+msgstr "Grups de permisos"
 
-#: ../../include/nav.php:190
-msgid "See all notifications"
-msgstr "Veure totes les Notificacions"
+#: ../../Zotlabs/Widget/Settings_menu.php:117
+msgid "Premium Channel Settings"
+msgstr "Ajustos Premium de Canal"
 
-#: ../../include/nav.php:193
-msgid "Private mail"
-msgstr "Correu privat"
+#: ../../Zotlabs/Widget/Bookmarkedchats.php:24
+msgid "Bookmarked Chatrooms"
+msgstr "Sales de Xat Favorites"
 
-#: ../../include/nav.php:194
-msgid "See all private messages"
-msgstr "Veure tots els missatges privats"
+#: ../../Zotlabs/Widget/Notifications.php:16
+msgid "New Network Activity"
+msgstr "Activitat nova a la xarxa"
 
-#: ../../include/nav.php:195
-msgid "Mark all private messages seen"
-msgstr "Marcar tots els missatges privats vistos"
+#: ../../Zotlabs/Widget/Notifications.php:17
+msgid "New Network Activity Notifications"
+msgstr "Notificacions noves d'activitat a la xarxa"
 
-#: ../../include/nav.php:201
-msgid "Event Calendar"
-msgstr "Calendari d'Events"
+#: ../../Zotlabs/Widget/Notifications.php:20
+msgid "View your network activity"
+msgstr "Mostra l'activitat a la xarxa"
 
-#: ../../include/nav.php:202
-msgid "See all events"
-msgstr "Veure tots els esdeveniments"
+#: ../../Zotlabs/Widget/Notifications.php:23
+msgid "Mark all notifications read"
+msgstr "Marca totes les notificacions com a vistes"
 
-#: ../../include/nav.php:203
+#: ../../Zotlabs/Widget/Notifications.php:26
+#: ../../Zotlabs/Widget/Notifications.php:45
+#: ../../Zotlabs/Widget/Notifications.php:141
+msgid "Show new posts only"
+msgstr "Mostra només les entrades noves"
+
+#: ../../Zotlabs/Widget/Notifications.php:27
+#: ../../Zotlabs/Widget/Notifications.php:46
+#: ../../Zotlabs/Widget/Notifications.php:142
+msgid "Filter by name"
+msgstr "Filtra per nom"
+
+#: ../../Zotlabs/Widget/Notifications.php:35
+msgid "New Home Activity"
+msgstr "Activitat nova al mur"
+
+#: ../../Zotlabs/Widget/Notifications.php:36
+msgid "New Home Activity Notifications"
+msgstr "Notificacions noves d'activitat al mur"
+
+#: ../../Zotlabs/Widget/Notifications.php:39
+msgid "View your home activity"
+msgstr "Mostra l'activitat al teu mur"
+
+#: ../../Zotlabs/Widget/Notifications.php:42
+#: ../../Zotlabs/Widget/Notifications.php:138
+msgid "Mark all notifications seen"
+msgstr "Marca totes les notificacions com a vistes"
+
+#: ../../Zotlabs/Widget/Notifications.php:54
+msgid "New Mails"
+msgstr "Correus nous"
+
+#: ../../Zotlabs/Widget/Notifications.php:55
+msgid "New Mails Notifications"
+msgstr "Notificacions noves de correus"
+
+#: ../../Zotlabs/Widget/Notifications.php:58
+msgid "View your private mails"
+msgstr "Mostra els correus privats"
+
+#: ../../Zotlabs/Widget/Notifications.php:61
+msgid "Mark all messages seen"
+msgstr "Marca tots els missatges com a llegits"
+
+#: ../../Zotlabs/Widget/Notifications.php:69
+msgid "New Events"
+msgstr "Esdeveniments nous"
+
+#: ../../Zotlabs/Widget/Notifications.php:70
+msgid "New Events Notifications"
+msgstr "Notificacions noves d'esdeveniments"
+
+#: ../../Zotlabs/Widget/Notifications.php:73
+msgid "View events"
+msgstr "Mostra els esdeveniments"
+
+#: ../../Zotlabs/Widget/Notifications.php:76
 msgid "Mark all events seen"
 msgstr "Marcar tots els esdeveniments vistos"
 
-#: ../../include/nav.php:206
-msgid "Manage Your Channels"
-msgstr "Gestiona els Teus Canals"
+#: ../../Zotlabs/Widget/Notifications.php:85
+msgid "New Connections Notifications"
+msgstr "Notificacions noves de connexió"
 
-#: ../../include/nav.php:208
-msgid "Account/Channel Settings"
-msgstr "Ajustos de Compte/Canal"
+#: ../../Zotlabs/Widget/Notifications.php:88
+msgid "View all connections"
+msgstr "Mostra totes les connexions"
 
-#: ../../include/nav.php:216
-msgid "Site Setup and Configuration"
-msgstr "Ajustos i Configuració del Lloc"
+#: ../../Zotlabs/Widget/Notifications.php:96
+msgid "New Files"
+msgstr "Arxius nous"
 
-#: ../../include/nav.php:247 ../../include/conversation.php:851
-msgid "Loading..."
-msgstr "Carregant..."
+#: ../../Zotlabs/Widget/Notifications.php:97
+msgid "New Files Notifications"
+msgstr "Notificacions noves d'arxius"
 
-#: ../../include/nav.php:252
-msgid "@name, #tag, ?doc, content"
-msgstr "@nom, #etiqueta, ?doc, contingut"
+#: ../../Zotlabs/Widget/Notifications.php:104
+#: ../../Zotlabs/Widget/Notifications.php:105
+msgid "Notices"
+msgstr "Noticies"
 
-#: ../../include/nav.php:253
-msgid "Please wait..."
-msgstr "Si us plau, espera......."
+#: ../../Zotlabs/Widget/Notifications.php:108
+msgid "View all notices"
+msgstr "Mostra totes les notificacions"
 
-#: ../../include/connections.php:95
-msgid "New window"
-msgstr "Nova finestra"
+#: ../../Zotlabs/Widget/Notifications.php:111
+msgid "Mark all notices seen"
+msgstr "Marca totes les notificacions com a vistes"
 
-#: ../../include/connections.php:96
-msgid "Open the selected location in a different window or browser tab"
-msgstr "Obrir la localització seleccionada en un altre finestra o pestanya del navegador"
+#: ../../Zotlabs/Widget/Notifications.php:121
+msgid "New Registrations"
+msgstr "Inscripcions noves"
 
-#: ../../include/connections.php:214
+#: ../../Zotlabs/Widget/Notifications.php:122
+msgid "New Registrations Notifications"
+msgstr "Notificacions noves d'inscripció"
+
+#: ../../Zotlabs/Widget/Notifications.php:132
+msgid "Public Stream Notifications"
+msgstr "Notificacions del flux públic"
+
+#: ../../Zotlabs/Widget/Notifications.php:135
+msgid "View the public stream"
+msgstr "Mostra el flux públic"
+
+#: ../../Zotlabs/Widget/Notifications.php:150
+msgid "Sorry, you have got no notifications at the moment"
+msgstr "No tens cap notificació"
+
+#: ../../util/nconfig.php:34
+msgid "Source channel not found."
+msgstr "No s'ha trobat el canal font."
+
+#: ../../boot.php:1562
+msgid "Create an account to access services and applications"
+msgstr "Crea un compte per tal d'accedir a serveis i aplicacions"
+
+#: ../../boot.php:1581 ../../include/nav.php:111 ../../include/nav.php:140
+#: ../../include/nav.php:159
+msgid "Logout"
+msgstr "Desconectar"
+
+#: ../../boot.php:1585
+msgid "Login/Email"
+msgstr "Correu d'usuari"
+
+#: ../../boot.php:1586
+msgid "Password"
+msgstr "Contrasenya"
+
+#: ../../boot.php:1587
+msgid "Remember me"
+msgstr "Recorda'm"
+
+#: ../../boot.php:1590
+msgid "Forgot your password?"
+msgstr "Has perdut la Contrasenya?"
+
+#: ../../boot.php:2347
 #, php-format
-msgid "User '%s' deleted"
-msgstr "usuari '%s' esborrat"
+msgid "[$Projectname] Website SSL error for %s"
+msgstr "[$Projectname] Error de TLS per a %s"
 
-#: ../../include/contact_widgets.php:11
+#: ../../boot.php:2352
+msgid "Website SSL certificate is not valid. Please correct."
+msgstr "El certificat SSL és invalid, soluciona-ho, si us plau."
+
+#: ../../boot.php:2468
 #, php-format
-msgid "%d invitation available"
-msgid_plural "%d invitations available"
-msgstr[0] "%d invitació disponible"
-msgstr[1] "%d invitacions disponibles"
+msgid "[$Projectname] Cron tasks not running on %s"
+msgstr "[$Projectname] Les tasques del cron tasks no s'estan executant a %s"
 
-#: ../../include/contact_widgets.php:19
-msgid "Find Channels"
-msgstr "Troba Canals"
+#: ../../boot.php:2473
+msgid "Cron/Scheduled tasks not running."
+msgstr "No s'estan executant les tasques programades al cron."
 
-#: ../../include/contact_widgets.php:20
-msgid "Enter name or interest"
-msgstr "Entra un nom o interes"
+#: ../../boot.php:2474 ../../include/datetime.php:232
+msgid "never"
+msgstr "mai"
 
-#: ../../include/contact_widgets.php:21
-msgid "Connect/Follow"
-msgstr "Conecta/Segueix"
+#: ../../view/theme/redbasic_c/php/config.php:16
+#: ../../view/theme/redbasic_c/php/config.php:19
+#: ../../view/theme/redbasic/php/config.php:16
+#: ../../view/theme/redbasic/php/config.php:19
+msgid "Focus (Hubzilla default)"
+msgstr "Focus (Hubzilla per defecte)"
 
-#: ../../include/contact_widgets.php:22
-msgid "Examples: Robert Morgenstein, Fishing"
-msgstr "Exemples: Lionel Messi, Futbolista"
+#: ../../view/theme/redbasic_c/php/config.php:99
+#: ../../view/theme/redbasic/php/config.php:97
+msgid "Theme settings"
+msgstr "Ajustos de tema"
 
-#: ../../include/contact_widgets.php:26
-msgid "Random Profile"
-msgstr "Perfil Aleatori"
+#: ../../view/theme/redbasic_c/php/config.php:100
+#: ../../view/theme/redbasic/php/config.php:98
+msgid "Narrow navbar"
+msgstr "Barra de navegació estreta"
 
-#: ../../include/contact_widgets.php:27
-msgid "Invite Friends"
-msgstr "Convida Amics"
+#: ../../view/theme/redbasic_c/php/config.php:101
+#: ../../view/theme/redbasic/php/config.php:99
+msgid "Navigation bar background color"
+msgstr "Color de fons de la barra de navegació"
 
-#: ../../include/contact_widgets.php:29
-msgid "Advanced example: name=fred and country=iceland"
-msgstr "Exemple avançat: nom=pep i pais=eire"
+#: ../../view/theme/redbasic_c/php/config.php:102
+#: ../../view/theme/redbasic/php/config.php:100
+msgid "Navigation bar icon color "
+msgstr "Color de la icona de la barra de navegació"
 
-#: ../../include/contact_widgets.php:122
+#: ../../view/theme/redbasic_c/php/config.php:103
+#: ../../view/theme/redbasic/php/config.php:101
+msgid "Navigation bar active icon color "
+msgstr "Color de la icona de la barra de navegació activa"
+
+#: ../../view/theme/redbasic_c/php/config.php:104
+#: ../../view/theme/redbasic/php/config.php:102
+msgid "Link color"
+msgstr "Color dels enllaços"
+
+#: ../../view/theme/redbasic_c/php/config.php:105
+#: ../../view/theme/redbasic/php/config.php:103
+msgid "Set font-color for banner"
+msgstr "Ajusta el color del tipus de lletra per la senyera"
+
+#: ../../view/theme/redbasic_c/php/config.php:106
+#: ../../view/theme/redbasic/php/config.php:104
+msgid "Set the background color"
+msgstr "Ajusta el color de fons"
+
+#: ../../view/theme/redbasic_c/php/config.php:107
+#: ../../view/theme/redbasic/php/config.php:105
+msgid "Set the background image"
+msgstr "Ajusta la imatge de fons"
+
+#: ../../view/theme/redbasic_c/php/config.php:108
+#: ../../view/theme/redbasic/php/config.php:106
+msgid "Set the background color of items"
+msgstr "ajusta el color dels articles de fons"
+
+#: ../../view/theme/redbasic_c/php/config.php:109
+#: ../../view/theme/redbasic/php/config.php:107
+msgid "Set the background color of comments"
+msgstr "Ajusta el color dels comentaris en segon pla"
+
+#: ../../view/theme/redbasic_c/php/config.php:110
+#: ../../view/theme/redbasic/php/config.php:108
+msgid "Set font-size for the entire application"
+msgstr "Ajusta la mida del tipus de lletra per tota l'aplicació"
+
+#: ../../view/theme/redbasic_c/php/config.php:110
+#: ../../view/theme/redbasic/php/config.php:108
+msgid "Examples: 1rem, 100%, 16px"
+msgstr "Exemples: 1rem, 100%, 16px"
+
+#: ../../view/theme/redbasic_c/php/config.php:111
+#: ../../view/theme/redbasic/php/config.php:109
+msgid "Set font-color for posts and comments"
+msgstr "Ajusta el color del tipus de lletra per entrades i comentaris"
+
+#: ../../view/theme/redbasic_c/php/config.php:112
+#: ../../view/theme/redbasic/php/config.php:110
+msgid "Set radius of corners"
+msgstr "Ajusta el radi de les cantonades"
+
+#: ../../view/theme/redbasic_c/php/config.php:112
+#: ../../view/theme/redbasic/php/config.php:110
+msgid "Example: 4px"
+msgstr "Exemple: 4px"
+
+#: ../../view/theme/redbasic_c/php/config.php:113
+#: ../../view/theme/redbasic/php/config.php:111
+msgid "Set shadow depth of photos"
+msgstr "Ajusta la profunditat d'ombres de les fotos"
+
+#: ../../view/theme/redbasic_c/php/config.php:114
+#: ../../view/theme/redbasic/php/config.php:112
+msgid "Set maximum width of content region in pixel"
+msgstr "Ajusta l'amplada màxima de la zona de contingut en pixels"
+
+#: ../../view/theme/redbasic_c/php/config.php:114
+#: ../../view/theme/redbasic/php/config.php:112
+msgid "Leave empty for default width"
+msgstr "Deixa en blanc per l'amplada predeterminada"
+
+#: ../../view/theme/redbasic_c/php/config.php:115
+msgid "Left align page content"
+msgstr "Alineació esquerra del contingut de la pàgina"
+
+#: ../../view/theme/redbasic_c/php/config.php:116
+#: ../../view/theme/redbasic/php/config.php:113
+msgid "Set size of conversation author photo"
+msgstr "Ajusta la mida de la foto del autor a la conversa"
+
+#: ../../view/theme/redbasic_c/php/config.php:117
+#: ../../view/theme/redbasic/php/config.php:114
+msgid "Set size of followup author photos"
+msgstr "Ajusta la mida del seguidor de les fotos de l'autor"
+
+#: ../../addon/rendezvous/rendezvous.php:57
+msgid "Errors encountered deleting database table "
+msgstr "S'ha produït un o més errors en esborrar una taula de la base de dades"
+
+#: ../../addon/rendezvous/rendezvous.php:95
+#: ../../addon/twitter/twitter.php:779
+msgid "Submit Settings"
+msgstr "Desa els canvis"
+
+#: ../../addon/rendezvous/rendezvous.php:96
+msgid "Drop tables when uninstalling?"
+msgstr "Vols eliminar les taules en desinstaŀlar?"
+
+#: ../../addon/rendezvous/rendezvous.php:96
+msgid ""
+"If checked, the Rendezvous database tables will be deleted when the plugin "
+"is uninstalled."
+msgstr "En cas afirmatiu, s'esborraran de la base de dades les taules del Rendezvous en desinstaŀlar l'extensió."
+
+#: ../../addon/rendezvous/rendezvous.php:97
+msgid "Mapbox Access Token"
+msgstr "Testimoni d'accés a Mapbox"
+
+#: ../../addon/rendezvous/rendezvous.php:97
+msgid ""
+"If you enter a Mapbox access token, it will be used to retrieve map tiles "
+"from Mapbox instead of the default OpenStreetMap tile server."
+msgstr "Es farà servir aquest testimoni per a descarregar les tesseŀles des de Mapbox en comptes del servidor per defecte d'OpenStreetMap."
+
+#: ../../addon/rendezvous/rendezvous.php:162
+msgid "Rendezvous"
+msgstr "Rendezvous"
+
+#: ../../addon/rendezvous/rendezvous.php:167
+msgid ""
+"This identity has been deleted by another member due to inactivity. Please "
+"press the \"New identity\" button or refresh the page to register a new "
+"identity. You may use the same name."
+msgstr "Un altre membre ha esborrat aquesta identitat per inactivitat. Pots crear-ne una nova amb el botó o recarregant la pàgina. Pots tornar a fer servir el mateix nom."
+
+#: ../../addon/rendezvous/rendezvous.php:168
+msgid "Welcome to Rendezvous!"
+msgstr "Benvingut/da al Rendezvous!"
+
+#: ../../addon/rendezvous/rendezvous.php:169
+msgid ""
+"Enter your name to join this rendezvous. To begin sharing your location with"
+" the other members, tap the GPS control. When your location is discovered, a"
+" red dot will appear and others will be able to see you on the map."
+msgstr "Escriu un nom per unir-te an aquest Rendezvous. Per a començar compartint la teva ubicació amb els altres membres, toca el control de GPS. Un cop descoberta la teva ubicació, apareixerà un punt vermell i la resta podran veure't en el mapa."
+
+#: ../../addon/rendezvous/rendezvous.php:171
+msgid "Let's meet here"
+msgstr "Trobem-nos aquí"
+
+#: ../../addon/rendezvous/rendezvous.php:174
+msgid "New marker"
+msgstr "Nova xinxeta"
+
+#: ../../addon/rendezvous/rendezvous.php:175
+msgid "Edit marker"
+msgstr "Modifica la xinxeta"
+
+#: ../../addon/rendezvous/rendezvous.php:176
+msgid "New identity"
+msgstr "Nova identitat"
+
+#: ../../addon/rendezvous/rendezvous.php:177
+msgid "Delete marker"
+msgstr "Esborra la xinxeta"
+
+#: ../../addon/rendezvous/rendezvous.php:178
+msgid "Delete member"
+msgstr "Esborra el membre"
+
+#: ../../addon/rendezvous/rendezvous.php:179
+msgid "Edit proximity alert"
+msgstr "Modifica l'alerta de proximitat"
+
+#: ../../addon/rendezvous/rendezvous.php:180
+msgid ""
+"A proximity alert will be issued when this member is within a certain radius"
+" of you.<br><br>Enter a radius in meters (0 to disable):"
+msgstr "Es mostrarà una alerta de proximitat si aquest membre està dins un cert radi de distància. <br><br>Introdueix un radi en metres (0 ho deshabilita):"
+
+#: ../../addon/rendezvous/rendezvous.php:180
+#: ../../addon/rendezvous/rendezvous.php:185
+msgid "distance"
+msgstr "distància"
+
+#: ../../addon/rendezvous/rendezvous.php:181
+msgid "Proximity alert distance (meters)"
+msgstr "Distància d'alerta de proximitat (metres)"
+
+#: ../../addon/rendezvous/rendezvous.php:182
+#: ../../addon/rendezvous/rendezvous.php:184
+msgid ""
+"A proximity alert will be issued when you are within a certain radius of the"
+" marker location.<br><br>Enter a radius in meters (0 to disable):"
+msgstr "Es mostrarà una alerta de proximitat quan siguis dins un cert radi de distància de la ubicació de la xinxeta.<br><br>Introdueix un radi en metres (0 ho deshabilita):"
+
+#: ../../addon/rendezvous/rendezvous.php:183
+msgid "Marker proximity alert"
+msgstr "Alerta de proximitat de xinxeta"
+
+#: ../../addon/rendezvous/rendezvous.php:186
+msgid "Reminder note"
+msgstr "Nota de recordatori"
+
+#: ../../addon/rendezvous/rendezvous.php:187
+msgid ""
+"Enter a note to be displayed when you are within the specified proximity..."
+msgstr "Introdueix una nota per a mostrar amb l'alerta"
+
+#: ../../addon/rendezvous/rendezvous.php:199
+msgid "Add new rendezvous"
+msgstr "Afegeix un rendezvous nou"
+
+#: ../../addon/rendezvous/rendezvous.php:200
+msgid ""
+"Create a new rendezvous and share the access link with those you wish to "
+"invite to the group. Those who open the link become members of the "
+"rendezvous. They can view other member locations, add markers to the map, or"
+" share their own locations with the group."
+msgstr "Crea un rendezvous nou i comparteix-lo amb aquelles persones a qui vulguis convidar al grup. Qui obri l'enllaç es faran membres del rendezvous. Podran veure les ubicacions dels altres membres, afegir xinxetes al mapa i compartir les seves ubicacions amb el grup."
+
+#: ../../addon/skeleton/skeleton.php:59
+msgid "Some setting"
+msgstr "Opció X"
+
+#: ../../addon/skeleton/skeleton.php:61
+msgid "A setting"
+msgstr "Opció Y"
+
+#: ../../addon/skeleton/skeleton.php:64
+msgid "Skeleton Settings"
+msgstr "Configuració del Skeleton"
+
+#: ../../addon/gnusoc/gnusoc.php:247
+msgid "GNU-Social Protocol Settings updated."
+msgstr "S'ha actualitzat la configuració del Protocol GNU-Social"
+
+#: ../../addon/gnusoc/gnusoc.php:266
+msgid ""
+"The GNU-Social protocol does not support location independence. Connections "
+"you make within that network may be unreachable from alternate channel "
+"locations."
+msgstr "El Protocol GNU-Social és incompatible amb la independència de hub. Les connexions que facis en aquesta xarxa no seran accessibles des de hubs alternatius del teu canal."
+
+#: ../../addon/gnusoc/gnusoc.php:269
+msgid "Enable the GNU-Social protocol for this channel"
+msgstr "Habilita el Protocol GNU-Social per a aquest canal"
+
+#: ../../addon/gnusoc/gnusoc.php:273
+msgid "GNU-Social Protocol Settings"
+msgstr "Configuració del Protocol GNU-Social "
+
+#: ../../addon/gnusoc/gnusoc.php:464
+msgid "Follow"
+msgstr "Segueix"
+
+#: ../../addon/gnusoc/gnusoc.php:467
 #, php-format
-msgid "%d connection in common"
-msgid_plural "%d connections in common"
-msgstr[0] "%d connexió en comú"
-msgstr[1] "%d connexions en comú"
+msgid "%1$s is now following %2$s"
+msgstr "%1$s ara segueix a %2$s"
 
-#: ../../include/contact_widgets.php:127
-msgid "show more"
-msgstr "mostrar més"
+#: ../../addon/planets/planets.php:121
+msgid "Planets Settings updated."
+msgstr "S'ha actualitzat la configuració de Planetes."
 
-#: ../../include/conversation.php:204
+#: ../../addon/planets/planets.php:149
+msgid "Enable Planets Plugin"
+msgstr "Habilita l'extensió Planetes"
+
+#: ../../addon/planets/planets.php:153
+msgid "Planets Settings"
+msgstr "Configuració de Planetes"
+
+#: ../../addon/openclipatar/openclipatar.php:50
+#: ../../addon/openclipatar/openclipatar.php:128
+msgid "System defaults:"
+msgstr "Opcions per defecte:"
+
+#: ../../addon/openclipatar/openclipatar.php:54
+msgid "Preferred Clipart IDs"
+msgstr "Identitats Clipart preferides"
+
+#: ../../addon/openclipatar/openclipatar.php:54
+msgid "List of preferred clipart ids. These will be shown first."
+msgstr "Llista d'identitats Clipart preferides. Aquestes es mostren primer"
+
+#: ../../addon/openclipatar/openclipatar.php:55
+msgid "Default Search Term"
+msgstr "Paraula de cerca predeterminada"
+
+#: ../../addon/openclipatar/openclipatar.php:55
+msgid "The default search term. These will be shown second."
+msgstr "La paraula de cerca predeterminada. Aquestes es mostraran en segon lloc."
+
+#: ../../addon/openclipatar/openclipatar.php:56
+msgid "Return After"
+msgstr "Acaba després de"
+
+#: ../../addon/openclipatar/openclipatar.php:56
+msgid "Page to load after image selection."
+msgstr "Pàgina per carregar després d'haver seleccionat una imatge."
+
+#: ../../addon/openclipatar/openclipatar.php:58 ../../include/channel.php:1301
+#: ../../include/nav.php:119
+msgid "Edit Profile"
+msgstr "Edita Perfil"
+
+#: ../../addon/openclipatar/openclipatar.php:59
+msgid "Profile List"
+msgstr "Llista de perfils"
+
+#: ../../addon/openclipatar/openclipatar.php:61
+msgid "Order of Preferred"
+msgstr "Ordre de les preferides"
+
+#: ../../addon/openclipatar/openclipatar.php:61
+msgid "Sort order of preferred clipart ids."
+msgstr "Ordena les identitats Clipart preferides"
+
+#: ../../addon/openclipatar/openclipatar.php:62
+#: ../../addon/openclipatar/openclipatar.php:68
+msgid "Newest first"
+msgstr "La més nova primer"
+
+#: ../../addon/openclipatar/openclipatar.php:65
+msgid "As entered"
+msgstr "En ordre d'entrada"
+
+#: ../../addon/openclipatar/openclipatar.php:67
+msgid "Order of other"
+msgstr "Ordre de les altres"
+
+#: ../../addon/openclipatar/openclipatar.php:67
+msgid "Sort order of other clipart ids."
+msgstr "Ordena les altres identitats Clipart."
+
+#: ../../addon/openclipatar/openclipatar.php:69
+msgid "Most downloaded first"
+msgstr "Les més descarregades primer"
+
+#: ../../addon/openclipatar/openclipatar.php:70
+msgid "Most liked first"
+msgstr "Les més votades primer"
+
+#: ../../addon/openclipatar/openclipatar.php:72
+msgid "Preferred IDs Message"
+msgstr "Missatge de les identitats preferides"
+
+#: ../../addon/openclipatar/openclipatar.php:72
+msgid "Message to display above preferred results."
+msgstr "Missatge per a mostrar per sobre dels resultats preferits."
+
+#: ../../addon/openclipatar/openclipatar.php:78
+msgid "Uploaded by: "
+msgstr "Carregada per:"
+
+#: ../../addon/openclipatar/openclipatar.php:78
+msgid "Drawn by: "
+msgstr "Dibuixada per:"
+
+#: ../../addon/openclipatar/openclipatar.php:182
+#: ../../addon/openclipatar/openclipatar.php:194
+msgid "Use this image"
+msgstr "Fes servir aquesta imatge"
+
+#: ../../addon/openclipatar/openclipatar.php:192
+msgid "Or select from a free OpenClipart.org image:"
+msgstr "O bé tria una imatge lliure d'OpenClipart.org:"
+
+#: ../../addon/openclipatar/openclipatar.php:195
+msgid "Search Term"
+msgstr "Paraules de cerca"
+
+#: ../../addon/openclipatar/openclipatar.php:232
+msgid "Unknown error. Please try again later."
+msgstr "S'ha produït un error desconegut. Torna a provar-ho més tard."
+
+#: ../../addon/openclipatar/openclipatar.php:308
+msgid "Profile photo updated successfully."
+msgstr "S'ha carregat la foto amb èxit."
+
+#: ../../addon/adultphotoflag/adultphotoflag.php:24
+msgid "Flag Adult Photos"
+msgstr "Marca contingut adult"
+
+#: ../../addon/adultphotoflag/adultphotoflag.php:25
+msgid ""
+"Provide photo edit option to hide inappropriate photos from default album "
+"view"
+msgstr "Habilita una opció per a amagar fotos sensibles de la vista per defecte de l'àlbum."
+
+#: ../../addon/wppost/wppost.php:45
+msgid "Post to WordPress"
+msgstr "Publica a un Wordpress"
+
+#: ../../addon/wppost/wppost.php:82
+msgid "Enable WordPress Post Plugin"
+msgstr "Activa l'extensió Publica a un Wordpress"
+
+#: ../../addon/wppost/wppost.php:86
+msgid "WordPress username"
+msgstr "Nom d'usuari al Wordpress"
+
+#: ../../addon/wppost/wppost.php:90
+msgid "WordPress password"
+msgstr "Contrassenya al Wordpress"
+
+#: ../../addon/wppost/wppost.php:94
+msgid "WordPress API URL"
+msgstr "Adreça URL de l'API del Wordpress"
+
+#: ../../addon/wppost/wppost.php:95
+msgid "Typically https://your-blog.tld/xmlrpc.php"
+msgstr "Normalment https://el-meu-blog.cat/xmlrpc.php"
+
+#: ../../addon/wppost/wppost.php:98
+msgid "WordPress blogid"
+msgstr "Identitat blogid del Wordpress"
+
+#: ../../addon/wppost/wppost.php:99
+msgid "For multi-user sites such as wordpress.com, otherwise leave blank"
+msgstr "Fer a llocs multi-usuari com wordpress.com . Deixa en blanc en cas contrari"
+
+#: ../../addon/wppost/wppost.php:105
+msgid "Post to WordPress by default"
+msgstr "Publica a Wordpress per defecte"
+
+#: ../../addon/wppost/wppost.php:109
+msgid "Forward comments (requires hubzilla_wp plugin)"
+msgstr "Reenvia comentaris (necessita l'extensió hubzilla_wp)"
+
+#: ../../addon/wppost/wppost.php:113
+msgid "WordPress Post Settings"
+msgstr "Configuració d'entrades"
+
+#: ../../addon/wppost/wppost.php:129
+msgid "Wordpress Settings saved."
+msgstr "S'ha desat la configuració."
+
+#: ../../addon/nsfw/nsfw.php:80
+msgid ""
+"This plugin looks in posts for the words/text you specify below, and "
+"collapses any content containing those keywords so it is not displayed at "
+"inappropriate times, such as sexual innuendo that may be improper in a work "
+"setting. It is polite and recommended to tag any content containing nudity "
+"with #NSFW.  This filter can also match any other word/text you specify, and"
+" can thereby be used as a general purpose content filter."
+msgstr "Aquesta extensió cerca paraules que especifiquis en les entrades, i amaga plegant qualsevol contingut que en contingui alguna. Així, no es mostrarà per defecte i no quedaràs exposat/da en llocs on més gent vegi la teva pantalla. Sempre es recomana etiquetar els continguts amb nuesa amb l'etiqueta #NSFW (insegur per a la feina, en anglès). Tanmateix, el filtre es pot fer servir per qualsevol tipus de contingut."
+
+#: ../../addon/nsfw/nsfw.php:84
+msgid "Enable Content filter"
+msgstr "Activa el filtre de contingut"
+
+#: ../../addon/nsfw/nsfw.php:88
+msgid "Comma separated list of keywords to hide"
+msgstr "Llista de paraules clau a amagar, separada per comes"
+
+#: ../../addon/nsfw/nsfw.php:88
+msgid "Word, /regular-expression/, lang=xx, lang!=xx"
+msgstr "Paraula, /expressió-regular/, lang=xx, lang=!xx. Nota: lang és per llengua en anglès"
+
+#: ../../addon/nsfw/nsfw.php:92
+msgid "Not Safe For Work Settings"
+msgstr "Configuració de Not Safe For Work"
+
+#: ../../addon/nsfw/nsfw.php:92
+msgid "General Purpose Content Filter"
+msgstr "Filtre de contingut genèric"
+
+#: ../../addon/nsfw/nsfw.php:110
+msgid "NSFW Settings saved."
+msgstr "S'ha desat la configuració del NSFW."
+
+#: ../../addon/nsfw/nsfw.php:207
+msgid "Possible adult content"
+msgstr "Possible contingut inadequat"
+
+#: ../../addon/nsfw/nsfw.php:222
 #, php-format
-msgid "%1$s is now connected with %2$s"
-msgstr "%1$s esta ara connectat amb %2$s"
+msgid "%s - view"
+msgstr "%s - mostra"
 
-#: ../../include/conversation.php:239
+#: ../../addon/ijpost/ijpost.php:42
+msgid "Post to Insanejournal"
+msgstr "Publicar a Insanejournal"
+
+#: ../../addon/ijpost/ijpost.php:73
+msgid "Enable InsaneJournal Post Plugin"
+msgstr "Habilita la publicació a InsaneJournal"
+
+#: ../../addon/ijpost/ijpost.php:77
+msgid "InsaneJournal username"
+msgstr "Nom d'usuari a InsaneJournal"
+
+#: ../../addon/ijpost/ijpost.php:81
+msgid "InsaneJournal password"
+msgstr "Contrasenya a InsaneJournal"
+
+#: ../../addon/ijpost/ijpost.php:85
+msgid "Post to InsaneJournal by default"
+msgstr "Publica per defecte a InsaneJournal"
+
+#: ../../addon/ijpost/ijpost.php:89
+msgid "InsaneJournal Post Settings"
+msgstr "Opcions de publicació a InsaneJournal"
+
+#: ../../addon/ijpost/ijpost.php:104
+msgid "Insane Journal Settings saved."
+msgstr "S'han actualitzat els paàrmetres de InsaneJournal."
+
+#: ../../addon/dwpost/dwpost.php:42
+msgid "Post to Dreamwidth"
+msgstr "Publica a Dreamwidth"
+
+#: ../../addon/dwpost/dwpost.php:73
+msgid "Enable Dreamwidth Post Plugin"
+msgstr "Habilita el connector per a publicar a la xarxa Dreamwidth"
+
+#: ../../addon/dwpost/dwpost.php:77
+msgid "Dreamwidth username"
+msgstr "Nom a Dreamwidth"
+
+#: ../../addon/dwpost/dwpost.php:81
+msgid "Dreamwidth password"
+msgstr "Contrasenya a Dreamwidth"
+
+#: ../../addon/dwpost/dwpost.php:85
+msgid "Post to Dreamwidth by default"
+msgstr "Publica a Dreamwidth per defecte"
+
+#: ../../addon/dwpost/dwpost.php:89
+msgid "Dreamwidth Post Settings"
+msgstr "Opcions de publicació a Dreamwidth"
+
+#: ../../addon/notifyadmin/notifyadmin.php:34
+msgid "New registration"
+msgstr "S'ha registrat un nou compte"
+
+#: ../../addon/notifyadmin/notifyadmin.php:42
 #, php-format
-msgid "%1$s poked %2$s"
-msgstr "%1$s  a esperonat %2$s"
+msgid "Message sent to %s. New account registration: %s"
+msgstr "S'ha enviat el correu a %s. El nou compte és %s"
 
-#: ../../include/conversation.php:691
+#: ../../addon/dirstats/dirstats.php:94
+msgid "Hubzilla Directory Stats"
+msgstr "Estadístiques del directori de Hubzilla"
+
+#: ../../addon/dirstats/dirstats.php:95
+msgid "Total Hubs"
+msgstr "Hubs totals"
+
+#: ../../addon/dirstats/dirstats.php:97
+msgid "Hubzilla Hubs"
+msgstr "Hubs de Hubzilla"
+
+#: ../../addon/dirstats/dirstats.php:99
+msgid "Friendica Hubs"
+msgstr "Hubs de Friendica"
+
+#: ../../addon/dirstats/dirstats.php:101
+msgid "Diaspora Pods"
+msgstr "Pods de Diaspora"
+
+#: ../../addon/dirstats/dirstats.php:103
+msgid "Hubzilla Channels"
+msgstr "Canals de Hubzilla"
+
+#: ../../addon/dirstats/dirstats.php:105
+msgid "Friendica Channels"
+msgstr "Canals de Friendica"
+
+#: ../../addon/dirstats/dirstats.php:107
+msgid "Diaspora Channels"
+msgstr "Canals de Diaspora"
+
+#: ../../addon/dirstats/dirstats.php:109
+msgid "Aged 35 and above"
+msgstr "De 35 o més anys d'edat"
+
+#: ../../addon/dirstats/dirstats.php:111
+msgid "Aged 34 and under"
+msgstr "De 34 o menys anys d'edat"
+
+#: ../../addon/dirstats/dirstats.php:113
+msgid "Average Age"
+msgstr "Mitjana d'edat"
+
+#: ../../addon/dirstats/dirstats.php:115
+msgid "Known Chatrooms"
+msgstr "Sales de xat conegudes"
+
+#: ../../addon/dirstats/dirstats.php:117
+msgid "Known Tags"
+msgstr "Etiquetes conegudes"
+
+#: ../../addon/dirstats/dirstats.php:119
+msgid ""
+"Please note Diaspora and Friendica statistics are merely those **this "
+"directory** is aware of, and not all those known in the network.  This also "
+"applies to chatrooms,"
+msgstr "Tingueu en compte que les estadístiques de Diaspora i Friendica només són les **aquest directori** n'és conscient, i no totes les de la xarxa. Això també aplica a sales de xat,"
+
+#: ../../addon/likebanner/likebanner.php:51
+msgid "Your Webbie:"
+msgstr "El teu Webbie:"
+
+#: ../../addon/likebanner/likebanner.php:54
+msgid "Fontsize (px):"
+msgstr "Mida de lletra (px):"
+
+#: ../../addon/likebanner/likebanner.php:68
+msgid "Link:"
+msgstr "Enllaç:"
+
+#: ../../addon/likebanner/likebanner.php:70
+msgid "Like us on Hubzilla"
+msgstr "Segueix-nos a Hubzilla"
+
+#: ../../addon/likebanner/likebanner.php:72
+msgid "Embed:"
+msgstr "Incrusta:"
+
+#: ../../addon/redphotos/redphotos.php:106
+msgid "Photos imported"
+msgstr "S'han importat les fotos"
+
+#: ../../addon/redphotos/redphotos.php:129
+msgid "Redmatrix Photo Album Import"
+msgstr "Importa els àlbums de fotos de $Projectname"
+
+#: ../../addon/redphotos/redphotos.php:130
+msgid "This will import all your Redmatrix photo albums to this channel."
+msgstr "Importa els àlbums de fotos de $Projectname"
+
+#: ../../addon/redphotos/redphotos.php:131
+#: ../../addon/redfiles/redfiles.php:121
+msgid "Redmatrix Server base URL"
+msgstr "Adreça URL arrel del servidor de Redmatrix"
+
+#: ../../addon/redphotos/redphotos.php:132
+#: ../../addon/redfiles/redfiles.php:122
+msgid "Redmatrix Login Username"
+msgstr "Nom d'usuari de Redmatrix"
+
+#: ../../addon/redphotos/redphotos.php:133
+#: ../../addon/redfiles/redfiles.php:123
+msgid "Redmatrix Login Password"
+msgstr "Contrasenya de Redmatrix"
+
+#: ../../addon/redphotos/redphotos.php:134
+msgid "Import just this album"
+msgstr "Importa només aquest album"
+
+#: ../../addon/redphotos/redphotos.php:134
+msgid "Leave blank to import all albums"
+msgstr "Deixa-ho en blanc per a importar tots els àlbums"
+
+#: ../../addon/redphotos/redphotos.php:135
+msgid "Maximum count to import"
+msgstr "Nombre màxim d'importacions"
+
+#: ../../addon/redphotos/redphotos.php:135
+msgid "0 or blank to import all available"
+msgstr "Deixa-ho en blanc o amb un 0 per a importar-ho tot"
+
+#: ../../addon/irc/irc.php:45
+msgid "Channels to auto connect"
+msgstr "Canals per connectar automàticament"
+
+#: ../../addon/irc/irc.php:45 ../../addon/irc/irc.php:49
+msgid "Comma separated list"
+msgstr "Llista amb separació per comes"
+
+#: ../../addon/irc/irc.php:49 ../../addon/irc/irc.php:96
+msgid "Popular Channels"
+msgstr "Canals populars"
+
+#: ../../addon/irc/irc.php:53
+msgid "IRC Settings"
+msgstr "Paràmetres de IRC"
+
+#: ../../addon/irc/irc.php:69
+msgid "IRC settings saved."
+msgstr "S'han actualitzat els paràmetres de IRC."
+
+#: ../../addon/irc/irc.php:74
+msgid "IRC Chatroom"
+msgstr "Sala de IRC"
+
+#: ../../addon/ljpost/ljpost.php:42
+msgid "Post to LiveJournal"
+msgstr "Publica a LiveJournal"
+
+#: ../../addon/ljpost/ljpost.php:70
+msgid "Enable LiveJournal Post Plugin"
+msgstr "Habilita la publicació a LiveJournal"
+
+#: ../../addon/ljpost/ljpost.php:74
+msgid "LiveJournal username"
+msgstr "Nom a LiveJournal"
+
+#: ../../addon/ljpost/ljpost.php:78
+msgid "LiveJournal password"
+msgstr "Contrasenya a LiveJournal"
+
+#: ../../addon/ljpost/ljpost.php:82
+msgid "Post to LiveJournal by default"
+msgstr "Publica a LiveJournal per defecte"
+
+#: ../../addon/ljpost/ljpost.php:86
+msgid "LiveJournal Post Settings"
+msgstr "Paràmetres de LiveJournal"
+
+#: ../../addon/ljpost/ljpost.php:101
+msgid "LiveJournal Settings saved."
+msgstr "S'han desat els paràmetres de LiveJournal."
+
+#: ../../addon/openid/openid.php:49
+msgid ""
+"We encountered a problem while logging in with the OpenID you provided. "
+"Please check the correct spelling of the ID."
+msgstr "No s'ha pogut autenticar la identitat OpenID que has proporcionat. Comprova que l'hagis introduïda bé."
+
+#: ../../addon/openid/openid.php:49
+msgid "The error message was:"
+msgstr "El missatge d'error ha estat:"
+
+#: ../../addon/openid/MysqlProvider.php:52
+msgid "First Name"
+msgstr "Nom"
+
+#: ../../addon/openid/MysqlProvider.php:53
+msgid "Last Name"
+msgstr "Cognoms"
+
+#: ../../addon/openid/MysqlProvider.php:54 ../../addon/redred/redred.php:111
+msgid "Nickname"
+msgstr "Àlies"
+
+#: ../../addon/openid/MysqlProvider.php:55
+msgid "Full Name"
+msgstr "Nom complet"
+
+#: ../../addon/openid/MysqlProvider.php:61
+msgid "Profile Photo 16px"
+msgstr "Imatge de perfil de 16x16 píxels"
+
+#: ../../addon/openid/MysqlProvider.php:62
+msgid "Profile Photo 32px"
+msgstr "Imatge de perfil de 32x32 píxels"
+
+#: ../../addon/openid/MysqlProvider.php:63
+msgid "Profile Photo 48px"
+msgstr "Imatge de perfil de 48x48 píxels"
+
+#: ../../addon/openid/MysqlProvider.php:64
+msgid "Profile Photo 64px"
+msgstr "Imatge de perfil de 64x64 píxels"
+
+#: ../../addon/openid/MysqlProvider.php:65
+msgid "Profile Photo 80px"
+msgstr "Imatge de perfil de 80x80 píxels"
+
+#: ../../addon/openid/MysqlProvider.php:66
+msgid "Profile Photo 128px"
+msgstr "Imatge de perfil de 128x128 píxels"
+
+#: ../../addon/openid/MysqlProvider.php:67
+msgid "Timezone"
+msgstr "Zona horària"
+
+#: ../../addon/openid/MysqlProvider.php:70
+msgid "Birth Year"
+msgstr "Any de naixement"
+
+#: ../../addon/openid/MysqlProvider.php:71
+msgid "Birth Month"
+msgstr "Mes de naixement"
+
+#: ../../addon/openid/MysqlProvider.php:72
+msgid "Birth Day"
+msgstr "Dia de naixement"
+
+#: ../../addon/openid/MysqlProvider.php:73
+msgid "Birthdate"
+msgstr "Aniversar"
+
+#: ../../addon/openid/Mod_Openid.php:30
+msgid "OpenID protocol error. No ID returned."
+msgstr "Error d'OpenID. No s'ha aconseguit cap ID."
+
+#: ../../addon/openid/Mod_Openid.php:188 ../../include/auth.php:290
+msgid "Login failed."
+msgstr "Identificació fallida."
+
+#: ../../addon/openid/Mod_Id.php:85 ../../include/selectors.php:49
+#: ../../include/selectors.php:66 ../../include/channel.php:1481
+msgid "Male"
+msgstr "Masculí"
+
+#: ../../addon/openid/Mod_Id.php:87 ../../include/selectors.php:49
+#: ../../include/selectors.php:66 ../../include/channel.php:1479
+msgid "Female"
+msgstr "Femení"
+
+#: ../../addon/randpost/randpost.php:97
+msgid "You're welcome."
+msgstr "De res."
+
+#: ../../addon/randpost/randpost.php:98
+msgid "Ah shucks..."
+msgstr "Oh merda..."
+
+#: ../../addon/randpost/randpost.php:99
+msgid "Don't mention it."
+msgstr "Ni ho pensis."
+
+#: ../../addon/randpost/randpost.php:100
+msgid "&lt;blush&gt;"
+msgstr "&lt;em poso vermell&gt;"
+
+#: ../../addon/startpage/startpage.php:109
+msgid "Page to load after login"
+msgstr "Pàgina a carregar després d'iniciar sessió"
+
+#: ../../addon/startpage/startpage.php:109
+msgid ""
+"Examples: &quot;apps&quot;, &quot;network?f=&gid=37&quot; (privacy "
+"collection), &quot;channel&quot; or &quot;notifications/system&quot; (leave "
+"blank for default network page (grid)."
+msgstr "Exemples: &quot;apps&quot;, &quot;network?f=&gid=37&quot; (grup de privacitat), &quot;channel&quot; or &quot;notifications/system&quot; (deixa-ho en blanc per a la pàgina per defecte, la del flux públic."
+
+#: ../../addon/startpage/startpage.php:113
+msgid "Startpage Settings"
+msgstr "Configuració de Pàgina d'inici"
+
+#: ../../addon/morepokes/morepokes.php:19
+msgid "bitchslap"
+msgstr "bofetades"
+
+#: ../../addon/morepokes/morepokes.php:19
+msgid "bitchslapped"
+msgstr "ha fet una bofetada a"
+
+#: ../../addon/morepokes/morepokes.php:20
+msgid "shag"
+msgstr "polvo"
+
+#: ../../addon/morepokes/morepokes.php:20
+msgid "shagged"
+msgstr "ha fet un polvo amb"
+
+#: ../../addon/morepokes/morepokes.php:21
+msgid "patent"
+msgstr "amb dret de"
+
+#: ../../addon/morepokes/morepokes.php:21
+msgid "patented"
+msgstr "ha patentat a"
+
+#: ../../addon/morepokes/morepokes.php:22
+msgid "hug"
+msgstr "abraçada"
+
+#: ../../addon/morepokes/morepokes.php:22
+msgid "hugged"
+msgstr "ha abraçat"
+
+#: ../../addon/morepokes/morepokes.php:23
+msgid "murder"
+msgstr "assassinat"
+
+#: ../../addon/morepokes/morepokes.php:23
+msgid "murdered"
+msgstr "ha assassinat"
+
+#: ../../addon/morepokes/morepokes.php:24
+msgid "worship"
+msgstr "retre-li culte"
+
+#: ../../addon/morepokes/morepokes.php:24
+msgid "worshipped"
+msgstr "ara ret culte a"
+
+#: ../../addon/morepokes/morepokes.php:25
+msgid "kiss"
+msgstr "un petó"
+
+#: ../../addon/morepokes/morepokes.php:25
+msgid "kissed"
+msgstr "ha fet un petó a"
+
+#: ../../addon/morepokes/morepokes.php:26
+msgid "tempt"
+msgstr "temptar"
+
+#: ../../addon/morepokes/morepokes.php:26
+msgid "tempted"
+msgstr "ha temptat a"
+
+#: ../../addon/morepokes/morepokes.php:27
+msgid "raise eyebrows at"
+msgstr "aixecar-li una cella"
+
+#: ../../addon/morepokes/morepokes.php:27
+msgid "raised their eyebrows at"
+msgstr "li ha aixecat una cella a"
+
+#: ../../addon/morepokes/morepokes.php:28
+msgid "insult"
+msgstr "insultar"
+
+#: ../../addon/morepokes/morepokes.php:28
+msgid "insulted"
+msgstr "ha insultat a"
+
+#: ../../addon/morepokes/morepokes.php:29
+msgid "praise"
+msgstr "elogiar"
+
+#: ../../addon/morepokes/morepokes.php:29
+msgid "praised"
+msgstr "ha elogiat a"
+
+#: ../../addon/morepokes/morepokes.php:30
+msgid "be dubious of"
+msgstr "sospitar"
+
+#: ../../addon/morepokes/morepokes.php:30
+msgid "was dubious of"
+msgstr "sospita de"
+
+#: ../../addon/morepokes/morepokes.php:31
+msgid "eat"
+msgstr "menjar"
+
+#: ../../addon/morepokes/morepokes.php:31
+msgid "ate"
+msgstr "s'ha menjat"
+
+#: ../../addon/morepokes/morepokes.php:32
+msgid "giggle and fawn at"
+msgstr "cantar-ne les mil meravelles"
+
+#: ../../addon/morepokes/morepokes.php:32
+msgid "giggled and fawned at"
+msgstr "està cantant les mil meravelles de"
+
+#: ../../addon/morepokes/morepokes.php:33
+msgid "doubt"
+msgstr "dubtar-ne"
+
+#: ../../addon/morepokes/morepokes.php:33
+msgid "doubted"
+msgstr "dubta de"
+
+#: ../../addon/morepokes/morepokes.php:34
+msgid "glare"
+msgstr "fer-li una mirada assassina"
+
+#: ../../addon/morepokes/morepokes.php:34
+msgid "glared at"
+msgstr "li ha fet una mirada assassina a"
+
+#: ../../addon/morepokes/morepokes.php:35
+msgid "fuck"
+msgstr "follar-hi"
+
+#: ../../addon/morepokes/morepokes.php:35
+msgid "fucked"
+msgstr "ha follat amb"
+
+#: ../../addon/morepokes/morepokes.php:36
+msgid "bonk"
+msgstr "tirar-se'l/la"
+
+#: ../../addon/morepokes/morepokes.php:36
+msgid "bonked"
+msgstr "s'ha tirat a"
+
+#: ../../addon/morepokes/morepokes.php:37
+msgid "declare undying love for"
+msgstr "declarar-li l'amor etern a"
+
+#: ../../addon/morepokes/morepokes.php:37
+msgid "declared undying love for"
+msgstr "li ha declarar amor etern a"
+
+#: ../../addon/diaspora/diaspora.php:778
+msgid "Diaspora Protocol Settings updated."
+msgstr "S'ha actualitzat la configuració del Protocol de Diàspora"
+
+#: ../../addon/diaspora/diaspora.php:797
+msgid ""
+"The Diaspora protocol does not support location independence. Connections "
+"you make within that network may be unreachable from alternate channel "
+"locations."
+msgstr "El Protocol de Diàspora és incompatible amb la independència de hub. Les connexions que facis en aquesta xarxa no seran accessibles des de hubs alternatius del teu canal."
+
+#: ../../addon/diaspora/diaspora.php:800
+msgid "Enable the Diaspora protocol for this channel"
+msgstr "Activa el Protocol de Diàspora per aquest canal"
+
+#: ../../addon/diaspora/diaspora.php:804
+msgid "Allow any Diaspora member to comment on your public posts"
+msgstr "Permet a qualsevol membre de Diàspora de comentar les teves entrades públiques"
+
+#: ../../addon/diaspora/diaspora.php:808
+msgid "Prevent your hashtags from being redirected to other sites"
+msgstr "Evita que les teves etiquetes siguin redirigides a altres llocs web"
+
+#: ../../addon/diaspora/diaspora.php:812
+msgid ""
+"Sign and forward posts and comments with no existing Diaspora signature"
+msgstr "Signa i reenvia entrades o comentaris encara que no tinguin una signatura de Diàspora vàlida."
+
+#: ../../addon/diaspora/diaspora.php:817
+msgid "Followed hashtags (comma separated, do not include the #)"
+msgstr "Etiquetes seguides (separades per comes i sense incloure #)"
+
+#: ../../addon/diaspora/diaspora.php:822
+msgid "Diaspora Protocol Settings"
+msgstr "Configuració del Protocol de Diàspora"
+
+#: ../../addon/diaspora/import_diaspora.php:16
+msgid "No username found in import file."
+msgstr "No s'ha trobat el nom d'usuari en el fitxer d'importació."
+
+#: ../../addon/diaspora/import_diaspora.php:41 ../../include/import.php:62
+msgid "Unable to create a unique channel address. Import failed."
+msgstr "No s'ha pogut importar el canal perquè l'adreça única de canal no s'ha pogut crear."
+
+#: ../../addon/testdrive/testdrive.php:104
 #, php-format
-msgid "View %s's profile @ %s"
-msgstr "Vista %s del perfil @ %s"
+msgid "Your account on %s will expire in a few days."
+msgstr "El teu compte a %s caducarà d'aquí a pocs dies."
 
-#: ../../include/conversation.php:710
-msgid "Categories:"
-msgstr "Categories:"
+#: ../../addon/testdrive/testdrive.php:105
+msgid "Your $Productname test account is about to expire."
+msgstr "El teu compte de prova a $Productname està a punt de caducar."
 
-#: ../../include/conversation.php:711
-msgid "Filed under:"
-msgstr "Arxivar a:"
+#: ../../addon/rainbowtag/rainbowtag.php:81
+msgid "Enable Rainbowtag"
+msgstr "Activa el Rainbowtag"
 
-#: ../../include/conversation.php:738
-msgid "View in context"
-msgstr "Veure en context"
+#: ../../addon/rainbowtag/rainbowtag.php:85
+msgid "Rainbowtag Settings"
+msgstr "Configuració de Rainbowtag"
 
-#: ../../include/conversation.php:847
-msgid "remove"
-msgstr "treu"
+#: ../../addon/rainbowtag/rainbowtag.php:101
+msgid "Rainbowtag Settings saved."
+msgstr "S'ha desat la configuració del Rainbowtag."
 
-#: ../../include/conversation.php:852
-msgid "Delete Selected Items"
-msgstr "Esborra els Articles Seleccionats"
+#: ../../addon/upload_limits/upload_limits.php:25
+msgid "Show Upload Limits"
+msgstr "Mostra els límits de pujada"
 
-#: ../../include/conversation.php:948
-msgid "View Source"
-msgstr "Veure l'Origen"
+#: ../../addon/upload_limits/upload_limits.php:27
+msgid "Hubzilla configured maximum size: "
+msgstr "Mida màxima configurada a $Projectname:"
 
-#: ../../include/conversation.php:949
-msgid "Follow Thread"
-msgstr "Segueix el Fil"
+#: ../../addon/upload_limits/upload_limits.php:28
+msgid "PHP upload_max_filesize: "
+msgstr "Mida màxima de fitxer del PHP (upload_max_filesize):"
 
-#: ../../include/conversation.php:950
-msgid "Unfollow Thread"
-msgstr "Fil Abandonat"
+#: ../../addon/upload_limits/upload_limits.php:29
+msgid "PHP post_max_size (must be larger than upload_max_filesize): "
+msgstr "Mida màxima de consulta web del PHP (post_max_size > upload_max_filesize):"
 
-#: ../../include/conversation.php:955
-msgid "Activity/Posts"
-msgstr "Activitat/Entrades"
+#: ../../addon/gravatar/gravatar.php:123
+msgid "generic profile image"
+msgstr "imatge de perfil genèrica"
 
-#: ../../include/conversation.php:957
-msgid "Edit Connection"
-msgstr "Modifica la Connexió"
+#: ../../addon/gravatar/gravatar.php:124
+msgid "random geometric pattern"
+msgstr "patró geomètric aleatori"
 
-#: ../../include/conversation.php:958
-msgid "Message"
-msgstr "Missatge"
+#: ../../addon/gravatar/gravatar.php:125
+msgid "monster face"
+msgstr "cara de monstre"
 
-#: ../../include/conversation.php:1075
+#: ../../addon/gravatar/gravatar.php:126
+msgid "computer generated face"
+msgstr "cara generada per ordinador"
+
+#: ../../addon/gravatar/gravatar.php:127
+msgid "retro arcade style face"
+msgstr "cara d'estil arcade retro"
+
+#: ../../addon/gravatar/gravatar.php:128
+msgid "Hub default profile photo"
+msgstr "Foto de perfil per defecte al hub"
+
+#: ../../addon/gravatar/gravatar.php:143
+msgid "Information"
+msgstr "Informació"
+
+#: ../../addon/gravatar/gravatar.php:143
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr "L'extensió Libravatar també està instaŀlada. Desactiva-la o desactiva aquesta. <br>Libravatar rebotarà a Gravatar si no es troba res a Libravatar."
+
+#: ../../addon/gravatar/gravatar.php:150
+#: ../../addon/msgfooter/msgfooter.php:46 ../../addon/xmpp/xmpp.php:91
+msgid "Save Settings"
+msgstr "Des la configuració"
+
+#: ../../addon/gravatar/gravatar.php:151
+msgid "Default avatar image"
+msgstr "Avatar per defecte"
+
+#: ../../addon/gravatar/gravatar.php:151
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr "Escull l'avatar per defecte si no se'n troba cap al Gravatar. Consulta el README"
+
+#: ../../addon/gravatar/gravatar.php:152
+msgid "Rating of images"
+msgstr "Categorització de les imatges"
+
+#: ../../addon/gravatar/gravatar.php:152
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr "Escull la categorització d'avatar per al teu lloc. Consulta el README"
+
+#: ../../addon/gravatar/gravatar.php:165
+msgid "Gravatar settings updated."
+msgstr "S'ha actualitzat la configuració del Gravatar"
+
+#: ../../addon/hzfiles/hzfiles.php:79
+msgid "Hubzilla File Storage Import"
+msgstr "Importació d'emmagatzematge de Hubzilla"
+
+#: ../../addon/hzfiles/hzfiles.php:80
+msgid "This will import all your cloud files from another server."
+msgstr "Permet importar tots els arxius de núvol des d'un altre servidor."
+
+#: ../../addon/hzfiles/hzfiles.php:81
+msgid "Hubzilla Server base URL"
+msgstr "Adreça URL base de l'altre servidor Hubzilla"
+
+#: ../../addon/hzfiles/hzfiles.php:82
+msgid "Since modified date yyyy-mm-dd"
+msgstr "Més nous que aaaa-mm-dd"
+
+#: ../../addon/hzfiles/hzfiles.php:83
+msgid "Until modified date yyyy-mm-dd"
+msgstr "Més antics que aaaa-mm-dd"
+
+#: ../../addon/visage/visage.php:93
+msgid "Recent Channel/Profile Viewers"
+msgstr "Visitants recents del canal o perfil"
+
+#: ../../addon/visage/visage.php:98
+msgid "This plugin/addon has not been configured."
+msgstr "Aquesta extensió encara no està configurada."
+
+#: ../../addon/visage/visage.php:99
 #, php-format
-msgid "%s likes this."
-msgstr "%s agrada això."
+msgid "Please visit the Visage settings on %s"
+msgstr "Visita la configuració del Visage a %s"
 
-#: ../../include/conversation.php:1075
+#: ../../addon/visage/visage.php:99
+msgid "your feature settings page"
+msgstr "la pàgina de configuració de funcionalitats"
+
+#: ../../addon/visage/visage.php:112
+msgid "No entries."
+msgstr "No hi ha entrades."
+
+#: ../../addon/visage/visage.php:166
+msgid "Enable Visage Visitor Logging"
+msgstr "Activa el registre de visitants de Visage"
+
+#: ../../addon/visage/visage.php:170
+msgid "Visage Settings"
+msgstr "Configuració del Visage"
+
+#: ../../addon/nsabait/nsabait.php:125
+msgid "Nsabait Settings updated."
+msgstr "S'ha actualitzat la configuració de NSAbait."
+
+#: ../../addon/nsabait/nsabait.php:157
+msgid "Enable NSAbait Plugin"
+msgstr "Activa l'extensió NSAbait"
+
+#: ../../addon/nsabait/nsabait.php:161
+msgid "NSAbait Settings"
+msgstr "Configuració del NSAbait"
+
+#: ../../addon/mailtest/mailtest.php:19
+msgid "Send test email"
+msgstr "Envia un correu de prova"
+
+#: ../../addon/mailtest/mailtest.php:50 ../../addon/hubwall/hubwall.php:50
+msgid "No recipients found."
+msgstr "No s'han trobat destinataris."
+
+#: ../../addon/mailtest/mailtest.php:66
+msgid "Mail sent."
+msgstr "S'ha enviat el correu."
+
+#: ../../addon/mailtest/mailtest.php:68
+msgid "Sending of mail failed."
+msgstr "Ha fallat l'enviament de correu."
+
+#: ../../addon/mailtest/mailtest.php:77
+msgid "Mail Test"
+msgstr "Prova de correu"
+
+#: ../../addon/mailtest/mailtest.php:96 ../../addon/hubwall/hubwall.php:92
+msgid "Message subject"
+msgstr "Assumpte"
+
+#: ../../addon/mdpost/mdpost.php:41
+msgid "Use markdown for editing posts"
+msgstr "Fes servir markdown per editar les entrades"
+
+#: ../../addon/openstreetmap/openstreetmap.php:146
+msgid "View Larger"
+msgstr "Amplia"
+
+#: ../../addon/openstreetmap/openstreetmap.php:169
+msgid "Tile Server URL"
+msgstr "Adreça URL del servidor de tesseŀles"
+
+#: ../../addon/openstreetmap/openstreetmap.php:169
+msgid ""
+"A list of <a href=\"http://wiki.openstreetmap.org/wiki/TMS\" "
+"target=\"_blank\">public tile servers</a>"
+msgstr "Una llista de <a href=\"http://wiki.openstreetmap.org/wiki/TMS\" target=\"_blank\">servidors públics de tesseŀles</a>"
+
+#: ../../addon/openstreetmap/openstreetmap.php:170
+msgid "Nominatim (reverse geocoding) Server URL"
+msgstr "Adreça URL del servei Nominatim (geocoding invers)"
+
+#: ../../addon/openstreetmap/openstreetmap.php:170
+msgid ""
+"A list of <a href=\"http://wiki.openstreetmap.org/wiki/Nominatim\" "
+"target=\"_blank\">Nominatim servers</a>"
+msgstr "Una llista de <a href=\"http://wiki.openstreetmap.org/wiki/TMS\" target=\"_blank\">servidors públics de Nominatim</a>"
+
+#: ../../addon/openstreetmap/openstreetmap.php:171
+msgid "Default zoom"
+msgstr "Zoom per defecte"
+
+#: ../../addon/openstreetmap/openstreetmap.php:171
+msgid ""
+"The default zoom level. (1:world, 18:highest, also depends on tile server)"
+msgstr "El nivell de zoom predeterminat. (1: mínim, món. 18: màxim. També depèn del servidor)"
+
+#: ../../addon/openstreetmap/openstreetmap.php:172
+msgid "Include marker on map"
+msgstr "Inclou una xinxeta al mapa"
+
+#: ../../addon/openstreetmap/openstreetmap.php:172
+msgid "Include a marker on the map."
+msgstr "Inclou una xinxeta al mapa."
+
+#: ../../addon/msgfooter/msgfooter.php:47
+msgid "text to include in all outgoing posts from this site"
+msgstr "text per incloure en totes les entrades que s'enviïn des d'aquest lloc"
+
+#: ../../addon/rtof/rtof.php:45
+msgid "Post to Friendica"
+msgstr "Publica a Friendica"
+
+#: ../../addon/rtof/rtof.php:62
+msgid "rtof Settings saved."
+msgstr "S'ha desat la Configuració de rtof."
+
+#: ../../addon/rtof/rtof.php:81
+msgid "Allow posting to Friendica"
+msgstr "Permet publicar a xarxes Friendica"
+
+#: ../../addon/rtof/rtof.php:85
+msgid "Send public postings to Friendica by default"
+msgstr "Envia per defecte les entrades públiques cap a Friendica"
+
+#: ../../addon/rtof/rtof.php:89
+msgid "Friendica API Path"
+msgstr "Ruta a l'API de Friendica"
+
+#: ../../addon/rtof/rtof.php:89 ../../addon/redred/redred.php:103
+msgid "https://{sitename}/api"
+msgstr "https://{nomdedomini}/api"
+
+#: ../../addon/rtof/rtof.php:93
+msgid "Friendica login name"
+msgstr "Nom d'usuari a Friendica"
+
+#: ../../addon/rtof/rtof.php:97
+msgid "Friendica password"
+msgstr "Contrasenya a Friendica"
+
+#: ../../addon/rtof/rtof.php:101
+msgid "Hubzilla to Friendica Post Settings"
+msgstr "Configuració de Publicació de Hubzilla cap a Friendica"
+
+#: ../../addon/jappixmini/jappixmini.php:305 ../../include/channel.php:1397
+#: ../../include/channel.php:1568
+msgid "Status:"
+msgstr "Estatus:"
+
+#: ../../addon/jappixmini/jappixmini.php:309
+msgid "Activate addon"
+msgstr "Habilita l'extensió"
+
+#: ../../addon/jappixmini/jappixmini.php:313
+msgid "Hide Jappixmini Chat-Widget from the webinterface"
+msgstr "Amaga el giny de xat Jappixmini"
+
+#: ../../addon/jappixmini/jappixmini.php:318
+msgid "Jabber username"
+msgstr "Nom a Jabber"
+
+#: ../../addon/jappixmini/jappixmini.php:324
+msgid "Jabber server"
+msgstr "Servidor de Jabber"
+
+#: ../../addon/jappixmini/jappixmini.php:330
+msgid "Jabber BOSH host URL"
+msgstr "URL de l'amfitrió BOSH de Jabber"
+
+#: ../../addon/jappixmini/jappixmini.php:337
+msgid "Jabber password"
+msgstr "Contrassenya de Jabber"
+
+#: ../../addon/jappixmini/jappixmini.php:343
+msgid "Encrypt Jabber password with Hubzilla password"
+msgstr "Xifra la contrasenya de Jabber amb la del Hubzilla"
+
+#: ../../addon/jappixmini/jappixmini.php:347 ../../addon/redred/redred.php:115
+msgid "Hubzilla password"
+msgstr "Contrasenya del Hubzilla"
+
+#: ../../addon/jappixmini/jappixmini.php:351
+#: ../../addon/jappixmini/jappixmini.php:355
+msgid "Approve subscription requests from Hubzilla contacts automatically"
+msgstr "Aprova automàticament les sol·licituds de subscripció de contactes de Hubzilla"
+
+#: ../../addon/jappixmini/jappixmini.php:359
+msgid "Purge internal list of jabber addresses of contacts"
+msgstr "Neteja la llista interna de contactes de Jabber"
+
+#: ../../addon/jappixmini/jappixmini.php:364
+msgid "Configuration Help"
+msgstr "Ajuda de configuració"
+
+#: ../../addon/jappixmini/jappixmini.php:371
+msgid "Jappix Mini Settings"
+msgstr "Paràmetres de Jappix Mini"
+
+#: ../../addon/superblock/superblock.php:112
+msgid "Currently blocked"
+msgstr "Bloquejats actualment"
+
+#: ../../addon/superblock/superblock.php:114
+msgid "No channels currently blocked"
+msgstr "No hi ha canals bloquejats"
+
+#: ../../addon/superblock/superblock.php:120
+msgid "\"Superblock\" Settings"
+msgstr "Configuració del Superblock"
+
+#: ../../addon/superblock/superblock.php:345
+msgid "Block Completely"
+msgstr "Bloqueja completament"
+
+#: ../../addon/superblock/superblock.php:394
+msgid "superblock settings updated"
+msgstr "S'ha actualitzat la configuració del Superblock"
+
+#: ../../addon/nofed/nofed.php:42
+msgid "Federate"
+msgstr "Federa"
+
+#: ../../addon/nofed/nofed.php:56
+msgid "nofed Settings saved."
+msgstr "S'ha desat la configuració del NoFed."
+
+#: ../../addon/nofed/nofed.php:72
+msgid "Allow Federation Toggle"
+msgstr "Permet commutar entre federar o no"
+
+#: ../../addon/nofed/nofed.php:76
+msgid "Federate posts by default"
+msgstr "Per defecte federa les entrades"
+
+#: ../../addon/nofed/nofed.php:80
+msgid "NoFed Settings"
+msgstr "Configuració del NoFed"
+
+#: ../../addon/redred/redred.php:45
+msgid "Post to Red"
+msgstr "Publica a Red"
+
+#: ../../addon/redred/redred.php:60
+msgid "Channel is required."
+msgstr "Cal un canal."
+
+#: ../../addon/redred/redred.php:76
+msgid "redred Settings saved."
+msgstr "S'ha desat la configuració del RedRed"
+
+#: ../../addon/redred/redred.php:95
+msgid "Allow posting to another Hubzilla Channel"
+msgstr "Permet publicar a un altre canal de Hubzilla"
+
+#: ../../addon/redred/redred.php:99
+msgid "Send public postings to Hubzilla channel by default"
+msgstr "Envia per defecte les entrades públiques cap a l'altre canal de Hubzilla"
+
+#: ../../addon/redred/redred.php:103
+msgid "Hubzilla API Path"
+msgstr "Ruta de l'API de Hubzilla"
+
+#: ../../addon/redred/redred.php:107
+msgid "Hubzilla login name"
+msgstr "Nom d'usuari a l'altre Hubzilla"
+
+#: ../../addon/redred/redred.php:111
+msgid "Hubzilla channel name"
+msgstr "Nom de canal a l'altre Hubzilla"
+
+#: ../../addon/redred/redred.php:119
+msgid "Hubzilla Crosspost Settings"
+msgstr "Configuració del replicador de Hubzilla"
+
+#: ../../addon/logrot/logrot.php:36
+msgid "Logfile archive directory"
+msgstr "Carpeta d'arxius de registre d'activitat"
+
+#: ../../addon/logrot/logrot.php:36
+msgid "Directory to store rotated logs"
+msgstr "Carpeta per desar els registres circulars"
+
+#: ../../addon/logrot/logrot.php:37
+msgid "Logfile size in bytes before rotating"
+msgstr "Mida en Bytes del fitxer de registre abans de rotar"
+
+#: ../../addon/logrot/logrot.php:38
+msgid "Number of logfiles to retain"
+msgstr "Número de fitxers de registre per a conservar"
+
+#: ../../addon/frphotos/frphotos.php:91
+msgid "Friendica Photo Album Import"
+msgstr "Importa àlbums de fotos de Friendica"
+
+#: ../../addon/frphotos/frphotos.php:92
+msgid "This will import all your Friendica photo albums to this Red channel."
+msgstr "Aquesta acció importarà tots els teus àlbums de fotos de Friendica a aquest canal."
+
+#: ../../addon/frphotos/frphotos.php:93
+msgid "Friendica Server base URL"
+msgstr "URL base del servidor de Friendica"
+
+#: ../../addon/frphotos/frphotos.php:94
+msgid "Friendica Login Username"
+msgstr "Nom de registre a Friendica"
+
+#: ../../addon/frphotos/frphotos.php:95
+msgid "Friendica Login Password"
+msgstr "Contrasenya a Friendica"
+
+#: ../../addon/pubcrawl/as.php:1101 ../../addon/pubcrawl/as.php:1228
+#: ../../addon/pubcrawl/as.php:1403 ../../include/network.php:1774
+msgid "ActivityPub"
+msgstr "ActivityPub"
+
+#: ../../addon/pubcrawl/pubcrawl.php:1034
+msgid "ActivityPub Protocol Settings updated."
+msgstr "S'ha actualitzat la configuració del Protocol ActivityPub."
+
+#: ../../addon/pubcrawl/pubcrawl.php:1043
+msgid ""
+"The ActivityPub protocol does not support location independence. Connections"
+" you make within that network may be unreachable from alternate channel "
+"locations."
+msgstr "El Protocol ActivityPub és incompatible amb la independència de hub. Les connexions que facis en aquesta xarxa no seran accessibles des de hubs alternatius del teu canal."
+
+#: ../../addon/pubcrawl/pubcrawl.php:1046
+msgid "Enable the ActivityPub protocol for this channel"
+msgstr "Activa el Protocol ActivityPub en aquest canal"
+
+#: ../../addon/pubcrawl/pubcrawl.php:1049
+msgid "Send multi-media HTML articles"
+msgstr "Envia articles HTML multimèdia"
+
+#: ../../addon/pubcrawl/pubcrawl.php:1049
+msgid "Not supported by some microblog services such as Mastodon"
+msgstr "Incompatible amb alguns serveis de microbloguing com Mastodon"
+
+#: ../../addon/pubcrawl/pubcrawl.php:1053
+msgid "ActivityPub Protocol Settings"
+msgstr "Configuració del Protocol ActivityPub"
+
+#: ../../addon/donate/donate.php:21
+msgid "Project Servers and Resources"
+msgstr "Servidors de projecte i Recursos"
+
+#: ../../addon/donate/donate.php:22
+msgid "Project Creator and Tech Lead"
+msgstr "Creador del projecte i cap tècnic"
+
+#: ../../addon/donate/donate.php:23
+msgid "Admin, developer, directorymin, support bloke"
+msgstr "Administradora, desenvolupadora, admin del directori, persona de suport"
+
+#: ../../addon/donate/donate.php:50
+msgid ""
+"And the hundreds of other people and organisations who helped make the "
+"Hubzilla possible."
+msgstr "I els centenars d'altra gent i organitzacions que han ajudat que Hubzilla fos possible."
+
+#: ../../addon/donate/donate.php:53
+msgid ""
+"The Redmatrix/Hubzilla projects are provided primarily by volunteers giving "
+"their time and expertise - and often paying out of pocket for services they "
+"share with others."
+msgstr "Els projectes Redmatrix i Hubzilla són oferts principalment per voluntàries que donen el seu temps i experiència i que fins i tot solen posar-hi diners de la seva butxaca per a compartir serveis amb altres."
+
+#: ../../addon/donate/donate.php:54
+msgid ""
+"There is no corporate funding and no ads, and we do not collect and sell "
+"your personal information. (We don't control your personal information - "
+"<strong>you do</strong>.)"
+msgstr "No rebem cap mena de finançament corporatiu, ni posem anuncis ni recollim i venem les teves dades personals. Nosaltres no controlem les dades personals, sinó <strong>tu</strong>."
+
+#: ../../addon/donate/donate.php:55
+msgid ""
+"Help support our ground-breaking work in decentralisation, web identity, and"
+" privacy."
+msgstr "Ajuda'ns a mantenir la nostra feina pionera cap a la descentralització, la identitat a la web i la privacitat."
+
+#: ../../addon/donate/donate.php:57
+msgid ""
+"Your donations keep servers and services running and also helps us to "
+"provide innovative new features and continued development."
+msgstr "Les teves donacions mantenen els servidors i els serveis corrent, i ens ajuda a oferir noves funcionalitats i continuar el desenvolupament en marxa."
+
+#: ../../addon/donate/donate.php:60
+msgid "Donate"
+msgstr "Dóna"
+
+#: ../../addon/donate/donate.php:62
+msgid ""
+"Choose a project, developer, or public hub to support with a one-time "
+"donation"
+msgstr "Tria un projecte, desenvolupador o hub públic per a donar suport amb una donació"
+
+#: ../../addon/donate/donate.php:63
+msgid "Donate Now"
+msgstr "Dóna ara"
+
+#: ../../addon/donate/donate.php:64
+msgid ""
+"<strong><em>Or</em></strong> become a project sponsor (Hubzilla Project "
+"only)"
+msgstr "<strong><em>O bé</em></strong>, fes-te patrocinador/a del projecte Hubzilla"
+
+#: ../../addon/donate/donate.php:65
+msgid ""
+"Please indicate if you would like your first name or full name (or nothing) "
+"to appear in our sponsor listing"
+msgstr "Indica com vols aparèixer a la llista de patrocinadors: anònim, amb nom, o nom i cognoms"
+
+#: ../../addon/donate/donate.php:66
+msgid "Sponsor"
+msgstr "Patrocinador"
+
+#: ../../addon/donate/donate.php:69
+msgid "Special thanks to: "
+msgstr "Agraïments especials a:"
+
+#: ../../addon/chords/Mod_Chords.php:44
+msgid ""
+"This is a fairly comprehensive and complete guitar chord dictionary which "
+"will list most of the available ways to play a certain chord, starting from "
+"the base of the fingerboard up to a few frets beyond the twelfth fret "
+"(beyond which everything repeats). A couple of non-standard tunings are "
+"provided for the benefit of slide players, etc."
+msgstr "És un diccionari prou complet d'acords de guitarra. Llista la majoria de maneres possibles de tocar un cert acord, començant des de la base del mànec fins una mica més apunt del dotzè trast, a partir del qual es repeteixen. Ofereix també un parell d'afinacions no estàndards."
+
+#: ../../addon/chords/Mod_Chords.php:46
+msgid ""
+"Chord names start with a root note (A-G) and may include sharps (#) and "
+"flats (b). This software will parse most of the standard naming conventions "
+"such as maj, min, dim, sus(2 or 4), aug, with optional repeating elements."
+msgstr "Els noms dels acords estan formats per la nota fonamental en notació anglesa (A-G), i modificadors com \"sostingut\" (#) i \"bemoll\" (b). El programa entén la majoria de convencions com maj, min, dim, sus2, sus4 i aug, amb més d'un element potencialment."
+
+#: ../../addon/chords/Mod_Chords.php:48
+msgid ""
+"Valid examples include  A, A7, Am7, Amaj7, Amaj9, Ammaj7, Aadd4, Asus2Add4, "
+"E7b13b11 ..."
+msgstr "Exemples vàlids: A, A7, Am7, Amaj7, Amaj9, Ammaj7, Aadd4, Asus2Add4, E7b13b11"
+
+#: ../../addon/chords/Mod_Chords.php:51
+msgid "Guitar Chords"
+msgstr "Acords de guitarra"
+
+#: ../../addon/chords/Mod_Chords.php:52
+msgid "The complete online chord dictionary"
+msgstr "El diccionari on-line d'acords"
+
+#: ../../addon/chords/Mod_Chords.php:57
+msgid "Tuning"
+msgstr "Afinació"
+
+#: ../../addon/chords/Mod_Chords.php:58
+msgid "Chord name: example: Em7"
+msgstr "Exemple de nom d'acord: Em7"
+
+#: ../../addon/chords/Mod_Chords.php:59
+msgid "Show for left handed stringing"
+msgstr "Disposició per esquerrans"
+
+#: ../../addon/chords/chords.php:33
+msgid "Quick Reference"
+msgstr "Xuleta"
+
+#: ../../addon/libertree/libertree.php:38
+msgid "Post to Libertree"
+msgstr "Publica a Libertree"
+
+#: ../../addon/libertree/libertree.php:69
+msgid "Enable Libertree Post Plugin"
+msgstr "Habilita la publicació a Libertree"
+
+#: ../../addon/libertree/libertree.php:73
+msgid "Libertree API token"
+msgstr "Token per a l'API de Libertree"
+
+#: ../../addon/libertree/libertree.php:77
+msgid "Libertree site URL"
+msgstr "URL del servidor de Libertree"
+
+#: ../../addon/libertree/libertree.php:81
+msgid "Post to Libertree by default"
+msgstr "Publica a Libertree per defecte"
+
+#: ../../addon/libertree/libertree.php:85
+msgid "Libertree Post Settings"
+msgstr "Paràmetres de publicació a Libertree"
+
+#: ../../addon/libertree/libertree.php:99
+msgid "Libertree Settings saved."
+msgstr "S'han actualitzat els paràmetres de Libertree."
+
+#: ../../addon/flattrwidget/flattrwidget.php:45
+msgid "Flattr this!"
+msgstr "Dóna-hi suport amb Flattr!"
+
+#: ../../addon/flattrwidget/flattrwidget.php:83
+msgid "Flattr widget settings updated."
+msgstr "S'han actualitzat els paràmetres del giny de Flattr."
+
+#: ../../addon/flattrwidget/flattrwidget.php:100
+msgid "Flattr user"
+msgstr "Nom a Flattr"
+
+#: ../../addon/flattrwidget/flattrwidget.php:104
+msgid "URL of the Thing to flattr"
+msgstr "URL del lloc per a donar suport"
+
+#: ../../addon/flattrwidget/flattrwidget.php:104
+msgid "If empty channel URL is used"
+msgstr "Si la deixes buida, es farà servir la URL del canal"
+
+#: ../../addon/flattrwidget/flattrwidget.php:108
+msgid "Title of the Thing to flattr"
+msgstr "Títol del lloc a donar suport"
+
+#: ../../addon/flattrwidget/flattrwidget.php:108
+msgid "If empty \"channel name on The Hubzilla\" will be used"
+msgstr "Si el deixes buit, es farà servir el nom del canal a Hubzilla"
+
+#: ../../addon/flattrwidget/flattrwidget.php:112
+msgid "Static or dynamic flattr button"
+msgstr "Botó estàtic o dinàmic"
+
+#: ../../addon/flattrwidget/flattrwidget.php:112
+msgid "static"
+msgstr "estàtic"
+
+#: ../../addon/flattrwidget/flattrwidget.php:112
+msgid "dynamic"
+msgstr "dinàmic"
+
+#: ../../addon/flattrwidget/flattrwidget.php:116
+msgid "Alignment of the widget"
+msgstr "Aliniament del giny"
+
+#: ../../addon/flattrwidget/flattrwidget.php:116
+msgid "left"
+msgstr "esquerra"
+
+#: ../../addon/flattrwidget/flattrwidget.php:116
+msgid "right"
+msgstr "dreta"
+
+#: ../../addon/flattrwidget/flattrwidget.php:120
+msgid "Enable Flattr widget"
+msgstr "Habilita el giny de Flattr"
+
+#: ../../addon/flattrwidget/flattrwidget.php:124
+msgid "Flattr Widget Settings"
+msgstr "Opcions del giny de Flattr"
+
+#: ../../addon/statusnet/statusnet.php:143
+msgid "Post to GNU social"
+msgstr "Publica a GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:195
+msgid ""
+"Please contact your site administrator.<br />The provided API URL is not "
+"valid."
+msgstr "Contacta l'administrador del teu lloc. <br />L'adreça URL de l'API no és vàlida."
+
+#: ../../addon/statusnet/statusnet.php:232
+msgid "We could not contact the GNU social API with the Path you entered."
+msgstr "No s'ha trobat una API de GNU Social a la ruta introduïda."
+
+#: ../../addon/statusnet/statusnet.php:266
+msgid "GNU social settings updated."
+msgstr "S'ha actualitzat la configuració de GNU Social "
+
+#: ../../addon/statusnet/statusnet.php:310
+msgid "Globally Available GNU social OAuthKeys"
+msgstr "Claus OAuth de GNU Social diponibles públicament"
+
+#: ../../addon/statusnet/statusnet.php:312
+msgid ""
+"There are preconfigured OAuth key pairs for some GNU social servers "
+"available. If you are using one of them, please use these credentials.<br "
+"/>If not feel free to connect to any other GNU social instance (see below)."
+msgstr "Hi ha disponibles preconfigurats alguns parells de clau OAuth per a alguns servidors de GNU Social. I en fas servir algun, fes servir aquestes credencials.<br />Altrament, pots connectar-te a qualsevol altra instància de GNU Social (mira més avall)"
+
+#: ../../addon/statusnet/statusnet.php:327
+msgid "Provide your own OAuth Credentials"
+msgstr "Proporciona credencials OAuth pròpies"
+
+#: ../../addon/statusnet/statusnet.php:329
+msgid ""
+"No consumer key pair for GNU social found. Register your Hubzilla Account as"
+" an desktop client on your GNU social account, copy the consumer key pair "
+"here and enter the API base root.<br />Before you register your own OAuth "
+"key pair ask the administrator if there is already a key pair for this "
+"Hubzilla installation at your favourite GNU social installation."
+msgstr "No s'ha trobat cap parell de claus per a GNU Social. Registra el teu compte de Hubzilla com un client d'escriptori al teu compte de GNU Social, després copia el parell de claus de consumidor aquí i finalment introdueix l'adreça arrel de l'API.<br />Abans de registrar el teu propi parell de claus, pregunta a l'administració d'aquest hub si ja hi ha un parell de claus registrat per al mateix servidor de GNU Social."
+
+#: ../../addon/statusnet/statusnet.php:333
+msgid "OAuth Consumer Key"
+msgstr "Clau de consumidor OAuth"
+
+#: ../../addon/statusnet/statusnet.php:337
+msgid "OAuth Consumer Secret"
+msgstr "Secret de consumidor OAuth"
+
+#: ../../addon/statusnet/statusnet.php:341
+msgid "Base API Path"
+msgstr "Ruta arrel de l'API"
+
+#: ../../addon/statusnet/statusnet.php:341
+msgid "Remember the trailing /"
+msgstr "Recorda la / final"
+
+#: ../../addon/statusnet/statusnet.php:345
+msgid "GNU social application name"
+msgstr "Nom de l'aplicació GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:368
+msgid ""
+"To connect to your GNU social account click the button below to get a "
+"security code from GNU social which you have to copy into the input box "
+"below and submit the form. Only your <strong>public</strong> posts will be "
+"posted to GNU social."
+msgstr "Per tal de connectar al teu compte de GNU Social, fes clic al botó de sota per a obtenir un codi de seguretat de GNU Social. Després insereix-lo a la caixa de sota i envia el formulari. Només seran publicades a GNU Social <strong>les teves entrades públiques</strong>"
+
+#: ../../addon/statusnet/statusnet.php:370
+msgid "Log in with GNU social"
+msgstr "Inicia la sessió amb GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:373
+msgid "Copy the security code from GNU social here"
+msgstr "Copia el codi de seguretat de GNU Social aquí"
+
+#: ../../addon/statusnet/statusnet.php:383
+msgid "Cancel Connection Process"
+msgstr "Aborta el procés de connexió"
+
+#: ../../addon/statusnet/statusnet.php:385
+msgid "Current GNU social API is"
+msgstr "La ruta actual a l'API de GNU Social és"
+
+#: ../../addon/statusnet/statusnet.php:389
+msgid "Cancel GNU social Connection"
+msgstr "Aborta la connexió a GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:401 ../../addon/twitter/twitter.php:233
+msgid "Currently connected to: "
+msgstr "Actualment estàs connectat/da a:"
+
+#: ../../addon/statusnet/statusnet.php:406
+msgid ""
+"<strong>Note</strong>: Due your privacy settings (<em>Hide your profile "
+"details from unknown viewers?</em>) the link potentially included in public "
+"postings relayed to GNU social will lead the visitor to a blank page "
+"informing the visitor that the access to your profile has been restricted."
+msgstr "<strong>Nota</strong>: La teva configuració de privacitat amaga els detalls del perfil a visitants desconeguts. Això provocarà que l'enllaç mostrat a GNU Social per a la teva identitat portarà a una pàgina en blanc avisant de la restricció."
+
+#: ../../addon/statusnet/statusnet.php:411
+msgid "Allow posting to GNU social"
+msgstr "Permet publicar a GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:411
+msgid ""
+"If enabled your public postings can be posted to the associated GNU-social "
+"account"
+msgstr "Si s'activa, les entrades públiques poden ser penjades al compte associat de GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:415
+msgid "Post to GNU social by default"
+msgstr "Per defecte publica a GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:415
+msgid ""
+"If enabled your public postings will be posted to the associated GNU-social "
+"account by default"
+msgstr "Si s'activa, per defecte es penjaran les teves entrades públiques al teu compte associat de GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:424 ../../addon/twitter/twitter.php:261
+msgid "Clear OAuth configuration"
+msgstr "Esborra la configuració de OAuth"
+
+#: ../../addon/statusnet/statusnet.php:432
+msgid "GNU social Post Settings"
+msgstr "Configuració de Publica a GNU Social"
+
+#: ../../addon/statusnet/statusnet.php:892
+msgid "API URL"
+msgstr "Adreça URL de l'API"
+
+#: ../../addon/statusnet/statusnet.php:895
+msgid "Application name"
+msgstr "Nom de l'aplicació"
+
+#: ../../addon/qrator/qrator.php:48
+msgid "QR code"
+msgstr "Codi QR"
+
+#: ../../addon/qrator/qrator.php:63
+msgid "QR Generator"
+msgstr "Generador de codi QR"
+
+#: ../../addon/qrator/qrator.php:64
+msgid "Enter some text"
+msgstr "Escriu un text"
+
+#: ../../addon/chess/chess.php:353 ../../addon/chess/chess.php:542
+msgid "Invalid game."
+msgstr "El joc no és vàlid."
+
+#: ../../addon/chess/chess.php:359 ../../addon/chess/chess.php:582
+msgid "You are not a player in this game."
+msgstr "No ets un jugador en aquest joc."
+
+#: ../../addon/chess/chess.php:415
+msgid "You must be a local channel to create a game."
+msgstr "Has de crear la partida des d'un canal local."
+
+#: ../../addon/chess/chess.php:433
+msgid "You must select one opponent that is not yourself."
+msgstr "Has de triar un oponent diferent a tu mateix/a."
+
+#: ../../addon/chess/chess.php:444
+msgid "Random color chosen."
+msgstr "S'ha escollit un color aleatori."
+
+#: ../../addon/chess/chess.php:452
+msgid "Error creating new game."
+msgstr "S'ha produït un error en crear la partida."
+
+#: ../../addon/chess/chess.php:486 ../../include/channel.php:1152
+msgid "Requested channel is not available."
+msgstr "El canal demanat no està disponible."
+
+#: ../../addon/chess/chess.php:500
+msgid "You must select a local channel /chess/channelname"
+msgstr "Has de triar un canal local /chess/nomdelcanal"
+
+#: ../../addon/chess/chess.php:1066
+msgid "Enable notifications"
+msgstr "Activa les notificacions"
+
+#: ../../addon/twitter/twitter.php:99
+msgid "Post to Twitter"
+msgstr "Publica a Twitter"
+
+#: ../../addon/twitter/twitter.php:155
+msgid "Twitter settings updated."
+msgstr "S'ha actualitzat la configuració de Twitter."
+
+#: ../../addon/twitter/twitter.php:184
+msgid ""
+"No consumer key pair for Twitter found. Please contact your site "
+"administrator."
+msgstr "No s'ha trobat cap parell de claus de Twitter. Contacte l'administrador del teu lloc."
+
+#: ../../addon/twitter/twitter.php:206
+msgid ""
+"At this Hubzilla instance the Twitter plugin was enabled but you have not "
+"yet connected your account to your Twitter account. To do so click the "
+"button below to get a PIN from Twitter which you have to copy into the input"
+" box below and submit the form. Only your <strong>public</strong> posts will"
+" be posted to Twitter."
+msgstr "L'extensió de Twitter està activada però encara no t'has connectat a cap compte de Twitter. Per a fer-ho, fes clic al botó de sota per a obtenir un PIN des de Twitter. Després insereix-lo a la caixa de sota i envia el formulari. Només seran publicades a GNU Social <strong>les teves entrades públiques</strong>"
+
+#: ../../addon/twitter/twitter.php:208
+msgid "Log in with Twitter"
+msgstr "Inicia la sessió amb Twitter"
+
+#: ../../addon/twitter/twitter.php:211
+msgid "Copy the PIN from Twitter here"
+msgstr "Copia el PIN de Twitter aquí"
+
+#: ../../addon/twitter/twitter.php:238
+msgid ""
+"<strong>Note:</strong> Due your privacy settings (<em>Hide your profile "
+"details from unknown viewers?</em>) the link potentially included in public "
+"postings relayed to Twitter will lead the visitor to a blank page informing "
+"the visitor that the access to your profile has been restricted."
+msgstr "<strong>Nota</strong>: La teva configuració de privacitat amaga els detalls del perfil a visitants desconeguts. Això provocarà que l'enllaç mostrat a Twitter per a la teva identitat portarà a una pàgina en blanc avisant de la restricció."
+
+#: ../../addon/twitter/twitter.php:243
+msgid "Allow posting to Twitter"
+msgstr "Permet publicar a Twitter"
+
+#: ../../addon/twitter/twitter.php:243
+msgid ""
+"If enabled your public postings can be posted to the associated Twitter "
+"account"
+msgstr "Si s'activa, les entrades públiques poden ser penjades al compte associat de Twitter"
+
+#: ../../addon/twitter/twitter.php:247
+msgid "Twitter post length"
+msgstr "Llargada del tuit"
+
+#: ../../addon/twitter/twitter.php:247
+msgid "Maximum tweet length"
+msgstr "Llargada màxima de tuit"
+
+#: ../../addon/twitter/twitter.php:252
+msgid "Send public postings to Twitter by default"
+msgstr "Envia per defecte les entrades públiques cap a Twitter"
+
+#: ../../addon/twitter/twitter.php:252
+msgid ""
+"If enabled your public postings will be posted to the associated Twitter "
+"account by default"
+msgstr "Si s'activa, per defecte es penjaran les teves entrades públiques al teu compte associat de Twitter"
+
+#: ../../addon/twitter/twitter.php:270
+msgid "Twitter Post Settings"
+msgstr "Configuració de Twitter"
+
+#: ../../addon/smileybutton/smileybutton.php:211
+msgid "Deactivate the feature"
+msgstr "Desactiva la funcionalitat"
+
+#: ../../addon/smileybutton/smileybutton.php:215
+msgid "Hide the button and show the smilies directly."
+msgstr "Amaga el botó i mostra les icones directament."
+
+#: ../../addon/smileybutton/smileybutton.php:219
+msgid "Smileybutton Settings"
+msgstr "Configuració de Smileybutton"
+
+#: ../../addon/piwik/piwik.php:85
+msgid ""
+"This website is tracked using the <a href='http://www.piwik.org'>Piwik</a> "
+"analytics tool."
+msgstr "Aquest lloc web analitza el trànsit amb l'eina <a href='http://www.piwik.org'>Piwik</a>."
+
+#: ../../addon/piwik/piwik.php:88
 #, php-format
-msgid "%s doesn't like this."
-msgstr "%s no agrada això."
+msgid ""
+"If you do not want that your visits are logged this way you <a href='%s'>can"
+" set a cookie to prevent Piwik from tracking further visits of the site</a> "
+"(opt-out)."
+msgstr "Si no vols que es registrin les teves visites d'aquesta manera, pots <a href='%s'>crear una cookie per fer que Piwik deixi de fer-ho</a>. En anglès es coneix com \"opt-out\"."
 
-#: ../../include/conversation.php:1079
+#: ../../addon/piwik/piwik.php:96
+msgid "Piwik Base URL"
+msgstr "Adreça URL arrel del Piwik"
+
+#: ../../addon/piwik/piwik.php:96
+msgid ""
+"Absolute path to your Piwik installation. (without protocol (http/s), with "
+"trailing slash)"
+msgstr "Adreça absoluta a la instaŀlació de Piwik: sense protocol (http[s]) amb una barra (/) final"
+
+#: ../../addon/piwik/piwik.php:97
+msgid "Site ID"
+msgstr "Identitat del lloc"
+
+#: ../../addon/piwik/piwik.php:98
+msgid "Show opt-out cookie link?"
+msgstr "Vols mostrar un enllaç per poder crear una cookie per evitar el seguiment?"
+
+#: ../../addon/piwik/piwik.php:99
+msgid "Asynchronous tracking"
+msgstr "Seguiment asíncron"
+
+#: ../../addon/piwik/piwik.php:100
+msgid "Enable frontend JavaScript error tracking"
+msgstr "Activa el seguiment d'errors de Javascript al frontend "
+
+#: ../../addon/piwik/piwik.php:100
+msgid "This feature requires Piwik >= 2.2.0"
+msgstr "Aquesta funcionalitat necessita una versió del Piwik >= 2.2.0"
+
+#: ../../addon/tour/tour.php:75
+msgid "Edit your profile and change settings."
+msgstr "Modifica el teu perfil i canvia la configuració."
+
+#: ../../addon/tour/tour.php:76
+msgid "Click here to see activity from your connections."
+msgstr "Clica aquí per a veure l'activitat de les teves connexions."
+
+#: ../../addon/tour/tour.php:77
+msgid "Click here to see your channel home."
+msgstr "Clica aquí per a veure el mur del teu canal."
+
+#: ../../addon/tour/tour.php:78
+msgid "You can access your private messages from here."
+msgstr "Pots accedir als teus missatges privats des d'aquí."
+
+#: ../../addon/tour/tour.php:79
+msgid "Create new events here."
+msgstr "Pots crear esdeveniments des d'aquí."
+
+#: ../../addon/tour/tour.php:80
+msgid ""
+"You can accept new connections and change permissions for existing ones "
+"here. You can also e.g. create groups of contacts."
+msgstr "Pots acceptar connexions noves des d'aquí i canviar els permisos de les existents. També pots crear grups de contactes, per exemple."
+
+#: ../../addon/tour/tour.php:81
+msgid "System notifications will arrive here"
+msgstr "Les notificacions t'arriben per aquí"
+
+#: ../../addon/tour/tour.php:82
+msgid "Search for content and users"
+msgstr "Cerca contingut i usuaris"
+
+#: ../../addon/tour/tour.php:83
+msgid "Browse for new contacts"
+msgstr "Explora per trobar nous contactes"
+
+#: ../../addon/tour/tour.php:84
+msgid "Launch installed apps"
+msgstr "Obre aplicacions instaŀlades"
+
+#: ../../addon/tour/tour.php:85
+msgid "Looking for help? Click here."
+msgstr "Que busques ajuda? Clica aquí."
+
+#: ../../addon/tour/tour.php:86
+msgid ""
+"New events have occurred in your network. Click here to see what has "
+"happened!"
+msgstr "Hi ha hagut activitat nova a la teva xarxa. Clica aquí a veure què ha passat!"
+
+#: ../../addon/tour/tour.php:87
+msgid "You have received a new private message. Click here to see from who!"
+msgstr "Has rebut un missatge privat. A veure de qui és!"
+
+#: ../../addon/tour/tour.php:88
+msgid "There are events this week. Click here too see which!"
+msgstr "Hi ha esdeveniments aquesta setmana. Clica per veure quins!"
+
+#: ../../addon/tour/tour.php:89
+msgid "You have received a new introduction. Click here to see who!"
+msgstr "Has rebut una presentació. Clica per veure de qui és!"
+
+#: ../../addon/tour/tour.php:90
+msgid ""
+"There is a new system notification. Click here to see what has happened!"
+msgstr "Tens una notificació de sistema. Clica per veure què ha passat!"
+
+#: ../../addon/tour/tour.php:93
+msgid "Click here to share text, images, videos and sound."
+msgstr "Clica aquí per a compartir text, imatges, vídeos, i sons."
+
+#: ../../addon/tour/tour.php:94
+msgid "You can write an optional title for your update (good for long posts)."
+msgstr "Si vols, pots posar un títol a les teves entrades. És una bona idea per a entrades llargues."
+
+#: ../../addon/tour/tour.php:95
+msgid "Entering some categories here makes it easier to find your post later."
+msgstr "Si afegeixes categories serà més fàcil de trobar l'entrada més endavant."
+
+#: ../../addon/tour/tour.php:96
+msgid "Share photos, links, location, etc."
+msgstr "Comparteix fotos, enllaços, la ubicació, etc."
+
+#: ../../addon/tour/tour.php:97
+msgid ""
+"Only want to share content for a while? Make it expire at a certain date."
+msgstr "Vols compartir un contingut només durant una estona? Fes-lo caducar a un cert moment."
+
+#: ../../addon/tour/tour.php:98
+msgid "You can password protect content."
+msgstr "Pots protegir el contingut per contrasenya."
+
+#: ../../addon/tour/tour.php:99
+msgid "Choose who you share with."
+msgstr "Escull amb qui ho vols compartir."
+
+#: ../../addon/tour/tour.php:101
+msgid "Click here when you are done."
+msgstr "I clica aquí quan acabis."
+
+#: ../../addon/tour/tour.php:104
+msgid "Adjust from which channels posts should be displayed."
+msgstr "Tria des de quins canals s'haurien de mostrar les entrades."
+
+#: ../../addon/tour/tour.php:105
+msgid "Only show posts from channels in the specified privacy group."
+msgstr "Mostra només entrades de canals especificats en el grup de privacitat."
+
+#: ../../addon/tour/tour.php:109
+msgid "Easily find posts containing tags (keywords preceded by the \"#\" symbol)."
+msgstr "Pots trobar fàcilment entrades que continguin etiquetes (paraules clau precedides per un símbol \"#\")."
+
+#: ../../addon/tour/tour.php:110
+msgid "Easily find posts in given category."
+msgstr "Troba fàcilment entrades en una certa categoria."
+
+#: ../../addon/tour/tour.php:111
+msgid "Easily find posts by date."
+msgstr "Troba fàcilment entrades per data."
+
+#: ../../addon/tour/tour.php:112
+msgid ""
+"Suggested users who have volounteered to be shown as suggestions, and who we"
+" think you might find interesting."
+msgstr "Els usuaris que et suggerim s'han mostrat voluntaris a ser suggerits perquè els puguis afegir. Que potser t'interessa connectar-t'hi?"
+
+#: ../../addon/tour/tour.php:113
+msgid "Here you see channels you have connected to."
+msgstr "Aquí pots veure els canals als quals estàs connectat/da."
+
+#: ../../addon/tour/tour.php:114
+msgid "Save your search so you can repeat it at a later date."
+msgstr "Si deses la teva cerca la podràs repetir més tard."
+
+#: ../../addon/tour/tour.php:117
+msgid ""
+"If you see this icon you can be sure that the sender is who it say it is. It"
+" is normal that it is not always possible to verify the sender, so the icon "
+"will be missing sometimes. There is usually no need to worry about that."
+msgstr "Si veus aquesta icona, pots donar per fet que el/la remitent és qui diu ser. De tota manera, és habitual que no es pugui verificar, i per tant, que de vegades falti aquesta icona. Però és només una capa més de seguretat del sistema."
+
+#: ../../addon/tour/tour.php:118
+msgid ""
+"Danger! It seems someone tried to forge a message! This message is not "
+"necessarily from who it says it is from!"
+msgstr "Alerta! Sembla que algú ha intentat falsificar un missatge! Pot ser que el remitent d'aquest missatge no sigui qui diu ser!"
+
+#: ../../addon/tour/tour.php:125
+msgid ""
+"Welcome to Hubzilla! Would you like to see a tour of the UI?</p> <p>You can "
+"pause it at any time and continue where you left off by reloading the page, "
+"or navigting to another page.</p><p>You can also advance by pressing the "
+"return key"
+msgstr "Benvingut/da a Hubzilla! T'agradaria fer un tur pel lloc?</p><p>Pots pausar-lo en qualsevol moment i continuar més tard on ho havies deixat. Per fer-ho navega a una altra pàgina o recarrega aquesta.</p><p>També pots avançar prement la tecla de retorn"
+
+#: ../../addon/sendzid/sendzid.php:25
+msgid "Extended Identity Sharing"
+msgstr "Compartició d'identitats extesa"
+
+#: ../../addon/sendzid/sendzid.php:26
+msgid ""
+"Share your identity with all websites on the internet. When disabled, "
+"identity is only shared with $Projectname sites."
+msgstr "Comparteix la teva identitat amb tota la web. Si es deshabilita, la identitat només es comparteix amb altres nodes de $Projectname."
+
+#: ../../addon/tictac/tictac.php:21
+msgid "Three Dimensional Tic-Tac-Toe"
+msgstr "Tres en ratlla 3D"
+
+#: ../../addon/tictac/tictac.php:54
+msgid "3D Tic-Tac-Toe"
+msgstr "Tres en ratlla 3D"
+
+#: ../../addon/tictac/tictac.php:59
+msgid "New game"
+msgstr "Nova partida"
+
+#: ../../addon/tictac/tictac.php:60
+msgid "New game with handicap"
+msgstr "Nova partida amb desavantatge"
+
+#: ../../addon/tictac/tictac.php:61
+msgid ""
+"Three dimensional tic-tac-toe is just like the traditional game except that "
+"it is played on multiple levels simultaneously. "
+msgstr "El tres en ratlla en 3D és com el clàssic en 2D excepte que es juga en diversos nivells simultàniament."
+
+#: ../../addon/tictac/tictac.php:62
+msgid ""
+"In this case there are three levels. You win by getting three in a row on "
+"any level, as well as up, down, and diagonally across the different levels."
+msgstr "En aquest cas hi ha tres nivells. Guanya qui aconsegueixi fer 3 en ratlla en qualsevol nivell, així com amunt, avall, o en diagonal en qualsevol nivell"
+
+#: ../../addon/tictac/tictac.php:64
+msgid ""
+"The handicap game disables the center position on the middle level because "
+"the player claiming this square often has an unfair advantage."
+msgstr "Una partida amb desavantatge desactiva la posició del centre perquè el jugador que aconsegueix aquest quadrat sol aconseguir un avantatge injust."
+
+#: ../../addon/tictac/tictac.php:183
+msgid "You go first..."
+msgstr "Comences!"
+
+#: ../../addon/tictac/tictac.php:188
+msgid "I'm going first this time..."
+msgstr "Aquest cop començo jo!"
+
+#: ../../addon/tictac/tictac.php:194
+msgid "You won!"
+msgstr "Has guanyat!"
+
+#: ../../addon/tictac/tictac.php:200 ../../addon/tictac/tictac.php:225
+msgid "\"Cat\" game!"
+msgstr "Empat!"
+
+#: ../../addon/tictac/tictac.php:223
+msgid "I won!"
+msgstr "He guanyat!"
+
+#: ../../addon/pageheader/pageheader.php:43
+msgid "Message to display on every page on this server"
+msgstr "Missatge per mostrar en cada pàgina d'aquest servidor"
+
+#: ../../addon/pageheader/pageheader.php:48
+msgid "Pageheader Settings"
+msgstr "Configuració del Pageheader"
+
+#: ../../addon/pageheader/pageheader.php:64
+msgid "pageheader Settings saved."
+msgstr "S'ha desat la configuració del Pageheader."
+
+#: ../../addon/authchoose/authchoose.php:67
+msgid "Only authenticate automatically to sites of your friends"
+msgstr "Autentica'm automàticament només en hubs on hi tinc connexions"
+
+#: ../../addon/authchoose/authchoose.php:67
+msgid "By default you are automatically authenticated anywhere in the network"
+msgstr "Per defecte se t'autentica en qualsevol hub de la xarxa"
+
+#: ../../addon/authchoose/authchoose.php:71
+msgid "Authchoose Settings"
+msgstr "Configuració de l'Authchoose"
+
+#: ../../addon/authchoose/authchoose.php:85
+msgid "Atuhchoose Settings updated."
+msgstr "S'ha actualitzat la configuració de l'Authchoose."
+
+#: ../../addon/moremoods/moremoods.php:19
+msgid "lonely"
+msgstr "solitari/ària"
+
+#: ../../addon/moremoods/moremoods.php:20
+msgid "drunk"
+msgstr "borratxo/a"
+
+#: ../../addon/moremoods/moremoods.php:21
+msgid "horny"
+msgstr "calent/a"
+
+#: ../../addon/moremoods/moremoods.php:22
+msgid "stoned"
+msgstr "perplex/a"
+
+#: ../../addon/moremoods/moremoods.php:23
+msgid "fucked up"
+msgstr "fotut/da"
+
+#: ../../addon/moremoods/moremoods.php:24
+msgid "clusterfucked"
+msgstr "rematadament fotut/da"
+
+#: ../../addon/moremoods/moremoods.php:25
+msgid "crazy"
+msgstr "boig/boja"
+
+#: ../../addon/moremoods/moremoods.php:26
+msgid "hurt"
+msgstr "ferit/da"
+
+#: ../../addon/moremoods/moremoods.php:27
+msgid "sleepy"
+msgstr "amb son"
+
+#: ../../addon/moremoods/moremoods.php:28
+msgid "grumpy"
+msgstr "de mal humor"
+
+#: ../../addon/moremoods/moremoods.php:29
+msgid "high"
+msgstr "flipat/da"
+
+#: ../../addon/moremoods/moremoods.php:30
+msgid "semi-conscious"
+msgstr "semi-conscient"
+
+#: ../../addon/moremoods/moremoods.php:31
+msgid "in love"
+msgstr "enamorat/da"
+
+#: ../../addon/moremoods/moremoods.php:32
+msgid "in lust"
+msgstr "en zel"
+
+#: ../../addon/moremoods/moremoods.php:33
+msgid "naked"
+msgstr "nu/nua"
+
+#: ../../addon/moremoods/moremoods.php:34
+msgid "stinky"
+msgstr "pudent/a"
+
+#: ../../addon/moremoods/moremoods.php:35
+msgid "sweaty"
+msgstr "suat/da"
+
+#: ../../addon/moremoods/moremoods.php:36
+msgid "bleeding out"
+msgstr "sagnant"
+
+#: ../../addon/moremoods/moremoods.php:37
+msgid "victorious"
+msgstr "victoriós/a"
+
+#: ../../addon/moremoods/moremoods.php:38
+msgid "defeated"
+msgstr "derrotat/da"
+
+#: ../../addon/moremoods/moremoods.php:39
+msgid "envious"
+msgstr "envejós/a"
+
+#: ../../addon/moremoods/moremoods.php:40
+msgid "jealous"
+msgstr "gelós/a"
+
+#: ../../addon/xmpp/xmpp.php:31
+msgid "XMPP settings updated."
+msgstr "S'ha actualitzat la configuració de l'XMPP."
+
+#: ../../addon/xmpp/xmpp.php:53
+msgid "Enable Chat"
+msgstr "Activa el xat"
+
+#: ../../addon/xmpp/xmpp.php:58
+msgid "Individual credentials"
+msgstr "Credencials individuals"
+
+#: ../../addon/xmpp/xmpp.php:64
+msgid "Jabber BOSH server"
+msgstr "Servidor de Jabber BOSH"
+
+#: ../../addon/xmpp/xmpp.php:69
+msgid "XMPP Settings"
+msgstr "Configuració XMPP"
+
+#: ../../addon/xmpp/xmpp.php:92
+msgid "Jabber BOSH host"
+msgstr "Nom de domini de Jabber BOSH"
+
+#: ../../addon/xmpp/xmpp.php:93
+msgid "Use central userbase"
+msgstr "Fes servir una base d'usuari/es central"
+
+#: ../../addon/xmpp/xmpp.php:93
+msgid ""
+"If enabled, members will automatically login to an ejabberd server that has "
+"to be installed on this machine with synchronized credentials via the "
+"\"auth_ejabberd.php\" script."
+msgstr "Si s'activa, s'iniciarà sessió automàticament als membres en un servidor ejabberd. Aquest ha d'estar instaŀlat en la mateixa màquina amb credencials sincronitzades, mitjançant l'script \"auth_ejabberd.php\"."
+
+#: ../../addon/wholikesme/wholikesme.php:29
+msgid "Who likes me?"
+msgstr "A qui agrado?"
+
+#: ../../addon/pumpio/pumpio.php:148
+msgid "You are now authenticated to pumpio."
+msgstr "Has iniciat sessió a pumpio."
+
+#: ../../addon/pumpio/pumpio.php:149
+msgid "return to the featured settings page"
+msgstr "torna a la pàgina de configuració"
+
+#: ../../addon/pumpio/pumpio.php:163
+msgid "Post to Pump.io"
+msgstr "Publica a Pump.io"
+
+#: ../../addon/pumpio/pumpio.php:198
+msgid "Pump.io servername"
+msgstr "Nom del servidor de Pump.io"
+
+#: ../../addon/pumpio/pumpio.php:198
+msgid "Without \"http://\" or \"https://\""
+msgstr "Sense \"http://\" ni \"https://\""
+
+#: ../../addon/pumpio/pumpio.php:202
+msgid "Pump.io username"
+msgstr "Nom d'usuari a Pump.io"
+
+#: ../../addon/pumpio/pumpio.php:202
+msgid "Without the servername"
+msgstr "Sense el nom de servidor"
+
+#: ../../addon/pumpio/pumpio.php:213
+msgid "You are not authenticated to pumpio"
+msgstr "No has iniciat sessió a pumpio"
+
+#: ../../addon/pumpio/pumpio.php:215
+msgid "(Re-)Authenticate your pump.io connection"
+msgstr "[Re]autentica la teva connexió a pump.io"
+
+#: ../../addon/pumpio/pumpio.php:219
+msgid "Enable pump.io Post Plugin"
+msgstr "Activa l'extensió Publica a pump.io"
+
+#: ../../addon/pumpio/pumpio.php:223
+msgid "Post to pump.io by default"
+msgstr "Publica a Pump.io per defecte"
+
+#: ../../addon/pumpio/pumpio.php:227
+msgid "Should posts be public"
+msgstr "Vols que les entrades siguin públiques?"
+
+#: ../../addon/pumpio/pumpio.php:231
+msgid "Mirror all public posts"
+msgstr "Replica totes les entrades públiques"
+
+#: ../../addon/pumpio/pumpio.php:237
+msgid "Pump.io Post Settings"
+msgstr "Configuració de les entrades de pump.io"
+
+#: ../../addon/pumpio/pumpio.php:266
+msgid "PumpIO Settings saved."
+msgstr "S'ha desat la configuració de pump.io"
+
+#: ../../addon/ldapauth/ldapauth.php:61
+msgid "An account has been created for you."
+msgstr "S'ha creat un compte nou."
+
+#: ../../addon/ldapauth/ldapauth.php:68
+msgid "Authentication successful but rejected: account creation is disabled."
+msgstr "L'autenticació ha tingut èxit però no s'ha pogut crear un compte perquè no està permès."
+
+#: ../../addon/opensearch/opensearch.php:26
 #, php-format
-msgid "<span  %1$s>%2$d people</span> like this."
-msgid_plural "<span  %1$s>%2$d people</span> like this."
-msgstr[0] "<span  %1$s>%2$d gent</span> agrada això."
-msgstr[1] "<span  %1$s>%2$d gent</span> agrada això."
+msgctxt "opensearch"
+msgid "Search %1$s (%2$s)"
+msgstr "Cerca %1$s(%2$s)"
 
-#: ../../include/conversation.php:1081
+#: ../../addon/opensearch/opensearch.php:28
+msgctxt "opensearch"
+msgid "$Projectname"
+msgstr "$Projectname"
+
+#: ../../addon/opensearch/opensearch.php:43
+msgid "Search $Projectname"
+msgstr "Cerca $Projectname"
+
+#: ../../addon/redfiles/redfiles.php:119
+msgid "Redmatrix File Storage Import"
+msgstr "Importa l'emmagatzematge d'arxius de Redmatrix"
+
+#: ../../addon/redfiles/redfiles.php:120
+msgid "This will import all your Redmatrix cloud files to this channel."
+msgstr "Importa tots els teus arxius de núvol cap aquest canal."
+
+#: ../../addon/redfiles/redfilehelper.php:64
+msgid "file"
+msgstr "arxiu"
+
+#: ../../addon/hubwall/hubwall.php:19
+msgid "Send email to all members"
+msgstr "Enviar correus a tothom"
+
+#: ../../addon/hubwall/hubwall.php:73
 #, php-format
-msgid "<span  %1$s>%2$d people</span> don't like this."
-msgid_plural "<span  %1$s>%2$d people</span> don't like this."
-msgstr[0] "<span  %1$s>%2$d gent</span> no agrada això."
-msgstr[1] "<span  %1$s>%2$d gent</span> no agrada això."
+msgid "%1$d of %2$d messages sent."
+msgstr "S'ha/n enviat %1$d de %2$d missatges."
 
-#: ../../include/conversation.php:1087
-msgid "and"
-msgstr "i"
+#: ../../addon/hubwall/hubwall.php:81
+msgid "Send email to all hub members."
+msgstr "Envia un correu a tots els membres del hub."
 
-#: ../../include/conversation.php:1090
-#, php-format
-msgid ", and %d other people"
-msgid_plural ", and %d other people"
-msgstr[0] ", i %d altra gent"
-msgstr[1] ", i %d altra gent"
+#: ../../addon/hubwall/hubwall.php:93
+msgid "Sender Email address"
+msgstr "Adreça del remitent"
 
-#: ../../include/conversation.php:1091
-#, php-format
-msgid "%s like this."
-msgstr "%s agrada això."
-
-#: ../../include/conversation.php:1091
-#, php-format
-msgid "%s don't like this."
-msgstr "%s no agrada això."
-
-#: ../../include/conversation.php:1130
-msgid "Set your location"
-msgstr "Ajusta la teva ubicació"
-
-#: ../../include/conversation.php:1131
-msgid "Clear browser location"
-msgstr "Treu la localització del navegador"
-
-#: ../../include/conversation.php:1177
-msgid "Tag term:"
-msgstr "Paraula de l'Etiqueta:"
-
-#: ../../include/conversation.php:1178
-msgid "Where are you right now?"
-msgstr "On ets ara?"
-
-#: ../../include/conversation.php:1210
-msgid "Page link name"
-msgstr "Nom de la pàgina enllaçada"
-
-#: ../../include/conversation.php:1213
-msgid "Post as"
-msgstr "Envia com"
-
-#: ../../include/conversation.php:1223
-msgid "Toggle voting"
-msgstr "Commutar votació"
-
-#: ../../include/conversation.php:1231
-msgid "Categories (optional, comma-separated list)"
-msgstr "Categories (opcional, llista separada per comes)"
-
-#: ../../include/conversation.php:1254
-msgid "Set publish date"
-msgstr "Ajusta la data de publicació"
-
-#: ../../include/conversation.php:1258
-msgid "OK"
-msgstr "OK"
-
-#: ../../include/conversation.php:1503
-msgid "Discover"
-msgstr "Descobrir"
-
-#: ../../include/conversation.php:1506
-msgid "Imported public streams"
-msgstr "Importar fluxos públics"
-
-#: ../../include/conversation.php:1511
-msgid "Commented Order"
-msgstr "Ordenar per Comentaris"
-
-#: ../../include/conversation.php:1514
-msgid "Sort by Comment Date"
-msgstr "Ordenar per Data del Comentari"
-
-#: ../../include/conversation.php:1518
-msgid "Posted Order"
-msgstr "Ordenar per Entrades"
-
-#: ../../include/conversation.php:1521
-msgid "Sort by Post Date"
-msgstr "Ordenar per Data d' Entrada"
-
-#: ../../include/conversation.php:1529
-msgid "Posts that mention or involve you"
-msgstr "Entrades que et mencionen o involucren"
-
-#: ../../include/conversation.php:1538
-msgid "Activity Stream - by date"
-msgstr "Activitat del Flux - per data"
-
-#: ../../include/conversation.php:1544
-msgid "Starred"
-msgstr "Preferit"
-
-#: ../../include/conversation.php:1547
-msgid "Favourite Posts"
-msgstr "Entrades Favorites"
-
-#: ../../include/conversation.php:1554
-msgid "Spam"
-msgstr "Spam"
-
-#: ../../include/conversation.php:1557
-msgid "Posts flagged as SPAM"
-msgstr "Entrades marcades com a SPAM"
-
-#: ../../include/conversation.php:1614
-msgid "Status Messages and Posts"
-msgstr "Estat dels Missatges i Entrades"
-
-#: ../../include/conversation.php:1623
-msgid "About"
-msgstr "El Meu Perfil"
-
-#: ../../include/conversation.php:1626
-msgid "Profile Details"
-msgstr "Detalls del Perfil"
-
-#: ../../include/conversation.php:1635 ../../include/photos.php:502
-msgid "Photo Albums"
-msgstr "Albums de Fotos"
-
-#: ../../include/conversation.php:1642
-msgid "Files and Storage"
-msgstr "Arxius i Emmagatzegament"
-
-#: ../../include/conversation.php:1678
-msgid "Saved Bookmarks"
-msgstr "Marcadors Guardats"
-
-#: ../../include/conversation.php:1688
-msgid "Manage Webpages"
-msgstr "Gestió de Pàgines Web"
-
-#: ../../include/conversation.php:1747
-msgctxt "noun"
-msgid "Attending"
-msgid_plural "Attending"
-msgstr[0] "Assistint"
-msgstr[1] "Assistint"
-
-#: ../../include/conversation.php:1750
-msgctxt "noun"
-msgid "Not Attending"
-msgid_plural "Not Attending"
-msgstr[0] "Desassistint"
-msgstr[1] "Desassistint"
-
-#: ../../include/conversation.php:1753
-msgctxt "noun"
-msgid "Undecided"
-msgid_plural "Undecided"
-msgstr[0] "Indecís"
-msgstr[1] "Indecisos"
-
-#: ../../include/conversation.php:1756
-msgctxt "noun"
-msgid "Agree"
-msgid_plural "Agrees"
-msgstr[0] "Acord"
-msgstr[1] "Acords"
-
-#: ../../include/conversation.php:1759
-msgctxt "noun"
-msgid "Disagree"
-msgid_plural "Disagrees"
-msgstr[0] "Desacord"
-msgstr[1] "Desacords"
-
-#: ../../include/conversation.php:1762
-msgctxt "noun"
-msgid "Abstain"
-msgid_plural "Abstains"
-msgstr[0] "Abstenirse"
-msgstr[1] "Abstenirse"
+#: ../../addon/hubwall/hubwall.php:94
+msgid "Test mode (only send to hub administrator)"
+msgstr "Mode de proves (envia'l només a l'administrador del hub)"
 
 #: ../../include/selectors.php:30
 msgid "Frequently"
@@ -8127,19 +11629,13 @@ msgstr "Transsexual"
 msgid "Hermaphrodite"
 msgstr "Hermafrodita"
 
-#: ../../include/selectors.php:49
+#: ../../include/selectors.php:49 ../../include/channel.php:1485
 msgid "Neuter"
 msgstr "Neutre"
 
-#: ../../include/selectors.php:49
+#: ../../include/selectors.php:49 ../../include/channel.php:1487
 msgid "Non-specific"
 msgstr "Indefinit"
-
-#: ../../include/selectors.php:49 ../../include/selectors.php:66
-#: ../../include/selectors.php:104 ../../include/selectors.php:140
-#: ../../include/permissions.php:881
-msgid "Other"
-msgstr "Altres"
 
 #: ../../include/selectors.php:49
 msgid "Undecided"
@@ -8317,821 +11813,802 @@ msgstr "No Et Fa Res"
 msgid "Ask me"
 msgstr "Pregunta"
 
-#: ../../include/PermissionDescription.php:31
-#: ../../include/acl_selectors.php:232
-msgid "Visible to your default audience"
-msgstr "Visible per a la teva audiència "
-
-#: ../../include/PermissionDescription.php:115
-#: ../../include/acl_selectors.php:268
-msgid "Only me"
-msgstr "Només jo"
-
-#: ../../include/PermissionDescription.php:116
-msgid "Public"
-msgstr "Públic"
-
-#: ../../include/PermissionDescription.php:117
-msgid "Anybody in the $Projectname network"
-msgstr "Ningú a la xarxa $Projectname"
-
-#: ../../include/PermissionDescription.php:118
+#: ../../include/conversation.php:169
 #, php-format
-msgid "Any account on %s"
-msgstr "Qualsevol compte a %s"
+msgid "likes %1$s's %2$s"
+msgstr "li agrada %2$s de %1$s"
 
-#: ../../include/PermissionDescription.php:119
-msgid "Any of my connections"
-msgstr "Qualsevol de les meves connexions"
-
-#: ../../include/PermissionDescription.php:120
-msgid "Only connections I specifically allow"
-msgstr "Només les connexions que permeto específicament"
-
-#: ../../include/PermissionDescription.php:121
-msgid "Anybody authenticated (could include visitors from other networks)"
-msgstr "Qualsevol persona autenticada (podria incloure als usuaris d'altres xarxes)"
-
-#: ../../include/PermissionDescription.php:122
-msgid "Any connections including those who haven't yet been approved"
-msgstr "Qualsevol connexió incloent aquells que encara no han estat aprovats"
-
-#: ../../include/PermissionDescription.php:161
-msgid ""
-"This is your default setting for the audience of your normal stream, and "
-"posts."
-msgstr "Aquest és l'ajust per defecte per al públic del seu flux normal i entrades."
-
-#: ../../include/PermissionDescription.php:162
-msgid ""
-"This is your default setting for who can view your default channel profile"
-msgstr "Aquesta és la configuració per defecte per a qui pugui veure el teu perfil per defecte del canal"
-
-#: ../../include/PermissionDescription.php:163
-msgid "This is your default setting for who can view your connections"
-msgstr "Aquesta és la configuració per defecte per a qui pugui veure les teves connexions"
-
-#: ../../include/PermissionDescription.php:164
-msgid ""
-"This is your default setting for who can view your file storage and photos"
-msgstr "Aquesta és la configuració per defecte per a qui pugui veure els teus arxius i fotos"
-
-#: ../../include/PermissionDescription.php:165
-msgid "This is your default setting for the audience of your webpages"
-msgstr "Aquests son els ajustos per defecte de l'audiència de les teves pàgines web"
-
-#: ../../include/account.php:28
-msgid "Not a valid email address"
-msgstr "Adreça de correu electrònic no vàlida"
-
-#: ../../include/account.php:30
-msgid "Your email domain is not among those allowed on this site"
-msgstr "El seu domini de correu electrònic no es troba entre els permesos en aquest lloc"
-
-#: ../../include/account.php:36
-msgid "Your email address is already registered at this site."
-msgstr "La teva adreça de correu electrònic ja esta registrada en aquest lloc"
-
-#: ../../include/account.php:68
-msgid "An invitation is required."
-msgstr "Es requereix Invitació"
-
-#: ../../include/account.php:72
-msgid "Invitation could not be verified."
-msgstr "L'invitació no ha pogut ser verificada"
-
-#: ../../include/account.php:122
-msgid "Please enter the required information."
-msgstr "Entra la informació sol·licitada"
-
-#: ../../include/account.php:189
-msgid "Failed to store account information."
-msgstr "Ha fallat guardar la informació del compte"
-
-#: ../../include/account.php:249
+#: ../../include/conversation.php:172
 #, php-format
-msgid "Registration confirmation for %s"
-msgstr "Registre confirmat per  %s"
+msgid "doesn't like %1$s's %2$s"
+msgstr "no li agrada %2$s de %1$s"
 
-#: ../../include/account.php:315
+#: ../../include/conversation.php:212
 #, php-format
-msgid "Registration request at %s"
-msgstr "Sol·licitud de registre a %s"
+msgid "%1$s is now connected with %2$s"
+msgstr "%1$s esta ara connectat amb %2$s"
 
-#: ../../include/account.php:317 ../../include/account.php:344
-#: ../../include/account.php:404 ../../include/network.php:1871
-msgid "Administrator"
-msgstr "Administrador"
-
-#: ../../include/account.php:339
-msgid "your registration password"
-msgstr "la teva contrasenya registrada"
-
-#: ../../include/account.php:342 ../../include/account.php:402
+#: ../../include/conversation.php:247
 #, php-format
-msgid "Registration details for %s"
-msgstr "Detalls del registre per %s"
+msgid "%1$s poked %2$s"
+msgstr "%1$s  a esperonat %2$s"
 
-#: ../../include/account.php:414
-msgid "Account approved."
-msgstr "Compte aprovat."
+#: ../../include/conversation.php:251 ../../include/text.php:1129
+#: ../../include/text.php:1133
+msgid "poked"
+msgstr "esperonat"
 
-#: ../../include/account.php:454
+#: ../../include/conversation.php:736
 #, php-format
-msgid "Registration revoked for %s"
-msgstr "Registre revocat per %s"
+msgid "View %s's profile @ %s"
+msgstr "Vista %s del perfil @ %s"
 
-#: ../../include/account.php:506
-msgid "Account verified. Please login."
-msgstr "Compte verificat. Si us plau, inicia sessió."
+#: ../../include/conversation.php:756
+msgid "Categories:"
+msgstr "Categories:"
 
-#: ../../include/account.php:723 ../../include/account.php:725
-msgid "Click here to upgrade."
-msgstr "Feu clic aquí per actualitzar."
+#: ../../include/conversation.php:757
+msgid "Filed under:"
+msgstr "Arxivar a:"
 
-#: ../../include/account.php:731
-msgid "This action exceeds the limits set by your subscription plan."
-msgstr "Aquesta acció és superior als límits establerts pel seu pla de subscripció."
+#: ../../include/conversation.php:783
+msgid "View in context"
+msgstr "Veure en context"
 
-#: ../../include/account.php:736
-msgid "This action is not available under your subscription plan."
-msgstr "Aquesta acció no està disponible en el seu pla de subscripció."
+#: ../../include/conversation.php:884
+msgid "remove"
+msgstr "treu"
 
-#: ../../include/attach.php:247 ../../include/attach.php:333
-msgid "Item was not found."
-msgstr "Article no trobat."
+#: ../../include/conversation.php:888
+msgid "Loading..."
+msgstr "Carregant..."
 
-#: ../../include/attach.php:497
-msgid "No source file."
-msgstr "No hi ha arxiu d'origen."
+#: ../../include/conversation.php:889
+msgid "Delete Selected Items"
+msgstr "Esborra els Articles Seleccionats"
 
-#: ../../include/attach.php:519
-msgid "Cannot locate file to replace"
-msgstr "No trobo l'arxiu a reemplaçar"
+#: ../../include/conversation.php:932
+msgid "View Source"
+msgstr "Veure l'Origen"
 
-#: ../../include/attach.php:537
-msgid "Cannot locate file to revise/update"
-msgstr "No trobo l'arxiu a revisar/actualitzar"
+#: ../../include/conversation.php:942
+msgid "Follow Thread"
+msgstr "Segueix el Fil"
 
-#: ../../include/attach.php:672
+#: ../../include/conversation.php:951
+msgid "Unfollow Thread"
+msgstr "Fil Abandonat"
+
+#: ../../include/conversation.php:1042
+msgid "Activity/Posts"
+msgstr "Activitat/Entrades"
+
+#: ../../include/conversation.php:1062
+msgid "Edit Connection"
+msgstr "Modifica la Connexió"
+
+#: ../../include/conversation.php:1072
+msgid "Message"
+msgstr "Missatge"
+
+#: ../../include/conversation.php:1206
 #, php-format
-msgid "File exceeds size limit of %d"
-msgstr "L'arxiu excedeix la mida limit de %d"
+msgid "%s likes this."
+msgstr "%s agrada això."
 
-#: ../../include/attach.php:686
+#: ../../include/conversation.php:1206
 #, php-format
-msgid "You have reached your limit of %1$.0f Mbytes attachment storage."
-msgstr "Has arribat al teu límit de %1$.0f Mbytes de emagatzematge d'adjunts."
+msgid "%s doesn't like this."
+msgstr "%s no agrada això."
 
-#: ../../include/attach.php:842
-msgid "File upload failed. Possible system limit or action terminated."
-msgstr "Pujada del arxiu fallida. Possible límit del sistema o acció interrompuda."
-
-#: ../../include/attach.php:855
-msgid "Stored file could not be verified. Upload failed."
-msgstr "L'arxiu guardat no es pot verificar. Pujada fallida."
-
-#: ../../include/attach.php:909 ../../include/attach.php:925
-msgid "Path not available."
-msgstr "Trajectòria no disponible"
-
-#: ../../include/attach.php:971 ../../include/attach.php:1123
-msgid "Empty pathname"
-msgstr "Trajèctoria vuida."
-
-#: ../../include/attach.php:997
-msgid "duplicate filename or path"
-msgstr "Nom o trajectòria duplicat"
-
-#: ../../include/attach.php:1019
-msgid "Path not found."
-msgstr "Trajectòria no trobada."
-
-#: ../../include/attach.php:1077
-msgid "mkdir failed."
-msgstr "mkdir va fracassar."
-
-#: ../../include/attach.php:1081
-msgid "database storage failed."
-msgstr "Arxiu de base de dades va fallar."
-
-#: ../../include/attach.php:1129
-msgid "Empty path"
-msgstr "Trajèctoria vuida"
-
-#: ../../include/channel.php:32
-msgid "Unable to obtain identity information from database"
-msgstr "Incapaç de trobar l'informació d'identitat a la base de dades"
-
-#: ../../include/channel.php:66
-msgid "Empty name"
-msgstr "Nom buit"
-
-#: ../../include/channel.php:69
-msgid "Name too long"
-msgstr "Nom massa llarg"
-
-#: ../../include/channel.php:180
-msgid "No account identifier"
-msgstr "Sense identificador de compte"
-
-#: ../../include/channel.php:192
-msgid "Nickname is required."
-msgstr "Alies/malnom es requerit."
-
-#: ../../include/channel.php:206
-msgid "Reserved nickname. Please choose another."
-msgstr "Àlies reservat. Tria un altre."
-
-#: ../../include/channel.php:211
-msgid ""
-"Nickname has unsupported characters or is already being used on this site."
-msgstr "L'álies te caracters no soportats o ja esta en ús en aquest lloc"
-
-#: ../../include/channel.php:287
-msgid "Unable to retrieve created identity"
-msgstr "No es pot recuperar la identitat creada"
-
-#: ../../include/channel.php:345
-msgid "Default Profile"
-msgstr "Perfil per Defecte"
-
-#: ../../include/channel.php:791
-msgid "Requested channel is not available."
-msgstr "El canal demanat no està disponible."
-
-#: ../../include/channel.php:938
-msgid "Create New Profile"
-msgstr "Crear un Perfil Nou"
-
-#: ../../include/channel.php:958
-msgid "Visible to everybody"
-msgstr "Visible per tothom"
-
-#: ../../include/channel.php:1031 ../../include/channel.php:1142
-msgid "Gender:"
-msgstr "Gènere:"
-
-#: ../../include/channel.php:1032 ../../include/channel.php:1186
-msgid "Status:"
-msgstr "Estatus:"
-
-#: ../../include/channel.php:1033 ../../include/channel.php:1197
-msgid "Homepage:"
-msgstr "Pàgina Personal:"
-
-#: ../../include/channel.php:1034
-msgid "Online Now"
-msgstr "Ara en Linia"
-
-#: ../../include/channel.php:1147
-msgid "Like this channel"
-msgstr "M'agrada aquest canal"
-
-#: ../../include/channel.php:1171
-msgid "j F, Y"
-msgstr "j F, Y"
-
-#: ../../include/channel.php:1172
-msgid "j F"
-msgstr "j F"
-
-#: ../../include/channel.php:1179
-msgid "Birthday:"
-msgstr "Aniversari:"
-
-#: ../../include/channel.php:1192
+#: ../../include/conversation.php:1210
 #, php-format
-msgid "for %1$d %2$s"
-msgstr "per %1$d %2$s"
-
-#: ../../include/channel.php:1195
-msgid "Sexual Preference:"
-msgstr "Preferència Sexual:"
-
-#: ../../include/channel.php:1201
-msgid "Tags:"
-msgstr "Etiquetes:"
-
-#: ../../include/channel.php:1203
-msgid "Political Views:"
-msgstr "Idees Polítiques:"
-
-#: ../../include/channel.php:1205
-msgid "Religion:"
-msgstr "Religió:"
-
-#: ../../include/channel.php:1209
-msgid "Hobbies/Interests:"
-msgstr "Aficions/Interessos:"
-
-#: ../../include/channel.php:1211
-msgid "Likes:"
-msgstr "Agrada:"
-
-#: ../../include/channel.php:1213
-msgid "Dislikes:"
-msgstr "Desagrada:"
-
-#: ../../include/channel.php:1215
-msgid "Contact information and Social Networks:"
-msgstr "Informació de contacte i Xarxes Socials:"
-
-#: ../../include/channel.php:1217
-msgid "My other channels:"
-msgstr "Els meus altres canals:"
-
-#: ../../include/channel.php:1219
-msgid "Musical interests:"
-msgstr "Interessos Musicals:"
-
-#: ../../include/channel.php:1221
-msgid "Books, literature:"
-msgstr "Llibres, literatura:"
-
-#: ../../include/channel.php:1223
-msgid "Television:"
-msgstr "Televisió:"
-
-#: ../../include/channel.php:1225
-msgid "Film/dance/culture/entertainment:"
-msgstr "Películes/Dança/Cultura/Entreteniment:"
-
-#: ../../include/channel.php:1227
-msgid "Love/Romance:"
-msgstr "Amor/Romace:"
-
-#: ../../include/channel.php:1229
-msgid "Work/employment:"
-msgstr "Treball/feina:"
-
-#: ../../include/channel.php:1231
-msgid "School/education:"
-msgstr "Escola/educació:"
-
-#: ../../include/channel.php:1251
-msgid "Like this thing"
-msgstr "M'agrada això"
-
-#: ../../include/features.php:48
-msgid "General Features"
-msgstr "Característiques Generals"
-
-#: ../../include/features.php:50
-msgid "Content Expiration"
-msgstr "Expiració del Contingut"
-
-#: ../../include/features.php:50
-msgid "Remove posts/comments and/or private messages at a future time"
-msgstr "eliminarà entrades/comentaris i/o missatges privats en un període determinat de temps."
-
-#: ../../include/features.php:51
-msgid "Multiple Profiles"
-msgstr "Multiples Perfils"
-
-#: ../../include/features.php:51
-msgid "Ability to create multiple profiles"
-msgstr "Capacitat per crear multiples perfils"
-
-#: ../../include/features.php:52
-msgid "Advanced Profiles"
-msgstr "Perfils Avançats"
-
-#: ../../include/features.php:52
-msgid "Additional profile sections and selections"
-msgstr "Seccions i seleccions addicionals de perfils "
-
-#: ../../include/features.php:53
-msgid "Profile Import/Export"
-msgstr "Importar/Exportar Perfil"
-
-#: ../../include/features.php:53
-msgid "Save and load profile details across sites/channels"
-msgstr "Guarda i carrega els detalls del perfil al llarg dels llocs/canals"
-
-#: ../../include/features.php:54
-msgid "Web Pages"
-msgstr "Pàgines Web"
-
-#: ../../include/features.php:54
-msgid "Provide managed web pages on your channel"
-msgstr "Proporcionar pàgines web gestionades al seu canal"
-
-#: ../../include/features.php:55
-msgid "Hide Rating"
-msgstr "Amaga la Valoració"
-
-#: ../../include/features.php:55
-msgid ""
-"Hide the rating buttons on your channel and profile pages. Note: People can "
-"still rate you somewhere else."
-msgstr "Amaga el botó de valoracions al teu canal i pàgines del perfil. Nota: Et poden continuar valorant en altres llocs."
-
-#: ../../include/features.php:56
-msgid "Private Notes"
-msgstr "Notes Privades"
-
-#: ../../include/features.php:56
-msgid "Enables a tool to store notes and reminders (note: not encrypted)"
-msgstr "Activa l'eina per guardar notes i recordatoris (nota:no està encriptat)"
-
-#: ../../include/features.php:57
-msgid "Navigation Channel Select"
-msgstr "Navegació pel Selector de Canals"
-
-#: ../../include/features.php:57
-msgid "Change channels directly from within the navigation dropdown menu"
-msgstr "Canvieu els canals directament des del menú desplegable de navegació"
-
-#: ../../include/features.php:58
-msgid "Photo Location"
-msgstr "Ubicació de la Foto"
-
-#: ../../include/features.php:58
-msgid "If location data is available on uploaded photos, link this to a map."
-msgstr "Si les dades d'ubicació estàn disponibles a les fotos pujades, vincular a un mapa."
-
-#: ../../include/features.php:59
-msgid "Access Controlled Chatrooms"
-msgstr "Accés Controlat a les Sales de Xat"
-
-#: ../../include/features.php:59
-msgid "Provide chatrooms and chat services with access control."
-msgstr "Proveeix sales de Xat i serveis de Xat amb control d'accés."
-
-#: ../../include/features.php:60
-msgid "Smart Birthdays"
-msgstr "Aniversaris Intel·ligents"
-
-#: ../../include/features.php:60
-msgid ""
-"Make birthday events timezone aware in case your friends are scattered "
-"across the planet."
-msgstr "Fes, conscients de la zona horària, els esdeveniments d'aniversari, en cas que els teus amics estiguin dispersos per tot el planeta."
-
-#: ../../include/features.php:61
-msgid "Expert Mode"
-msgstr "Manera Experta"
-
-#: ../../include/features.php:61
-msgid "Enable Expert Mode to provide advanced configuration options"
-msgstr "Activar Mode Expert per a proporcionar opcions avançades de configuració"
-
-#: ../../include/features.php:62
-msgid "Premium Channel"
-msgstr "Privilegis del Canal"
-
-#: ../../include/features.php:62
-msgid ""
-"Allows you to set restrictions and terms on those that connect with your "
-"channel"
-msgstr "Li permet establir restriccions i els termes en els quals es connecten amb el seu canal"
-
-#: ../../include/features.php:67
-msgid "Post Composition Features"
-msgstr "Característiques de Composició d'Entrades"
-
-#: ../../include/features.php:70
-msgid "Large Photos"
-msgstr "Grans Fotos"
-
-#: ../../include/features.php:70
-msgid ""
-"Include large (1024px) photo thumbnails in posts. If not enabled, use small "
-"(640px) photo thumbnails"
-msgstr "Inclou gran (1024px) foto de miniatura a les entrades. Si no està activat, empra petita (640px) foto de miniatura."
-
-#: ../../include/features.php:71
-msgid "Automatically import channel content from other channels or feeds"
-msgstr "Importa automàticament el contingut del canal des de altres canals o feeds"
-
-#: ../../include/features.php:72
-msgid "Even More Encryption"
-msgstr "Encara Més Encriptació"
-
-#: ../../include/features.php:72
-msgid ""
-"Allow optional encryption of content end-to-end with a shared secret key"
-msgstr "Permet l'encripció opcional del contingut extrem-a-extrem amb clau secreta compartida"
-
-#: ../../include/features.php:73
-msgid "Enable Voting Tools"
-msgstr "Habilitar Eines de Votació"
-
-#: ../../include/features.php:73
-msgid "Provide a class of post which others can vote on"
-msgstr "Proporcionar una classe d'entrada que altres puguin votar"
-
-#: ../../include/features.php:74
-msgid "Delayed Posting"
-msgstr "Retarda Publicació"
-
-#: ../../include/features.php:74
-msgid "Allow posts to be published at a later date"
-msgstr "Permet que les publicacions es publiquin en data posterior"
-
-#: ../../include/features.php:75
-msgid "Suppress Duplicate Posts/Comments"
-msgstr "Suprimeix Duplicats de Publicacions/Comentaris"
-
-#: ../../include/features.php:75
-msgid ""
-"Prevent posts with identical content to be published with less than two "
-"minutes in between submissions."
-msgstr "Evita que publicacions amb identic contingut siguin publicades amb menys de dos minuts entre entregues."
-
-#: ../../include/features.php:81
-msgid "Network and Stream Filtering"
-msgstr "Filtrat de Xarxa i Flux"
-
-#: ../../include/features.php:82
-msgid "Search by Date"
-msgstr "Cerca per Data"
-
-#: ../../include/features.php:82
-msgid "Ability to select posts by date ranges"
-msgstr "Capacitat per seleccionar entrades per rang de dates"
-
-#: ../../include/features.php:83 ../../include/group.php:311
-msgid "Privacy Groups"
-msgstr "Grup Privat"
-
-#: ../../include/features.php:83
-msgid "Enable management and selection of privacy groups"
-msgstr "Habilita gestió i selecció de grups privats"
-
-#: ../../include/features.php:84
-msgid "Save search terms for re-use"
-msgstr "Guardar els termin de la cerca per a re-usar"
-
-#: ../../include/features.php:85
-msgid "Network Personal Tab"
-msgstr "Pestanya Personal de Xarxa"
-
-#: ../../include/features.php:85
-msgid "Enable tab to display only Network posts that you've interacted on"
-msgstr "Activa la pestanya per mostrar només les entrades de xarxa en les que has intervingut"
-
-#: ../../include/features.php:86
-msgid "Network New Tab"
-msgstr "Pestanya Nou a la Xarxa"
-
-#: ../../include/features.php:86
-msgid "Enable tab to display all new Network activity"
-msgstr "Activa pestanya per mostrar tota l'activitat nova de la Xarxa"
-
-#: ../../include/features.php:87
-msgid "Affinity Tool"
-msgstr "Eina d'Afinitat"
-
-#: ../../include/features.php:87
-msgid "Filter stream activity by depth of relationships"
-msgstr "Filtre d'activitat del flux per importància de la relació"
-
-#: ../../include/features.php:88
-msgid "Connection Filtering"
-msgstr "Filtre de Connexió"
-
-#: ../../include/features.php:88
-msgid "Filter incoming posts from connections based on keywords/content"
-msgstr "Filtre de missatges d'entrada de conexions, basat en paraules clau/contingut "
-
-#: ../../include/features.php:89
-msgid "Show channel suggestions"
-msgstr "Mostra suggerencies de canals"
-
-#: ../../include/features.php:94
-msgid "Post/Comment Tools"
-msgstr "Eina d'Entrades/Comentaris"
-
-#: ../../include/features.php:95
-msgid "Community Tagging"
-msgstr "Etiquetat per la Comunitat"
-
-#: ../../include/features.php:95
-msgid "Ability to tag existing posts"
-msgstr "Capacitat d'etiquetar entrades existents"
-
-#: ../../include/features.php:96
-msgid "Post Categories"
-msgstr "Categories d'Entrades"
-
-#: ../../include/features.php:96
-msgid "Add categories to your posts"
-msgstr "Afegeix categoria a la teva entrada"
-
-#: ../../include/features.php:97
-msgid "Emoji Reactions"
-msgstr ""
-
-#: ../../include/features.php:97
-msgid "Add emoji reaction ability to posts"
-msgstr ""
-
-#: ../../include/features.php:98
-msgid "Ability to file posts under folders"
-msgstr "Capacitat de arxivar entrades en les carpetes"
-
-#: ../../include/features.php:99
-msgid "Dislike Posts"
-msgstr "No Agrada l'Entrada"
-
-#: ../../include/features.php:99
-msgid "Ability to dislike posts/comments"
-msgstr "Capacitat per marcar amb \"No Agrada\" les entrades/comentaris"
-
-#: ../../include/features.php:100
-msgid "Star Posts"
-msgstr "Entrades Excel·lents"
-
-#: ../../include/features.php:100
-msgid "Ability to mark special posts with a star indicator"
-msgstr "Capacitat per marcar entrades especials amb l'indicador d'excel·lencia"
-
-#: ../../include/features.php:101
-msgid "Tag Cloud"
-msgstr "Núvol d'Etiquetes."
-
-#: ../../include/features.php:101
-msgid "Provide a personal tag cloud on your channel page"
-msgstr "Proporcionar un núvol d'etiquetes personals a la teva pàgina de canal"
-
-#: ../../include/oembed.php:324
-msgid "Embedded content"
-msgstr "Contingut embegut"
-
-#: ../../include/oembed.php:333
-msgid "Embedding disabled"
-msgstr "Incorporació desactivada"
-
-#: ../../include/acl_selectors.php:271
-msgid "Who can see this?"
-msgstr "Qui pot veure això?"
-
-#: ../../include/acl_selectors.php:272
-msgid "Custom selection"
-msgstr "Selecció a mida"
-
-#: ../../include/acl_selectors.php:273
-msgid ""
-"Select \"Show\" to allow viewing. \"Don't show\" lets you override and limit"
-" the scope of \"Show\"."
-msgstr "Selecciona \"Mostrar\" per permetre la visualització. \"No Mostrar\" et permet obviar i limitar l'abast de \"Mostrar\"."
-
-#: ../../include/acl_selectors.php:274
-msgid "Show"
-msgstr "Mostra"
-
-#: ../../include/acl_selectors.php:275
-msgid "Don't show"
-msgstr "No mostrar"
-
-#: ../../include/acl_selectors.php:281
+msgid "<span  %1$s>%2$d people</span> like this."
+msgid_plural "<span  %1$s>%2$d people</span> like this."
+msgstr[0] "<span  %1$s>%2$d gent</span> agrada això."
+msgstr[1] "<span  %1$s>%2$d gent</span> agrada això."
+
+#: ../../include/conversation.php:1212
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't like this."
+msgid_plural "<span  %1$s>%2$d people</span> don't like this."
+msgstr[0] "<span  %1$s>%2$d gent</span> no agrada això."
+msgstr[1] "<span  %1$s>%2$d gent</span> no agrada això."
+
+#: ../../include/conversation.php:1218
+msgid "and"
+msgstr "i"
+
+#: ../../include/conversation.php:1221
+#, php-format
+msgid ", and %d other people"
+msgid_plural ", and %d other people"
+msgstr[0] ", i %d altra gent"
+msgstr[1] ", i %d altra gent"
+
+#: ../../include/conversation.php:1222
+#, php-format
+msgid "%s like this."
+msgstr "%s agrada això."
+
+#: ../../include/conversation.php:1222
+#, php-format
+msgid "%s don't like this."
+msgstr "%s no agrada això."
+
+#: ../../include/conversation.php:1265
+msgid "Set your location"
+msgstr "Ajusta la teva ubicació"
+
+#: ../../include/conversation.php:1266
+msgid "Clear browser location"
+msgstr "Treu la localització del navegador"
+
+#: ../../include/conversation.php:1314
+msgid "Tag term:"
+msgstr "Paraula de l'Etiqueta:"
+
+#: ../../include/conversation.php:1315
+msgid "Where are you right now?"
+msgstr "On ets ara?"
+
+#: ../../include/conversation.php:1320
+msgid "Choose a different album..."
+msgstr "Tria un àlbum diferent..."
+
+#: ../../include/conversation.php:1324
+msgid "Comments enabled"
+msgstr "S'han activat els comentaris"
+
+#: ../../include/conversation.php:1325
+msgid "Comments disabled"
+msgstr "S'han activat els comentaris"
+
+#: ../../include/conversation.php:1372
+msgid "Page link name"
+msgstr "Nom de la pàgina enllaçada"
+
+#: ../../include/conversation.php:1375
+msgid "Post as"
+msgstr "Envia com"
+
+#: ../../include/conversation.php:1389
+msgid "Toggle voting"
+msgstr "Commutar votació"
+
+#: ../../include/conversation.php:1392
+msgid "Disable comments"
+msgstr "Desactiva els comentaris"
+
+#: ../../include/conversation.php:1393
+msgid "Toggle comments"
+msgstr "Commuta l'estat dels comentaris"
+
+#: ../../include/conversation.php:1401
+msgid "Categories (optional, comma-separated list)"
+msgstr "Categories (opcional, llista separada per comes)"
+
+#: ../../include/conversation.php:1424
 msgid "Other networks and post services"
 msgstr "Altres xarxes i serveis de correu"
 
-#: ../../include/acl_selectors.php:311
+#: ../../include/conversation.php:1430
+msgid "Set publish date"
+msgstr "Ajusta la data de publicació"
+
+#: ../../include/conversation.php:1690
+msgid "Commented Order"
+msgstr "Ordenar per Comentaris"
+
+#: ../../include/conversation.php:1693
+msgid "Sort by Comment Date"
+msgstr "Ordenar per Data del Comentari"
+
+#: ../../include/conversation.php:1697
+msgid "Posted Order"
+msgstr "Ordenar per Entrades"
+
+#: ../../include/conversation.php:1700
+msgid "Sort by Post Date"
+msgstr "Ordenar per Data d' Entrada"
+
+#: ../../include/conversation.php:1708
+msgid "Posts that mention or involve you"
+msgstr "Entrades que et mencionen o involucren"
+
+#: ../../include/conversation.php:1717
+msgid "Activity Stream - by date"
+msgstr "Activitat del Flux - per data"
+
+#: ../../include/conversation.php:1723
+msgid "Starred"
+msgstr "Preferit"
+
+#: ../../include/conversation.php:1726
+msgid "Favourite Posts"
+msgstr "Entrades Favorites"
+
+#: ../../include/conversation.php:1733
+msgid "Spam"
+msgstr "Spam"
+
+#: ../../include/conversation.php:1736
+msgid "Posts flagged as SPAM"
+msgstr "Entrades marcades com a SPAM"
+
+#: ../../include/conversation.php:1811 ../../include/nav.php:381
+msgid "Status Messages and Posts"
+msgstr "Estat dels Missatges i Entrades"
+
+#: ../../include/conversation.php:1824 ../../include/nav.php:394
+msgid "Profile Details"
+msgstr "Detalls del Perfil"
+
+#: ../../include/conversation.php:1834 ../../include/nav.php:404
+#: ../../include/photos.php:655
+msgid "Photo Albums"
+msgstr "Albums de Fotos"
+
+#: ../../include/conversation.php:1842 ../../include/nav.php:412
+msgid "Files and Storage"
+msgstr "Arxius i Emmagatzegament"
+
+#: ../../include/conversation.php:1879 ../../include/nav.php:447
+msgid "Bookmarks"
+msgstr "Marcadors"
+
+#: ../../include/conversation.php:1882 ../../include/nav.php:450
+msgid "Saved Bookmarks"
+msgstr "Marcadors Guardats"
+
+#: ../../include/conversation.php:1893 ../../include/nav.php:461
+msgid "View Cards"
+msgstr "Mostra les targetes"
+
+#: ../../include/conversation.php:1901
+msgid "articles"
+msgstr "articles"
+
+#: ../../include/conversation.php:1904 ../../include/nav.php:472
+msgid "View Articles"
+msgstr "Mostra els articles"
+
+#: ../../include/conversation.php:1915 ../../include/nav.php:484
+msgid "View Webpages"
+msgstr "Mostra les pàgines web"
+
+#: ../../include/conversation.php:1984
+msgctxt "noun"
+msgid "Attending"
+msgid_plural "Attending"
+msgstr[0] "Assistint"
+msgstr[1] "Assistint"
+
+#: ../../include/conversation.php:1987
+msgctxt "noun"
+msgid "Not Attending"
+msgid_plural "Not Attending"
+msgstr[0] "Desassistint"
+msgstr[1] "Desassistint"
+
+#: ../../include/conversation.php:1990
+msgctxt "noun"
+msgid "Undecided"
+msgid_plural "Undecided"
+msgstr[0] "Indecís"
+msgstr[1] "Indecisos"
+
+#: ../../include/conversation.php:1993
+msgctxt "noun"
+msgid "Agree"
+msgid_plural "Agrees"
+msgstr[0] "Acord"
+msgstr[1] "Acords"
+
+#: ../../include/conversation.php:1996
+msgctxt "noun"
+msgid "Disagree"
+msgid_plural "Disagrees"
+msgstr[0] "Desacord"
+msgstr[1] "Desacords"
+
+#: ../../include/conversation.php:1999
+msgctxt "noun"
+msgid "Abstain"
+msgid_plural "Abstains"
+msgstr[0] "Abstenirse"
+msgstr[1] "Abstenirse"
+
+#: ../../include/dir_fns.php:141
+msgid "Directory Options"
+msgstr "Opcions de Directori"
+
+#: ../../include/dir_fns.php:143
+msgid "Safe Mode"
+msgstr "Manera Segura"
+
+#: ../../include/dir_fns.php:144
+msgid "Public Forums Only"
+msgstr "Només Fòrums Públics"
+
+#: ../../include/dir_fns.php:145
+msgid "This Website Only"
+msgstr "Només Aquest Lloc Web"
+
+#: ../../include/bookmarks.php:34
 #, php-format
+msgid "%1$s's bookmarks"
+msgstr "%1$s de marcadors"
+
+#: ../../include/import.php:41
 msgid ""
-"Post permissions %s cannot be changed %s after a post is shared.</br />These"
-" permissions set who is allowed to view the post."
-msgstr "Els permisos d'entrada %s no poden esser canviats %s posteriorment a que una entrada ja està compartida. </br />Aquest ajust dels permisos indica qui pot veure l'entrada."
+"Cannot create a duplicate channel identifier on this system. Import failed."
+msgstr "No s'ha pogut importar el canal perquè l'identificador del canal no s'ha pogut duplicar en aquest servidor."
 
-#: ../../include/auth.php:105
-msgid "Logged out."
-msgstr "Sortir."
+#: ../../include/import.php:106
+msgid "Cloned channel not found. Import failed."
+msgstr "No s'ha pogut importar el canal perquè el canal clonat no s'ha trobat."
 
-#: ../../include/auth.php:212
-msgid "Failed authentication"
-msgstr "Autenticació fallida"
+#: ../../include/text.php:492
+msgid "prev"
+msgstr "prev"
 
-#: ../../include/datetime.php:135
-msgid "Birthday"
-msgstr "Aniversari"
+#: ../../include/text.php:494
+msgid "first"
+msgstr "primer"
 
-#: ../../include/datetime.php:137
-msgid "Age: "
-msgstr "Edat:"
+#: ../../include/text.php:523
+msgid "last"
+msgstr "últim"
 
-#: ../../include/datetime.php:139
-msgid "YYYY-MM-DD or MM-DD"
-msgstr "YYYY-MM-DD o MM-DD"
+#: ../../include/text.php:526
+msgid "next"
+msgstr "pròxim"
 
-#: ../../include/datetime.php:272 ../../boot.php:2470
-msgid "never"
-msgstr "mai"
+#: ../../include/text.php:537
+msgid "older"
+msgstr "el més antic"
 
-#: ../../include/datetime.php:278
-msgid "less than a second ago"
-msgstr "fa menys d'un segon"
+#: ../../include/text.php:539
+msgid "newer"
+msgstr "El més nou"
 
-#: ../../include/datetime.php:296
+#: ../../include/text.php:961
+msgid "No connections"
+msgstr "Sense Connexions"
+
+#: ../../include/text.php:993
 #, php-format
-msgctxt "e.g. 22 hours ago, 1 minute ago"
-msgid "%1$d %2$s ago"
-msgstr "Fa %1$d %2$s"
+msgid "View all %s connections"
+msgstr "Veure totes les connexions de %s"
 
-#: ../../include/datetime.php:307
-msgctxt "relative_date"
-msgid "year"
-msgid_plural "years"
-msgstr[0] "any"
-msgstr[1] "anys"
+#: ../../include/text.php:1129 ../../include/text.php:1133
+msgid "poke"
+msgstr "esperona"
 
-#: ../../include/datetime.php:310
-msgctxt "relative_date"
-msgid "month"
-msgid_plural "months"
-msgstr[0] "mes"
-msgstr[1] "mesos "
+#: ../../include/text.php:1134
+msgid "ping"
+msgstr "coloca"
 
-#: ../../include/datetime.php:313
-msgctxt "relative_date"
-msgid "week"
-msgid_plural "weeks"
-msgstr[0] "setmana"
-msgstr[1] "setmanes"
+#: ../../include/text.php:1134
+msgid "pinged"
+msgstr "colocat"
 
-#: ../../include/datetime.php:316
-msgctxt "relative_date"
-msgid "day"
-msgid_plural "days"
-msgstr[0] "dia"
-msgstr[1] "dies"
+#: ../../include/text.php:1135
+msgid "prod"
+msgstr "picar"
 
-#: ../../include/datetime.php:319
-msgctxt "relative_date"
-msgid "hour"
-msgid_plural "hours"
-msgstr[0] "hora"
-msgstr[1] "hores"
+#: ../../include/text.php:1135
+msgid "prodded"
+msgstr "picat"
 
-#: ../../include/datetime.php:322
-msgctxt "relative_date"
-msgid "minute"
-msgid_plural "minutes"
-msgstr[0] "minut"
-msgstr[1] "minuts"
+#: ../../include/text.php:1136
+msgid "slap"
+msgstr "bufetada"
 
-#: ../../include/datetime.php:325
-msgctxt "relative_date"
-msgid "second"
-msgid_plural "seconds"
-msgstr[0] "segon"
-msgstr[1] "segons"
+#: ../../include/text.php:1136
+msgid "slapped"
+msgstr "bufetejat"
 
-#: ../../include/datetime.php:562
+#: ../../include/text.php:1137
+msgid "finger"
+msgstr "senyal"
+
+#: ../../include/text.php:1137
+msgid "fingered"
+msgstr "senyalat"
+
+#: ../../include/text.php:1138
+msgid "rebuff"
+msgstr "menyspreu"
+
+#: ../../include/text.php:1138
+msgid "rebuffed"
+msgstr "menyspreuat"
+
+#: ../../include/text.php:1161
+msgid "happy"
+msgstr "feliç"
+
+#: ../../include/text.php:1162
+msgid "sad"
+msgstr "trist"
+
+#: ../../include/text.php:1163
+msgid "mellow"
+msgstr "melós"
+
+#: ../../include/text.php:1164
+msgid "tired"
+msgstr "cansat"
+
+#: ../../include/text.php:1165
+msgid "perky"
+msgstr "turgent"
+
+#: ../../include/text.php:1166
+msgid "angry"
+msgstr "enfadat"
+
+#: ../../include/text.php:1167
+msgid "stupefied"
+msgstr "estupefacte"
+
+#: ../../include/text.php:1168
+msgid "puzzled"
+msgstr "perplexe"
+
+#: ../../include/text.php:1169
+msgid "interested"
+msgstr "Interessat"
+
+#: ../../include/text.php:1170
+msgid "bitter"
+msgstr "amargat"
+
+#: ../../include/text.php:1171
+msgid "cheerful"
+msgstr "feliç"
+
+#: ../../include/text.php:1172
+msgid "alive"
+msgstr "viu"
+
+#: ../../include/text.php:1173
+msgid "annoyed"
+msgstr "molest"
+
+#: ../../include/text.php:1174
+msgid "anxious"
+msgstr "ansiós"
+
+#: ../../include/text.php:1175
+msgid "cranky"
+msgstr "malagaitós"
+
+#: ../../include/text.php:1176
+msgid "disturbed"
+msgstr "transtornat"
+
+#: ../../include/text.php:1177
+msgid "frustrated"
+msgstr "frustrat"
+
+#: ../../include/text.php:1178
+msgid "depressed"
+msgstr "deprimit"
+
+#: ../../include/text.php:1179
+msgid "motivated"
+msgstr "motivat"
+
+#: ../../include/text.php:1180
+msgid "relaxed"
+msgstr "relaxat"
+
+#: ../../include/text.php:1181
+msgid "surprised"
+msgstr "sorprès"
+
+#: ../../include/text.php:1360 ../../include/js_strings.php:76
+msgid "Monday"
+msgstr "Dilluns"
+
+#: ../../include/text.php:1360 ../../include/js_strings.php:77
+msgid "Tuesday"
+msgstr "Dimarts"
+
+#: ../../include/text.php:1360 ../../include/js_strings.php:78
+msgid "Wednesday"
+msgstr "Dimecres"
+
+#: ../../include/text.php:1360 ../../include/js_strings.php:79
+msgid "Thursday"
+msgstr "Dijous"
+
+#: ../../include/text.php:1360 ../../include/js_strings.php:80
+msgid "Friday"
+msgstr "Divendres"
+
+#: ../../include/text.php:1360 ../../include/js_strings.php:81
+msgid "Saturday"
+msgstr "Dissabte"
+
+#: ../../include/text.php:1360 ../../include/js_strings.php:75
+msgid "Sunday"
+msgstr "Diumenge"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:51
+msgid "January"
+msgstr "Gener"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:52
+msgid "February"
+msgstr "Febrer"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:53
+msgid "March"
+msgstr "Març"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:54
+msgid "April"
+msgstr "Abril"
+
+#: ../../include/text.php:1364
+msgid "May"
+msgstr "Maig"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:56
+msgid "June"
+msgstr "Juny"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:57
+msgid "July"
+msgstr "Juliol"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:58
+msgid "August"
+msgstr "Agost"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:59
+msgid "September"
+msgstr "Setembre"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:60
+msgid "October"
+msgstr "Octubre"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:61
+msgid "November"
+msgstr "Novembre"
+
+#: ../../include/text.php:1364 ../../include/js_strings.php:62
+msgid "December"
+msgstr "Desembre"
+
+#: ../../include/text.php:1428 ../../include/text.php:1432
+msgid "Unknown Attachment"
+msgstr "Adjunt Desconegut"
+
+#: ../../include/text.php:1434 ../../include/feedutils.php:852
+msgid "unknown"
+msgstr "desconegut"
+
+#: ../../include/text.php:1470
+msgid "remove category"
+msgstr "elimina categoria"
+
+#: ../../include/text.php:1544
+msgid "remove from file"
+msgstr "elimina del arxiu"
+
+#: ../../include/text.php:1686 ../../include/message.php:12
+msgid "Download binary/encrypted content"
+msgstr "Descarrega el binari o contingut xifrat"
+
+#: ../../include/text.php:1848 ../../include/language.php:397
+msgid "default"
+msgstr "per defecte"
+
+#: ../../include/text.php:1856
+msgid "Page layout"
+msgstr "Disseny de pàgina"
+
+#: ../../include/text.php:1856
+msgid "You can create your own with the layouts tool"
+msgstr "Pots crear el teu propi amb l'editor de dissenys de pàgina."
+
+#: ../../include/text.php:1867
+msgid "HTML"
+msgstr "HTML"
+
+#: ../../include/text.php:1870
+msgid "Comanche Layout"
+msgstr "Disseny Comanche"
+
+#: ../../include/text.php:1875
+msgid "PHP"
+msgstr "PHP"
+
+#: ../../include/text.php:1884
+msgid "Page content type"
+msgstr "Tipus de contingut de la pàgina"
+
+#: ../../include/text.php:2017
+msgid "activity"
+msgstr "activitat"
+
+#: ../../include/text.php:2099
+msgid "a-z, 0-9, -, and _ only"
+msgstr "només caràcters alfanumèrics en minúscula (a-z, 0-9), guió (-) i guió baix (_)"
+
+#: ../../include/text.php:2399
+msgid "Design Tools"
+msgstr "Eines de disseny"
+
+#: ../../include/text.php:2405
+msgid "Pages"
+msgstr "Pàgines"
+
+#: ../../include/text.php:2427
+msgid "Import website..."
+msgstr "Importa un lloc web"
+
+#: ../../include/text.php:2428
+msgid "Select folder to import"
+msgstr "Escull la carpeta a on importar"
+
+#: ../../include/text.php:2429
+msgid "Import from a zipped folder:"
+msgstr "Importa des d'una carpeta comprimida:"
+
+#: ../../include/text.php:2430
+msgid "Import from cloud files:"
+msgstr "Importa des de fitxers penjats a un núvol:"
+
+#: ../../include/text.php:2431
+msgid "/cloud/channel/path/to/folder"
+msgstr "/núvol/canal/ruta/a/la/carpeta"
+
+#: ../../include/text.php:2432
+msgid "Enter path to website files"
+msgstr "Introdueix la ruta als arxius de la web"
+
+#: ../../include/text.php:2433
+msgid "Select folder"
+msgstr "Escull la carpeta"
+
+#: ../../include/text.php:2434
+msgid "Export website..."
+msgstr "Exporta un lloc web"
+
+#: ../../include/text.php:2435
+msgid "Export to a zip file"
+msgstr "Exporta a una carpeta comprimida"
+
+#: ../../include/text.php:2436
+msgid "website.zip"
+msgstr "lloc-web.zip"
+
+#: ../../include/text.php:2437
+msgid "Enter a name for the zip file."
+msgstr "Introdueix un nom per al fitxer comprimit."
+
+#: ../../include/text.php:2438
+msgid "Export to cloud files"
+msgstr "Exporta a arxius de núvol"
+
+#: ../../include/text.php:2439
+msgid "/path/to/export/folder"
+msgstr "/ruta/a/la/carpeta/exportació"
+
+#: ../../include/text.php:2440
+msgid "Enter a path to a cloud files destination."
+msgstr "Introdueix la ruta dels fitxers de núvol de destí."
+
+#: ../../include/text.php:2441
+msgid "Specify folder"
+msgstr "Escull una carpeta"
+
+#: ../../include/contact_widgets.php:11
 #, php-format
-msgid "%1$s's birthday"
-msgstr "Aniversari de %1$s"
+msgid "%d invitation available"
+msgid_plural "%d invitations available"
+msgstr[0] "%d invitació disponible"
+msgstr[1] "%d invitacions disponibles"
 
-#: ../../include/datetime.php:563
+#: ../../include/contact_widgets.php:19
+msgid "Find Channels"
+msgstr "Troba Canals"
+
+#: ../../include/contact_widgets.php:20
+msgid "Enter name or interest"
+msgstr "Entra un nom o interes"
+
+#: ../../include/contact_widgets.php:21
+msgid "Connect/Follow"
+msgstr "Conecta/Segueix"
+
+#: ../../include/contact_widgets.php:22
+msgid "Examples: Robert Morgenstein, Fishing"
+msgstr "Exemples: Lionel Messi, Futbolista"
+
+#: ../../include/contact_widgets.php:26
+msgid "Random Profile"
+msgstr "Perfil Aleatori"
+
+#: ../../include/contact_widgets.php:27
+msgid "Invite Friends"
+msgstr "Convida Amics"
+
+#: ../../include/contact_widgets.php:29
+msgid "Advanced example: name=fred and country=iceland"
+msgstr "Exemple avançat: nom=pep i pais=eire"
+
+#: ../../include/contact_widgets.php:223
+msgid "Common Connections"
+msgstr "Connexions en comú"
+
+#: ../../include/contact_widgets.php:228
 #, php-format
-msgid "Happy Birthday %1$s"
-msgstr "Feliç Aniversari %1$s"
+msgid "View all %d common connections"
+msgstr "Mostra totes les connexions en comú amb %d"
 
-#: ../../include/group.php:26
-msgid ""
-"A deleted group with this name was revived. Existing item permissions "
-"<strong>may</strong> apply to this group and any future members. If this is "
-"not what you intended, please create another group with a different name."
-msgstr "Un grup esborrat amb aquest nom fou reviscolat. Els permisos dels items existents <strong>poden</strong> aplicar-se a aquest grup i qualsevol membre futur. Si no es això el que vols, si et plau, crea un altre grup amb un nom diferent."
+#: ../../include/markdown.php:158 ../../include/bbcode.php:343
+#, php-format
+msgid "%1$s wrote the following %2$s %3$s"
+msgstr "%1$s va escriure el següent %2$s %3$s"
 
-#: ../../include/group.php:248
-msgid "Add new connections to this privacy group"
-msgstr "Afegir noves connexions a aquest grup privat"
+#: ../../include/follow.php:37
+msgid "Channel is blocked on this site."
+msgstr "El canal està bloquejat en aquest lloc."
 
-#: ../../include/group.php:289
-msgid "edit"
-msgstr "edita"
+#: ../../include/follow.php:42
+msgid "Channel location missing."
+msgstr "Ubicació del canal perduda."
 
-#: ../../include/group.php:312
-msgid "Edit group"
-msgstr "Editar grup"
+#: ../../include/follow.php:84
+msgid "Response from remote channel was incomplete."
+msgstr "La resposta del canal remot fou incompleta."
 
-#: ../../include/group.php:313
-msgid "Add privacy group"
-msgstr "Afegir grup privat"
+#: ../../include/follow.php:101
+msgid "Channel was deleted and no longer exists."
+msgstr "El canal fou esborrat i actualment no existeix."
 
-#: ../../include/group.php:314
-msgid "Channels not in any privacy group"
-msgstr "Sense canals en grups privats"
+#: ../../include/follow.php:156
+msgid "Remote channel or protocol unavailable."
+msgstr "El canal remot o el protocol no estan disponibles."
+
+#: ../../include/follow.php:179
+msgid "Channel discovery failed."
+msgstr "Descobriment de canal fallit."
+
+#: ../../include/follow.php:191
+msgid "Protocol disabled."
+msgstr "Protocol desactivat."
+
+#: ../../include/follow.php:202
+msgid "Cannot connect to yourself."
+msgstr "No pots connectar amb tu mateix."
 
 #: ../../include/js_strings.php:5
 msgid "Delete this item?"
 msgstr "Esborrar aquest item?"
 
 #: ../../include/js_strings.php:8
-msgid "[-] show less"
-msgstr "[-] mostra menys"
+#, php-format
+msgid "%s show less"
+msgstr "%smostra'n menys"
 
 #: ../../include/js_strings.php:9
-msgid "[+] expand"
-msgstr "[+] expandeix"
+#, php-format
+msgid "%s expand"
+msgstr "%sdesplega"
 
 #: ../../include/js_strings.php:10
-msgid "[-] collapse"
-msgstr "[-] colapsa"
+#, php-format
+msgid "%s collapse"
+msgstr "%splega"
 
 #: ../../include/js_strings.php:11
 msgid "Password too short"
@@ -9181,426 +12658,201 @@ msgstr "Si us plau, entra l'enllaç URL"
 msgid "Unsaved changes. Are you sure you wish to leave this page?"
 msgstr "Hi ha canvis sense desar, estàs segur que vols abandonar la pàgina?"
 
-#: ../../include/js_strings.php:27
-msgid "timeago.prefixAgo"
-msgstr "timeago.prefixAgo"
-
-#: ../../include/js_strings.php:28
-msgid "timeago.prefixFromNow"
-msgstr "timeago.prefixFromNow"
-
-#: ../../include/js_strings.php:29
-msgid "ago"
-msgstr "abans"
-
-#: ../../include/js_strings.php:30
-msgid "from now"
-msgstr "des d'ara"
-
 #: ../../include/js_strings.php:31
-msgid "less than a minute"
-msgstr "menys d'un minut"
+msgid "timeago.prefixAgo"
+msgstr "fa"
 
 #: ../../include/js_strings.php:32
+msgid "timeago.prefixFromNow"
+msgstr "d'aquí a"
+
+#: ../../include/js_strings.php:33
+msgid "timeago.suffixAgo"
+msgstr "fa"
+
+#: ../../include/js_strings.php:34
+msgid "timeago.suffixFromNow"
+msgstr "d'aquí a"
+
+#: ../../include/js_strings.php:37
+msgid "less than a minute"
+msgstr "uns segons"
+
+#: ../../include/js_strings.php:38
 msgid "about a minute"
 msgstr "prop d'un minut"
 
-#: ../../include/js_strings.php:33
+#: ../../include/js_strings.php:39
 #, php-format
 msgid "%d minutes"
 msgstr "%d minuts"
 
-#: ../../include/js_strings.php:34
+#: ../../include/js_strings.php:40
 msgid "about an hour"
 msgstr "prop d'una hora"
 
-#: ../../include/js_strings.php:35
+#: ../../include/js_strings.php:41
 #, php-format
 msgid "about %d hours"
-msgstr "al voltant de %d hores"
+msgstr "unes %d hores"
 
-#: ../../include/js_strings.php:36
+#: ../../include/js_strings.php:42
 msgid "a day"
 msgstr "un dia"
 
-#: ../../include/js_strings.php:37
+#: ../../include/js_strings.php:43
 #, php-format
 msgid "%d days"
 msgstr "%d dies"
 
-#: ../../include/js_strings.php:38
+#: ../../include/js_strings.php:44
 msgid "about a month"
 msgstr "prop d'un mes"
 
-#: ../../include/js_strings.php:39
+#: ../../include/js_strings.php:45
 #, php-format
 msgid "%d months"
 msgstr "%d mesos"
 
-#: ../../include/js_strings.php:40
+#: ../../include/js_strings.php:46
 msgid "about a year"
 msgstr "prop d'un any"
 
-#: ../../include/js_strings.php:41
+#: ../../include/js_strings.php:47
 #, php-format
 msgid "%d years"
 msgstr "%d anys"
 
-#: ../../include/js_strings.php:42
+#: ../../include/js_strings.php:48
 msgid " "
 msgstr " "
 
-#: ../../include/js_strings.php:43
+#: ../../include/js_strings.php:49
 msgid "timeago.numbers"
 msgstr "timeago.numbers"
 
-#: ../../include/js_strings.php:49
+#: ../../include/js_strings.php:55
 msgctxt "long"
 msgid "May"
-msgstr "Maig"
-
-#: ../../include/js_strings.php:57
-msgid "Jan"
-msgstr "Gen"
-
-#: ../../include/js_strings.php:58
-msgid "Feb"
-msgstr "Feb"
-
-#: ../../include/js_strings.php:59
-msgid "Mar"
-msgstr "Mar"
-
-#: ../../include/js_strings.php:60
-msgid "Apr"
-msgstr "Apr"
-
-#: ../../include/js_strings.php:61
-msgctxt "short"
-msgid "May"
-msgstr "Maig"
-
-#: ../../include/js_strings.php:62
-msgid "Jun"
-msgstr "Jun"
+msgstr "maig"
 
 #: ../../include/js_strings.php:63
-msgid "Jul"
-msgstr "Jul"
+msgid "Jan"
+msgstr "gen."
 
 #: ../../include/js_strings.php:64
-msgid "Aug"
-msgstr "Ago"
+msgid "Feb"
+msgstr "feb."
 
 #: ../../include/js_strings.php:65
-msgid "Sep"
-msgstr "Set"
+msgid "Mar"
+msgstr "març"
 
 #: ../../include/js_strings.php:66
-msgid "Oct"
-msgstr "Oct"
+msgid "Apr"
+msgstr "abr."
 
 #: ../../include/js_strings.php:67
-msgid "Nov"
-msgstr "Nov"
+msgctxt "short"
+msgid "May"
+msgstr "maig"
 
 #: ../../include/js_strings.php:68
+msgid "Jun"
+msgstr "juny"
+
+#: ../../include/js_strings.php:69
+msgid "Jul"
+msgstr "jul."
+
+#: ../../include/js_strings.php:70
+msgid "Aug"
+msgstr "ag."
+
+#: ../../include/js_strings.php:71
+msgid "Sep"
+msgstr "set."
+
+#: ../../include/js_strings.php:72
+msgid "Oct"
+msgstr "oct."
+
+#: ../../include/js_strings.php:73
+msgid "Nov"
+msgstr "nov."
+
+#: ../../include/js_strings.php:74
 msgid "Dec"
-msgstr "Des"
-
-#: ../../include/js_strings.php:76
-msgid "Sun"
-msgstr "Dg."
-
-#: ../../include/js_strings.php:77
-msgid "Mon"
-msgstr "Dl."
-
-#: ../../include/js_strings.php:78
-msgid "Tue"
-msgstr "Dm."
-
-#: ../../include/js_strings.php:79
-msgid "Wed"
-msgstr "Dc."
-
-#: ../../include/js_strings.php:80
-msgid "Thu"
-msgstr "Dj."
-
-#: ../../include/js_strings.php:81
-msgid "Fri"
-msgstr "Dv."
+msgstr "des."
 
 #: ../../include/js_strings.php:82
-msgid "Sat"
-msgstr "Ds."
+msgid "Sun"
+msgstr "dg."
 
 #: ../../include/js_strings.php:83
+msgid "Mon"
+msgstr "dl."
+
+#: ../../include/js_strings.php:84
+msgid "Tue"
+msgstr "dm."
+
+#: ../../include/js_strings.php:85
+msgid "Wed"
+msgstr "dc."
+
+#: ../../include/js_strings.php:86
+msgid "Thu"
+msgstr "dj."
+
+#: ../../include/js_strings.php:87
+msgid "Fri"
+msgstr "dv."
+
+#: ../../include/js_strings.php:88
+msgid "Sat"
+msgstr "ds."
+
+#: ../../include/js_strings.php:89
 msgctxt "calendar"
 msgid "today"
 msgstr "avui"
 
-#: ../../include/js_strings.php:84
+#: ../../include/js_strings.php:90
 msgctxt "calendar"
 msgid "month"
 msgstr "mes"
 
-#: ../../include/js_strings.php:85
+#: ../../include/js_strings.php:91
 msgctxt "calendar"
 msgid "week"
 msgstr "setmana"
 
-#: ../../include/js_strings.php:86
+#: ../../include/js_strings.php:92
 msgctxt "calendar"
 msgid "day"
 msgstr "dia"
 
-#: ../../include/js_strings.php:87
+#: ../../include/js_strings.php:93
 msgctxt "calendar"
 msgid "All day"
 msgstr "Tot el dia"
 
-#: ../../include/network.php:657
-msgid "view full size"
-msgstr "Veure a mida competa"
+#: ../../include/message.php:40
+msgid "Unable to determine sender."
+msgstr "incapaç de determinar el remitent"
 
-#: ../../include/network.php:1885
-msgid "No Subject"
-msgstr "Sense Assumpte"
+#: ../../include/message.php:79
+msgid "No recipient provided."
+msgstr "No s'ha proporcionat bústia."
 
-#: ../../include/network.php:2146 ../../include/network.php:2147
-msgid "Friendica"
-msgstr "Friendica"
+#: ../../include/message.php:84
+msgid "[no subject]"
+msgstr "[no subject]"
 
-#: ../../include/network.php:2148
-msgid "OStatus"
-msgstr "OStatus"
-
-#: ../../include/network.php:2149
-msgid "GNU-Social"
-msgstr "GNU-Social"
-
-#: ../../include/network.php:2150
-msgid "RSS/Atom"
-msgstr "RSS/Atom"
-
-#: ../../include/network.php:2152
-msgid "Diaspora"
-msgstr "Diaspora"
-
-#: ../../include/network.php:2153
-msgid "Facebook"
-msgstr "Facebook"
-
-#: ../../include/network.php:2154
-msgid "Zot"
-msgstr "Zot"
-
-#: ../../include/network.php:2155
-msgid "LinkedIn"
-msgstr "LinkedIn"
-
-#: ../../include/network.php:2156
-msgid "XMPP/IM"
-msgstr "XMPP/IM"
-
-#: ../../include/network.php:2157
-msgid "MySpace"
-msgstr "MySpace"
-
-#: ../../include/photos.php:110
-#, php-format
-msgid "Image exceeds website size limit of %lu bytes"
-msgstr "La imatge excedeix la mida limit pel lloc web en %lu bytes"
-
-#: ../../include/photos.php:117
-msgid "Image file is empty."
-msgstr "El fitxer d'imatge esta buit."
-
-#: ../../include/photos.php:255
-msgid "Photo storage failed."
-msgstr "Fracassà l'emmagatzematge de la Foto"
-
-#: ../../include/photos.php:295
-msgid "a new photo"
-msgstr "Una foto nova"
-
-#: ../../include/photos.php:299
-#, php-format
-msgctxt "photo_upload"
-msgid "%1$s posted %2$s to %3$s"
-msgstr "%1$s enviat %2$s a %3$s"
-
-#: ../../include/photos.php:506
-msgid "Upload New Photos"
-msgstr "Puja Noves Fotos"
-
-#: ../../include/zot.php:699
-msgid "Invalid data packet"
-msgstr "paquet de dades invàlid"
-
-#: ../../include/zot.php:715
-msgid "Unable to verify channel signature"
-msgstr "No es pot verificar la signatura del canal"
-
-#: ../../include/zot.php:2363
-#, php-format
-msgid "Unable to verify site signature for %s"
-msgstr "No es pot verificar la signatura del lloc per %s"
-
-#: ../../include/zot.php:3712
-msgid "invalid target signature"
-msgstr "Signatura objectiu invàlida"
-
-#: ../../include/page_widgets.php:6
-msgid "New Page"
-msgstr "Pàgina Nova"
-
-#: ../../include/page_widgets.php:43
-msgid "Title"
-msgstr "Títol"
-
-#: ../../include/permissions.php:26
-msgid "Can view my normal stream and posts"
-msgstr "Pot veure el flux i entrades normals"
-
-#: ../../include/permissions.php:27
-msgid "Can view my default channel profile"
-msgstr "Pot veure el meu perfil del canal per defecte"
-
-#: ../../include/permissions.php:28
-msgid "Can view my connections"
-msgstr "Pot veure les meves connexions"
-
-#: ../../include/permissions.php:29
-msgid "Can view my file storage and photos"
-msgstr "Pot veure al meu magatzem d'arxius i fotos"
-
-#: ../../include/permissions.php:30
-msgid "Can view my webpages"
-msgstr "Pot veure les meves pàgines web"
-
-#: ../../include/permissions.php:33
-msgid "Can send me their channel stream and posts"
-msgstr "Pot enviar-me el flux i entrades del seu canal"
-
-#: ../../include/permissions.php:34
-msgid "Can post on my channel page (\"wall\")"
-msgstr "Pot fer entrades a la meva pàgina de canal (\"mur\")"
-
-#: ../../include/permissions.php:35
-msgid "Can comment on or like my posts"
-msgstr "Pot fer comentaris o dir si agrada en les meves entrades"
-
-#: ../../include/permissions.php:36
-msgid "Can send me private mail messages"
-msgstr "Pot enviar-me un missatge de correu privat"
-
-#: ../../include/permissions.php:37
-msgid "Can like/dislike stuff"
-msgstr "Pot dir si agrada/desagrada "
-
-#: ../../include/permissions.php:37
-msgid "Profiles and things other than posts/comments"
-msgstr "Perfils i altres coses a més d'entrades/comentaris"
-
-#: ../../include/permissions.php:39
-msgid "Can forward to all my channel contacts via post @mentions"
-msgstr "Ho pot enviar a tots els meus contactes del canal via entrades @mencions"
-
-#: ../../include/permissions.php:39
-msgid "Advanced - useful for creating group forum channels"
-msgstr "Avançat - capaç de crear canals de grups de foro"
-
-#: ../../include/permissions.php:40
-msgid "Can chat with me (when available)"
-msgstr "Pot xatejar amb mi (si estic disponible)"
-
-#: ../../include/permissions.php:41
-msgid "Can write to my file storage and photos"
-msgstr "Pot escriure al meu magatzem d'arxius i fotos"
-
-#: ../../include/permissions.php:42
-msgid "Can edit my webpages"
-msgstr "Pot editar les meves pàgines web"
-
-#: ../../include/permissions.php:44
-msgid "Can source my public posts in derived channels"
-msgstr "Pot mostrar l'origen de les meves entrades públiques en altres canals"
-
-#: ../../include/permissions.php:44
-msgid "Somewhat advanced - very useful in open communities"
-msgstr "Quelcom avançat - molt útil en comunitats obertes"
-
-#: ../../include/permissions.php:46
-msgid "Can administer my channel resources"
-msgstr "Pot administrar els meus recursos del canal"
-
-#: ../../include/permissions.php:46
-msgid ""
-"Extremely advanced. Leave this alone unless you know what you are doing"
-msgstr "Extremadament avançat. No toquis res si no saps que estàs fent"
-
-#: ../../include/permissions.php:877
-msgid "Social Networking"
-msgstr "Xarxes Socials"
-
-#: ../../include/permissions.php:877
-msgid "Social - Mostly Public"
-msgstr "Social -  Principalment Públic"
-
-#: ../../include/permissions.php:877
-msgid "Social - Restricted"
-msgstr "Social - Restingit"
-
-#: ../../include/permissions.php:877
-msgid "Social - Private"
-msgstr "Social - Privat"
-
-#: ../../include/permissions.php:878
-msgid "Community Forum"
-msgstr "Foro de Comunitat"
-
-#: ../../include/permissions.php:878
-msgid "Forum - Mostly Public"
-msgstr "Fòrum - Principalment Públic"
-
-#: ../../include/permissions.php:878
-msgid "Forum - Restricted"
-msgstr "Fòrum - Restringit"
-
-#: ../../include/permissions.php:878
-msgid "Forum - Private"
-msgstr "Fòrum - Privat"
-
-#: ../../include/permissions.php:879
-msgid "Feed Republish"
-msgstr "Republicador"
-
-#: ../../include/permissions.php:879
-msgid "Feed - Mostly Public"
-msgstr "Realimentador - Públic Principalment"
-
-#: ../../include/permissions.php:879
-msgid "Feed - Restricted"
-msgstr "Retroalimentador - Restringit"
-
-#: ../../include/permissions.php:880
-msgid "Special Purpose"
-msgstr "Objectiu Especial"
-
-#: ../../include/permissions.php:880
-msgid "Special - Celebrity/Soapbox"
-msgstr "Espacial - Celebritat/Plataforma"
-
-#: ../../include/permissions.php:880
-msgid "Special - Group Repository"
-msgstr "Especial  - Repositori d'un Grup"
-
-#: ../../include/permissions.php:881
-msgid "Custom/Expert Mode"
-msgstr "Personalitzat/Manera Experta"
+#: ../../include/message.php:214
+msgid "Stored post could not be verified."
+msgstr "L'entrada guardada no pot ser verificada"
 
 #: ../../include/activities.php:41
 msgid " and "
@@ -9625,206 +12877,1186 @@ msgstr "Visita %1$s en %2$s"
 msgid "%1$s has an updated %2$s, changing %3$s."
 msgstr "%1$s Ha actualitzat %2$s, canviant %3$s."
 
-#: ../../include/bb2diaspora.php:398
-msgid "Attachments:"
-msgstr "Adjuntat:"
+#: ../../include/attach.php:265 ../../include/attach.php:361
+msgid "Item was not found."
+msgstr "Article no trobat."
 
-#: ../../include/bb2diaspora.php:487
-msgid "$Projectname event notification:"
-msgstr "Notificació d'esdeveniment de $Projectname"
+#: ../../include/attach.php:554
+msgid "No source file."
+msgstr "No hi ha arxiu d'origen."
 
-#: ../../view/theme/redbasic/php/config.php:82
-msgid "Focus (Hubzilla default)"
-msgstr "Focus (Hubzilla per defecte)"
+#: ../../include/attach.php:576
+msgid "Cannot locate file to replace"
+msgstr "No trobo l'arxiu a reemplaçar"
 
-#: ../../view/theme/redbasic/php/config.php:103
-msgid "Theme settings"
-msgstr "Ajustos de tema"
+#: ../../include/attach.php:595
+msgid "Cannot locate file to revise/update"
+msgstr "No trobo l'arxiu a revisar/actualitzar"
 
-#: ../../view/theme/redbasic/php/config.php:104
-msgid "Select scheme"
-msgstr "Tria esquema"
-
-#: ../../view/theme/redbasic/php/config.php:105
-msgid "Narrow navbar"
-msgstr "Barra de navegació estreta"
-
-#: ../../view/theme/redbasic/php/config.php:106
-msgid "Navigation bar background color"
-msgstr "Color de fons de la barra de navegació"
-
-#: ../../view/theme/redbasic/php/config.php:107
-msgid "Navigation bar gradient top color"
-msgstr "Gradient de color de la part superior de la barra de navegació"
-
-#: ../../view/theme/redbasic/php/config.php:108
-msgid "Navigation bar gradient bottom color"
-msgstr "Gradient de color de la part inferior de la barra de navegació"
-
-#: ../../view/theme/redbasic/php/config.php:109
-msgid "Navigation active button gradient top color"
-msgstr "Gradient de color de la part superior del botó actiu de la barra de navegació"
-
-#: ../../view/theme/redbasic/php/config.php:110
-msgid "Navigation active button gradient bottom color"
-msgstr "Gradient de color de la part inferior del botó actiu de la barra de navegació"
-
-#: ../../view/theme/redbasic/php/config.php:111
-msgid "Navigation bar border color "
-msgstr "Color de la barra de navegació"
-
-#: ../../view/theme/redbasic/php/config.php:112
-msgid "Navigation bar icon color "
-msgstr "Color de la icona de la barra de navegació"
-
-#: ../../view/theme/redbasic/php/config.php:113
-msgid "Navigation bar active icon color "
-msgstr "Color de la icona de la barra de navegació activa"
-
-#: ../../view/theme/redbasic/php/config.php:114
-msgid "link color"
-msgstr "Color d'enllaç"
-
-#: ../../view/theme/redbasic/php/config.php:115
-msgid "Set font-color for banner"
-msgstr "Ajusta el color del tipus de lletra per la senyera"
-
-#: ../../view/theme/redbasic/php/config.php:116
-msgid "Set the background color"
-msgstr "Ajusta el color de fons"
-
-#: ../../view/theme/redbasic/php/config.php:117
-msgid "Set the background image"
-msgstr "Ajusta la imatge de fons"
-
-#: ../../view/theme/redbasic/php/config.php:118
-msgid "Set the background color of items"
-msgstr "ajusta el color dels articles de fons"
-
-#: ../../view/theme/redbasic/php/config.php:119
-msgid "Set the background color of comments"
-msgstr "Ajusta el color dels comentaris en segon pla"
-
-#: ../../view/theme/redbasic/php/config.php:120
-msgid "Set the border color of comments"
-msgstr "Canviar el color del marge dels comentaris"
-
-#: ../../view/theme/redbasic/php/config.php:121
-msgid "Set the indent for comments"
-msgstr "ajusta l'indentació dels comentaris"
-
-#: ../../view/theme/redbasic/php/config.php:122
-msgid "Set the basic color for item icons"
-msgstr "ajusta el color basic per les icones dels articles"
-
-#: ../../view/theme/redbasic/php/config.php:123
-msgid "Set the hover color for item icons"
-msgstr "Ajusta el color de la libració de les icones dels articles"
-
-#: ../../view/theme/redbasic/php/config.php:124
-msgid "Set font-size for the entire application"
-msgstr "Ajusta la mida del tipus de lletra per tota l'aplicació"
-
-#: ../../view/theme/redbasic/php/config.php:124
-msgid "Example: 14px"
-msgstr "Exemple: 14px"
-
-#: ../../view/theme/redbasic/php/config.php:125
-msgid "Set font-size for posts and comments"
-msgstr "Ajusta la mida del tipus de lletra per a entrades i comentaris"
-
-#: ../../view/theme/redbasic/php/config.php:126
-msgid "Set font-color for posts and comments"
-msgstr "Ajusta el color del tipus de lletra per entrades i comentaris"
-
-#: ../../view/theme/redbasic/php/config.php:127
-msgid "Set radius of corners"
-msgstr "Ajusta el radi de les cantonades"
-
-#: ../../view/theme/redbasic/php/config.php:128
-msgid "Set shadow depth of photos"
-msgstr "Ajusta la profunditat d'ombres de les fotos"
-
-#: ../../view/theme/redbasic/php/config.php:129
-msgid "Set maximum width of content region in pixel"
-msgstr "Ajusta l'amplada màxima de la zona de contingut en pixels"
-
-#: ../../view/theme/redbasic/php/config.php:129
-msgid "Leave empty for default width"
-msgstr "Deixa en blanc per l'amplada predeterminada"
-
-#: ../../view/theme/redbasic/php/config.php:130
-msgid "Left align page content"
-msgstr "Alineació esquerra del contingut de la pàgina"
-
-#: ../../view/theme/redbasic/php/config.php:131
-msgid "Set minimum opacity of nav bar - to hide it"
-msgstr "Ajusta la opacitat mínima de la harra de navegació - per amagar-la"
-
-#: ../../view/theme/redbasic/php/config.php:132
-msgid "Set size of conversation author photo"
-msgstr "Ajusta la mida de la foto del autor a la conversa"
-
-#: ../../view/theme/redbasic/php/config.php:133
-msgid "Set size of followup author photos"
-msgstr "Ajusta la mida del seguidor de les fotos de l'autor"
-
-#: ../../boot.php:1162
+#: ../../include/attach.php:737
 #, php-format
-msgctxt "opensearch"
-msgid "Search %1$s (%2$s)"
-msgstr "Cerca %1$s(%2$s)"
+msgid "File exceeds size limit of %d"
+msgstr "L'arxiu excedeix la mida limit de %d"
 
-#: ../../boot.php:1162
-msgctxt "opensearch"
-msgid "$Projectname"
-msgstr "$Projectname"
-
-#: ../../boot.php:1480
+#: ../../include/attach.php:758
 #, php-format
-msgid "Update %s failed. See error logs."
-msgstr "L'actualització %s ha fallat. Mira el registre d'errors."
+msgid "You have reached your limit of %1$.0f Mbytes attachment storage."
+msgstr "Has arribat al teu límit de %1$.0f Mbytes de emagatzematge d'adjunts."
 
-#: ../../boot.php:1483
-#, php-format
-msgid "Update Error at %s"
-msgstr "Error d'Actualització a %s"
+#: ../../include/attach.php:940
+msgid "File upload failed. Possible system limit or action terminated."
+msgstr "Pujada del arxiu fallida. Possible límit del sistema o acció interrompuda."
 
-#: ../../boot.php:1684
+#: ../../include/attach.php:959
+msgid "Stored file could not be verified. Upload failed."
+msgstr "L'arxiu guardat no es pot verificar. Pujada fallida."
+
+#: ../../include/attach.php:1033 ../../include/attach.php:1049
+msgid "Path not available."
+msgstr "Trajectòria no disponible"
+
+#: ../../include/attach.php:1098 ../../include/attach.php:1263
+msgid "Empty pathname"
+msgstr "Trajèctoria vuida."
+
+#: ../../include/attach.php:1124
+msgid "duplicate filename or path"
+msgstr "Nom o trajectòria duplicat"
+
+#: ../../include/attach.php:1149
+msgid "Path not found."
+msgstr "Trajectòria no trobada."
+
+#: ../../include/attach.php:1217
+msgid "mkdir failed."
+msgstr "mkdir va fracassar."
+
+#: ../../include/attach.php:1221
+msgid "database storage failed."
+msgstr "Arxiu de base de dades va fallar."
+
+#: ../../include/attach.php:1269
+msgid "Empty path"
+msgstr "Trajèctoria vuida"
+
+#: ../../include/security.php:532
 msgid ""
-"Create an account to access services and applications within the Hubzilla"
-msgstr "Crea un compte per accedir als serveis i aplicacions dins de Hubzilla"
+"The form security token was not correct. This probably happened because the "
+"form has been opened for too long (>3 hours) before submitting it."
+msgstr "El formulario de la cadena de seguridad no era correcto. Esto probablemente ocurrió porque el formulario se ha abierto durante demasiado tiempo (> 3 horas) antes de enviarlo."
 
-#: ../../boot.php:1706
-msgid "Password"
-msgstr "Contrasenya"
+#: ../../include/items.php:885 ../../include/items.php:945
+msgid "(Unknown)"
+msgstr "(Desconegut)"
 
-#: ../../boot.php:1707
-msgid "Remember me"
-msgstr "Recorda'm"
+#: ../../include/items.php:1129
+msgid "Visible to anybody on the internet."
+msgstr "Visible per tothom a la Internet"
 
-#: ../../boot.php:1710
-msgid "Forgot your password?"
-msgstr "Has perdut la Contrasenya?"
+#: ../../include/items.php:1131
+msgid "Visible to you only."
+msgstr "Visible només per tú."
 
-#: ../../boot.php:2276
-msgid "toggle mobile"
-msgstr "canvia a format per a mòbils"
+#: ../../include/items.php:1133
+msgid "Visible to anybody in this network."
+msgstr "Visible per tothom en aquesta xarxa."
 
-#: ../../boot.php:2425
-msgid "Website SSL certificate is not valid. Please correct."
-msgstr "El certificat SSL és invalid, soluciona-ho, si us plau."
+#: ../../include/items.php:1135
+msgid "Visible to anybody authenticated."
+msgstr "Visible per tothom autenticat."
 
-#: ../../boot.php:2428
+#: ../../include/items.php:1137
 #, php-format
-msgid "[hubzilla] Website SSL error for %s"
-msgstr "[hubzilla] Error de SSL per la web %s"
+msgid "Visible to anybody on %s."
+msgstr "Visible per a tothom a %s."
 
-#: ../../boot.php:2469
-msgid "Cron/Scheduled tasks not running."
-msgstr "No s'estan executant les tasques programades al cron."
+#: ../../include/items.php:1139
+msgid "Visible to all connections."
+msgstr "Visible per a totes les connexions."
 
-#: ../../boot.php:2473
+#: ../../include/items.php:1141
+msgid "Visible to approved connections."
+msgstr "Visible per a les connexions aprovades."
+
+#: ../../include/items.php:1143
+msgid "Visible to specific connections."
+msgstr "Visible per a específiques connexions."
+
+#: ../../include/items.php:4147
+msgid "Privacy group is empty."
+msgstr "El grup privat està vuit."
+
+#: ../../include/items.php:4154
 #, php-format
-msgid "[hubzilla] Cron tasks not running on %s"
-msgstr "[hubzilla] Les tasques de Cron no rulen a %s"
+msgid "Privacy group: %s"
+msgstr "Grup privat: %s"
+
+#: ../../include/items.php:4166
+msgid "Connection not found."
+msgstr "Connexió no trobada."
+
+#: ../../include/items.php:4515
+msgid "profile photo"
+msgstr "foto del perfil"
+
+#: ../../include/items.php:4706
+#, php-format
+msgid "[Edited %s]"
+msgstr "[S'ha editat %s]"
+
+#: ../../include/items.php:4706
+msgctxt "edit_activity"
+msgid "Post"
+msgstr "Entrada"
+
+#: ../../include/items.php:4706
+msgctxt "edit_activity"
+msgid "Comment"
+msgstr "Comentari"
+
+#: ../../include/channel.php:35
+msgid "Unable to obtain identity information from database"
+msgstr "Incapaç de trobar l'informació d'identitat a la base de dades"
+
+#: ../../include/channel.php:68
+msgid "Empty name"
+msgstr "Nom buit"
+
+#: ../../include/channel.php:71
+msgid "Name too long"
+msgstr "Nom massa llarg"
+
+#: ../../include/channel.php:188
+msgid "No account identifier"
+msgstr "Sense identificador de compte"
+
+#: ../../include/channel.php:200
+msgid "Nickname is required."
+msgstr "Alies/malnom es requerit."
+
+#: ../../include/channel.php:277
+msgid "Unable to retrieve created identity"
+msgstr "No es pot recuperar la identitat creada"
+
+#: ../../include/channel.php:373
+msgid "Default Profile"
+msgstr "Perfil per Defecte"
+
+#: ../../include/channel.php:532 ../../include/channel.php:621
+msgid "Unable to retrieve modified identity"
+msgstr "No s'ha pogut carregar la identitat modificada"
+
+#: ../../include/channel.php:1298
+msgid "Create New Profile"
+msgstr "Crear un Perfil Nou"
+
+#: ../../include/channel.php:1319
+msgid "Visible to everybody"
+msgstr "Visible per tothom"
+
+#: ../../include/channel.php:1396 ../../include/channel.php:1524
+msgid "Gender:"
+msgstr "Gènere:"
+
+#: ../../include/channel.php:1398 ../../include/channel.php:1579
+msgid "Homepage:"
+msgstr "Pàgina Personal:"
+
+#: ../../include/channel.php:1399
+msgid "Online Now"
+msgstr "Ara en Linia"
+
+#: ../../include/channel.php:1452
+msgid "Change your profile photo"
+msgstr "Canvia la foto de peril"
+
+#: ../../include/channel.php:1483
+msgid "Trans"
+msgstr "Trans"
+
+#: ../../include/channel.php:1529
+msgid "Like this channel"
+msgstr "M'agrada aquest canal"
+
+#: ../../include/channel.php:1553
+msgid "j F, Y"
+msgstr "j F, Y"
+
+#: ../../include/channel.php:1554
+msgid "j F"
+msgstr "j F"
+
+#: ../../include/channel.php:1561
+msgid "Birthday:"
+msgstr "Aniversari:"
+
+#: ../../include/channel.php:1574
+#, php-format
+msgid "for %1$d %2$s"
+msgstr "per %1$d %2$s"
+
+#: ../../include/channel.php:1577
+msgid "Sexual Preference:"
+msgstr "Preferència Sexual:"
+
+#: ../../include/channel.php:1583
+msgid "Tags:"
+msgstr "Etiquetes:"
+
+#: ../../include/channel.php:1585
+msgid "Political Views:"
+msgstr "Idees Polítiques:"
+
+#: ../../include/channel.php:1587
+msgid "Religion:"
+msgstr "Religió:"
+
+#: ../../include/channel.php:1591
+msgid "Hobbies/Interests:"
+msgstr "Aficions/Interessos:"
+
+#: ../../include/channel.php:1593
+msgid "Likes:"
+msgstr "Agrada:"
+
+#: ../../include/channel.php:1595
+msgid "Dislikes:"
+msgstr "Desagrada:"
+
+#: ../../include/channel.php:1597
+msgid "Contact information and Social Networks:"
+msgstr "Informació de contacte i Xarxes Socials:"
+
+#: ../../include/channel.php:1599
+msgid "My other channels:"
+msgstr "Els meus altres canals:"
+
+#: ../../include/channel.php:1601
+msgid "Musical interests:"
+msgstr "Interessos Musicals:"
+
+#: ../../include/channel.php:1603
+msgid "Books, literature:"
+msgstr "Llibres, literatura:"
+
+#: ../../include/channel.php:1605
+msgid "Television:"
+msgstr "Televisió:"
+
+#: ../../include/channel.php:1607
+msgid "Film/dance/culture/entertainment:"
+msgstr "Películes/Dança/Cultura/Entreteniment:"
+
+#: ../../include/channel.php:1609
+msgid "Love/Romance:"
+msgstr "Amor/Romace:"
+
+#: ../../include/channel.php:1611
+msgid "Work/employment:"
+msgstr "Treball/feina:"
+
+#: ../../include/channel.php:1613
+msgid "School/education:"
+msgstr "Escola/educació:"
+
+#: ../../include/channel.php:1636
+msgid "Like this thing"
+msgstr "M'agrada això"
+
+#: ../../include/event.php:24 ../../include/event.php:71
+msgid "l F d, Y \\@ g:i A"
+msgstr "l d \\d\\e/\\d' F de Y \\@ H:i T"
+
+#: ../../include/event.php:32 ../../include/event.php:75
+msgid "Starts:"
+msgstr "Inicia:"
+
+#: ../../include/event.php:42 ../../include/event.php:79
+msgid "Finishes:"
+msgstr "Acaba:"
+
+#: ../../include/event.php:1011
+msgid "This event has been added to your calendar."
+msgstr "Aquest succés ha estat afegit al teu calendari."
+
+#: ../../include/event.php:1227
+msgid "Not specified"
+msgstr "Sense especificar"
+
+#: ../../include/event.php:1228
+msgid "Needs Action"
+msgstr "Necessita una Acció"
+
+#: ../../include/event.php:1229
+msgid "Completed"
+msgstr "Completat"
+
+#: ../../include/event.php:1230
+msgid "In Process"
+msgstr "En Procès"
+
+#: ../../include/event.php:1231
+msgid "Cancelled"
+msgstr "Cancel·lat"
+
+#: ../../include/event.php:1310 ../../include/connections.php:684
+msgid "Home, Voice"
+msgstr "Casa, veu"
+
+#: ../../include/event.php:1311 ../../include/connections.php:685
+msgid "Home, Fax"
+msgstr "Casa, fax"
+
+#: ../../include/event.php:1313 ../../include/connections.php:687
+msgid "Work, Voice"
+msgstr "Feina, veu"
+
+#: ../../include/event.php:1314 ../../include/connections.php:688
+msgid "Work, Fax"
+msgstr "Feina, fax"
+
+#: ../../include/network.php:762
+msgid "view full size"
+msgstr "Veure a mida competa"
+
+#: ../../include/network.php:1769 ../../include/network.php:1770
+msgid "Friendica"
+msgstr "Friendica"
+
+#: ../../include/network.php:1771
+msgid "OStatus"
+msgstr "OStatus"
+
+#: ../../include/network.php:1772
+msgid "GNU-Social"
+msgstr "GNU-Social"
+
+#: ../../include/network.php:1773
+msgid "RSS/Atom"
+msgstr "RSS/Atom"
+
+#: ../../include/network.php:1776
+msgid "Diaspora"
+msgstr "Diaspora"
+
+#: ../../include/network.php:1777
+msgid "Facebook"
+msgstr "Facebook"
+
+#: ../../include/network.php:1778
+msgid "Zot"
+msgstr "Zot"
+
+#: ../../include/network.php:1779
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: ../../include/network.php:1780
+msgid "XMPP/IM"
+msgstr "XMPP/IM"
+
+#: ../../include/network.php:1781
+msgid "MySpace"
+msgstr "MySpace"
+
+#: ../../include/language.php:410
+msgid "Select an alternate language"
+msgstr "Tria un idioma alternatiu"
+
+#: ../../include/acl_selectors.php:113
+msgid "Who can see this?"
+msgstr "Qui pot veure això?"
+
+#: ../../include/acl_selectors.php:114
+msgid "Custom selection"
+msgstr "Selecció a mida"
+
+#: ../../include/acl_selectors.php:115
+msgid ""
+"Select \"Show\" to allow viewing. \"Don't show\" lets you override and limit"
+" the scope of \"Show\"."
+msgstr "Selecciona \"Mostrar\" per permetre la visualització. \"No Mostrar\" et permet obviar i limitar l'abast de \"Mostrar\"."
+
+#: ../../include/acl_selectors.php:116
+msgid "Show"
+msgstr "Mostra"
+
+#: ../../include/acl_selectors.php:117
+msgid "Don't show"
+msgstr "No mostrar"
+
+#: ../../include/acl_selectors.php:150
+#, php-format
+msgid ""
+"Post permissions %s cannot be changed %s after a post is shared.</br />These"
+" permissions set who is allowed to view the post."
+msgstr "Els permisos d'entrada %s no poden esser canviats %s posteriorment a que una entrada ja està compartida. </br />Aquest ajust dels permisos indica qui pot veure l'entrada."
+
+#: ../../include/dba/dba_driver.php:178
+#, php-format
+msgid "Cannot locate DNS info for database server '%s'"
+msgstr "No s'ha trobat informació de DNS pel servidor de base de dades '%s'"
+
+#: ../../include/bbcode.php:198 ../../include/bbcode.php:1151
+#: ../../include/bbcode.php:1154 ../../include/bbcode.php:1159
+#: ../../include/bbcode.php:1162 ../../include/bbcode.php:1165
+#: ../../include/bbcode.php:1168 ../../include/bbcode.php:1173
+#: ../../include/bbcode.php:1176 ../../include/bbcode.php:1181
+#: ../../include/bbcode.php:1184 ../../include/bbcode.php:1187
+#: ../../include/bbcode.php:1190
+msgid "Image/photo"
+msgstr "Imatge/foto"
+
+#: ../../include/bbcode.php:237 ../../include/bbcode.php:1201
+msgid "Encrypted content"
+msgstr "Contingut encriptat"
+
+#: ../../include/bbcode.php:253
+#, php-format
+msgid "Install %1$s element %2$s"
+msgstr "Instaŀla l'element %2$s del tipus %1$s"
+
+#: ../../include/bbcode.php:257
+#, php-format
+msgid ""
+"This post contains an installable %s element, however you lack permissions "
+"to install it on this site."
+msgstr "Aquesta entrada contè un element %s instal·lable, potser manques de permissos per instal·lar-lo en aquest lloc."
+
+#: ../../include/bbcode.php:335
+msgid "card"
+msgstr "targeta"
+
+#: ../../include/bbcode.php:337
+msgid "article"
+msgstr "article"
+
+#: ../../include/bbcode.php:420 ../../include/bbcode.php:428
+msgid "Click to open/close"
+msgstr "Clic per obrir/tancar"
+
+#: ../../include/bbcode.php:428
+msgid "spoiler"
+msgstr "xafa guitarres"
+
+#: ../../include/bbcode.php:441
+msgid "View article"
+msgstr "Mostra l'article"
+
+#: ../../include/bbcode.php:441
+msgid "View summary"
+msgstr "Mostra'n un resum"
+
+#: ../../include/bbcode.php:1139
+msgid "$1 wrote:"
+msgstr "$1 va escriure:"
+
+#: ../../include/oembed.php:328
+msgid " by "
+msgstr "de"
+
+#: ../../include/oembed.php:329
+msgid " on "
+msgstr "a"
+
+#: ../../include/oembed.php:358
+msgid "Embedded content"
+msgstr "Contingut embegut"
+
+#: ../../include/oembed.php:367
+msgid "Embedding disabled"
+msgstr "Incorporació desactivada"
+
+#: ../../include/zid.php:346
+#, php-format
+msgid "OpenWebAuth: %1$s welcomes %2$s"
+msgstr "OpenWebAuth: %1$s dóna la benvinguda a %2$s"
+
+#: ../../include/features.php:54
+msgid "General Features"
+msgstr "Característiques Generals"
+
+#: ../../include/features.php:60
+msgid "Advanced Profiles"
+msgstr "Perfils Avançats"
+
+#: ../../include/features.php:61
+msgid "Additional profile sections and selections"
+msgstr "Seccions i seleccions addicionals de perfils "
+
+#: ../../include/features.php:69
+msgid "Profile Import/Export"
+msgstr "Importar/Exportar Perfil"
+
+#: ../../include/features.php:70
+msgid "Save and load profile details across sites/channels"
+msgstr "Guarda i carrega els detalls del perfil al llarg dels llocs/canals"
+
+#: ../../include/features.php:78
+msgid "Web Pages"
+msgstr "Pàgines Web"
+
+#: ../../include/features.php:79
+msgid "Provide managed web pages on your channel"
+msgstr "Proporcionar pàgines web gestionades al seu canal"
+
+#: ../../include/features.php:88
+msgid "Provide a wiki for your channel"
+msgstr "Proporciona una wiki per al teu canal"
+
+#: ../../include/features.php:105
+msgid "Private Notes"
+msgstr "Notes Privades"
+
+#: ../../include/features.php:106
+msgid "Enables a tool to store notes and reminders (note: not encrypted)"
+msgstr "Activa l'eina per guardar notes i recordatoris (nota:no està encriptat)"
+
+#: ../../include/features.php:115
+msgid "Create personal planning cards"
+msgstr "Crea targetes de planificació personal"
+
+#: ../../include/features.php:125
+msgid "Create interactive articles"
+msgstr "Crea articles interactius"
+
+#: ../../include/features.php:133
+msgid "Navigation Channel Select"
+msgstr "Navegació pel Selector de Canals"
+
+#: ../../include/features.php:134
+msgid "Change channels directly from within the navigation dropdown menu"
+msgstr "Canvieu els canals directament des del menú desplegable de navegació"
+
+#: ../../include/features.php:142
+msgid "Photo Location"
+msgstr "Ubicació de la Foto"
+
+#: ../../include/features.php:143
+msgid "If location data is available on uploaded photos, link this to a map."
+msgstr "Si les dades d'ubicació estàn disponibles a les fotos pujades, vincular a un mapa."
+
+#: ../../include/features.php:151
+msgid "Access Controlled Chatrooms"
+msgstr "Accés Controlat a les Sales de Xat"
+
+#: ../../include/features.php:152
+msgid "Provide chatrooms and chat services with access control."
+msgstr "Proveeix sales de Xat i serveis de Xat amb control d'accés."
+
+#: ../../include/features.php:161
+msgid "Smart Birthdays"
+msgstr "Aniversaris Intel·ligents"
+
+#: ../../include/features.php:162
+msgid ""
+"Make birthday events timezone aware in case your friends are scattered "
+"across the planet."
+msgstr "Fes, conscients de la zona horària, els esdeveniments d'aniversari, en cas que els teus amics estiguin dispersos per tot el planeta."
+
+#: ../../include/features.php:170
+msgid "Event Timezone Selection"
+msgstr "Zona horària dels esdeveniments"
+
+#: ../../include/features.php:171
+msgid "Allow event creation in timezones other than your own."
+msgstr "Permet crear esdeveniments en zones horàries diferents a la teva."
+
+#: ../../include/features.php:180
+msgid "Premium Channel"
+msgstr "Privilegis del Canal"
+
+#: ../../include/features.php:181
+msgid ""
+"Allows you to set restrictions and terms on those that connect with your "
+"channel"
+msgstr "Li permet establir restriccions i els termes en els quals es connecten amb el seu canal"
+
+#: ../../include/features.php:189
+msgid "Advanced Directory Search"
+msgstr "Cerca de directori avançada"
+
+#: ../../include/features.php:190
+msgid "Allows creation of complex directory search queries"
+msgstr "Permet fer cerques de directori complexes"
+
+#: ../../include/features.php:198
+msgid "Advanced Theme and Layout Settings"
+msgstr "Configuració de disseny i de tema avançada"
+
+#: ../../include/features.php:199
+msgid "Allows fine tuning of themes and page layouts"
+msgstr "Permet configurar al detall els temes i els dissenys de pàgina"
+
+#: ../../include/features.php:208
+msgid "Access Control and Permissions"
+msgstr "Control d'accés i permisos"
+
+#: ../../include/features.php:212 ../../include/group.php:328
+msgid "Privacy Groups"
+msgstr "Grup Privat"
+
+#: ../../include/features.php:213
+msgid "Enable management and selection of privacy groups"
+msgstr "Habilita gestió i selecció de grups privats"
+
+#: ../../include/features.php:221
+msgid "Multiple Profiles"
+msgstr "Multiples Perfils"
+
+#: ../../include/features.php:222
+msgid "Ability to create multiple profiles"
+msgstr "Capacitat per crear multiples perfils"
+
+#: ../../include/features.php:232
+msgid "Provide alternate connection permission roles."
+msgstr "Proporciona rols diferents per als permisos de connexió."
+
+#: ../../include/features.php:240
+msgid "OAuth Clients"
+msgstr "Clients d'OAuth"
+
+#: ../../include/features.php:241
+msgid "Manage authenticatication tokens for mobile and remote apps."
+msgstr "Gestiona els tokens d'autenticació per al mòbils i aplicacions remotes."
+
+#: ../../include/features.php:249
+msgid "Access Tokens"
+msgstr "Tokens d'accés"
+
+#: ../../include/features.php:250
+msgid "Create access tokens so that non-members can access private content."
+msgstr "Crea tokens d'accés per tal que no-membres puguis accedir contingut privat."
+
+#: ../../include/features.php:261
+msgid "Post Composition Features"
+msgstr "Característiques de Composició d'Entrades"
+
+#: ../../include/features.php:265
+msgid "Large Photos"
+msgstr "Grans Fotos"
+
+#: ../../include/features.php:266
+msgid ""
+"Include large (1024px) photo thumbnails in posts. If not enabled, use small "
+"(640px) photo thumbnails"
+msgstr "Inclou gran (1024px) foto de miniatura a les entrades. Si no està activat, empra petita (640px) foto de miniatura."
+
+#: ../../include/features.php:275
+msgid "Automatically import channel content from other channels or feeds"
+msgstr "Importa automàticament el contingut del canal des de altres canals o feeds"
+
+#: ../../include/features.php:283
+msgid "Even More Encryption"
+msgstr "Encara Més Encriptació"
+
+#: ../../include/features.php:284
+msgid ""
+"Allow optional encryption of content end-to-end with a shared secret key"
+msgstr "Permet l'encripció opcional del contingut extrem-a-extrem amb clau secreta compartida"
+
+#: ../../include/features.php:292
+msgid "Enable Voting Tools"
+msgstr "Habilitar Eines de Votació"
+
+#: ../../include/features.php:293
+msgid "Provide a class of post which others can vote on"
+msgstr "Proporcionar una classe d'entrada que altres puguin votar"
+
+#: ../../include/features.php:301
+msgid "Disable Comments"
+msgstr "Deshabilita els comentaris"
+
+#: ../../include/features.php:302
+msgid "Provide the option to disable comments for a post"
+msgstr "Proporciona l'opció de deshabilitar els comentaris per a una entrada"
+
+#: ../../include/features.php:310
+msgid "Delayed Posting"
+msgstr "Retarda Publicació"
+
+#: ../../include/features.php:311
+msgid "Allow posts to be published at a later date"
+msgstr "Permet que les publicacions es publiquin en data posterior"
+
+#: ../../include/features.php:319
+msgid "Content Expiration"
+msgstr "Expiració del Contingut"
+
+#: ../../include/features.php:320
+msgid "Remove posts/comments and/or private messages at a future time"
+msgstr "eliminarà entrades/comentaris i/o missatges privats en un període determinat de temps."
+
+#: ../../include/features.php:328
+msgid "Suppress Duplicate Posts/Comments"
+msgstr "Suprimeix Duplicats de Publicacions/Comentaris"
+
+#: ../../include/features.php:329
+msgid ""
+"Prevent posts with identical content to be published with less than two "
+"minutes in between submissions."
+msgstr "Evita que publicacions amb identic contingut siguin publicades amb menys de dos minuts entre entregues."
+
+#: ../../include/features.php:340
+msgid "Network and Stream Filtering"
+msgstr "Filtrat de Xarxa i Flux"
+
+#: ../../include/features.php:344
+msgid "Search by Date"
+msgstr "Cerca per Data"
+
+#: ../../include/features.php:345
+msgid "Ability to select posts by date ranges"
+msgstr "Capacitat per seleccionar entrades per rang de dates"
+
+#: ../../include/features.php:355
+msgid "Save search terms for re-use"
+msgstr "Guardar els termin de la cerca per a re-usar"
+
+#: ../../include/features.php:363
+msgid "Network Personal Tab"
+msgstr "Pestanya Personal de Xarxa"
+
+#: ../../include/features.php:364
+msgid "Enable tab to display only Network posts that you've interacted on"
+msgstr "Activa la pestanya per mostrar només les entrades de xarxa en les que has intervingut"
+
+#: ../../include/features.php:372
+msgid "Network New Tab"
+msgstr "Pestanya Nou a la Xarxa"
+
+#: ../../include/features.php:373
+msgid "Enable tab to display all new Network activity"
+msgstr "Activa pestanya per mostrar tota l'activitat nova de la Xarxa"
+
+#: ../../include/features.php:381
+msgid "Affinity Tool"
+msgstr "Eina d'Afinitat"
+
+#: ../../include/features.php:382
+msgid "Filter stream activity by depth of relationships"
+msgstr "Filtre d'activitat del flux per importància de la relació"
+
+#: ../../include/features.php:391
+msgid "Show friend and connection suggestions"
+msgstr "Suggereix connexions o amistats"
+
+#: ../../include/features.php:399
+msgid "Connection Filtering"
+msgstr "Filtre de Connexió"
+
+#: ../../include/features.php:400
+msgid "Filter incoming posts from connections based on keywords/content"
+msgstr "Filtre de missatges d'entrada de conexions, basat en paraules clau/contingut "
+
+#: ../../include/features.php:412
+msgid "Post/Comment Tools"
+msgstr "Eina d'Entrades/Comentaris"
+
+#: ../../include/features.php:416
+msgid "Community Tagging"
+msgstr "Etiquetat per la Comunitat"
+
+#: ../../include/features.php:417
+msgid "Ability to tag existing posts"
+msgstr "Capacitat d'etiquetar entrades existents"
+
+#: ../../include/features.php:425
+msgid "Post Categories"
+msgstr "Categories d'Entrades"
+
+#: ../../include/features.php:426
+msgid "Add categories to your posts"
+msgstr "Afegeix categoria a la teva entrada"
+
+#: ../../include/features.php:434
+msgid "Emoji Reactions"
+msgstr "Reaccions dels Emoji"
+
+#: ../../include/features.php:435
+msgid "Add emoji reaction ability to posts"
+msgstr "Afegeix un emoji habilitat per reaccionar a entrades"
+
+#: ../../include/features.php:444
+msgid "Ability to file posts under folders"
+msgstr "Capacitat de arxivar entrades en les carpetes"
+
+#: ../../include/features.php:452
+msgid "Dislike Posts"
+msgstr "No Agrada l'Entrada"
+
+#: ../../include/features.php:453
+msgid "Ability to dislike posts/comments"
+msgstr "Capacitat per marcar amb \"No Agrada\" les entrades/comentaris"
+
+#: ../../include/features.php:461
+msgid "Star Posts"
+msgstr "Entrades Excel·lents"
+
+#: ../../include/features.php:462
+msgid "Ability to mark special posts with a star indicator"
+msgstr "Capacitat per marcar entrades especials amb l'indicador d'excel·lencia"
+
+#: ../../include/features.php:470
+msgid "Tag Cloud"
+msgstr "Núvol d'Etiquetes."
+
+#: ../../include/features.php:471
+msgid "Provide a personal tag cloud on your channel page"
+msgstr "Proporcionar un núvol d'etiquetes personals a la teva pàgina de canal"
+
+#: ../../include/taxonomy.php:384 ../../include/taxonomy.php:405
+msgid "Tags"
+msgstr "Etiquetes"
+
+#: ../../include/taxonomy.php:487
+msgid "Keywords"
+msgstr "Paraules clau"
+
+#: ../../include/taxonomy.php:508
+msgid "have"
+msgstr "tinc"
+
+#: ../../include/taxonomy.php:508
+msgid "has"
+msgstr "tens"
+
+#: ../../include/taxonomy.php:509
+msgid "want"
+msgstr "vull"
+
+#: ../../include/taxonomy.php:509
+msgid "wants"
+msgstr "vols"
+
+#: ../../include/taxonomy.php:510
+msgid "likes"
+msgstr "agrada"
+
+#: ../../include/taxonomy.php:511
+msgid "dislikes"
+msgstr "desagrada"
+
+#: ../../include/account.php:35
+msgid "Not a valid email address"
+msgstr "Adreça de correu electrònic no vàlida"
+
+#: ../../include/account.php:37
+msgid "Your email domain is not among those allowed on this site"
+msgstr "El seu domini de correu electrònic no es troba entre els permesos en aquest lloc"
+
+#: ../../include/account.php:43
+msgid "Your email address is already registered at this site."
+msgstr "La teva adreça de correu electrònic ja esta registrada en aquest lloc"
+
+#: ../../include/account.php:75
+msgid "An invitation is required."
+msgstr "Es requereix Invitació"
+
+#: ../../include/account.php:79
+msgid "Invitation could not be verified."
+msgstr "L'invitació no ha pogut ser verificada"
+
+#: ../../include/account.php:157
+msgid "Please enter the required information."
+msgstr "Entra la informació sol·licitada"
+
+#: ../../include/account.php:224
+msgid "Failed to store account information."
+msgstr "Ha fallat guardar la informació del compte"
+
+#: ../../include/account.php:313
+#, php-format
+msgid "Registration confirmation for %s"
+msgstr "Inscripció confirmada per  %s"
+
+#: ../../include/account.php:382
+#, php-format
+msgid "Registration request at %s"
+msgstr "Sol·licitud d'inscripció a %s"
+
+#: ../../include/account.php:404
+msgid "your registration password"
+msgstr "la teva contrasenya registrada"
+
+#: ../../include/account.php:410 ../../include/account.php:472
+#, php-format
+msgid "Registration details for %s"
+msgstr "Detalls de l'inscripció per %s"
+
+#: ../../include/account.php:483
+msgid "Account approved."
+msgstr "Compte aprovat."
+
+#: ../../include/account.php:523
+#, php-format
+msgid "Registration revoked for %s"
+msgstr "Inscripció revocada per %s"
+
+#: ../../include/account.php:802 ../../include/account.php:804
+msgid "Click here to upgrade."
+msgstr "Feu clic aquí per actualitzar."
+
+#: ../../include/account.php:810
+msgid "This action exceeds the limits set by your subscription plan."
+msgstr "Aquesta acció és superior als límits establerts pel seu pla de subscripció."
+
+#: ../../include/account.php:815
+msgid "This action is not available under your subscription plan."
+msgstr "Aquesta acció no està disponible en el seu pla de subscripció."
+
+#: ../../include/datetime.php:134
+msgid "Birthday"
+msgstr "Aniversari"
+
+#: ../../include/datetime.php:134
+msgid "Age: "
+msgstr "Edat:"
+
+#: ../../include/datetime.php:134
+msgid "YYYY-MM-DD or MM-DD"
+msgstr "YYYY-MM-DD o MM-DD"
+
+#: ../../include/datetime.php:238
+msgid "less than a second ago"
+msgstr "fa menys d'un segon"
+
+#: ../../include/datetime.php:256
+#, php-format
+msgctxt "e.g. 22 hours ago, 1 minute ago"
+msgid "%1$d %2$s ago"
+msgstr "Fa %1$d %2$s"
+
+#: ../../include/datetime.php:267
+msgctxt "relative_date"
+msgid "year"
+msgid_plural "years"
+msgstr[0] "any"
+msgstr[1] "anys"
+
+#: ../../include/datetime.php:270
+msgctxt "relative_date"
+msgid "month"
+msgid_plural "months"
+msgstr[0] "mes"
+msgstr[1] "mesos "
+
+#: ../../include/datetime.php:273
+msgctxt "relative_date"
+msgid "week"
+msgid_plural "weeks"
+msgstr[0] "setmana"
+msgstr[1] "setmanes"
+
+#: ../../include/datetime.php:276
+msgctxt "relative_date"
+msgid "day"
+msgid_plural "days"
+msgstr[0] "dia"
+msgstr[1] "dies"
+
+#: ../../include/datetime.php:279
+msgctxt "relative_date"
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "hores"
+
+#: ../../include/datetime.php:282
+msgctxt "relative_date"
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minuts"
+
+#: ../../include/datetime.php:285
+msgctxt "relative_date"
+msgid "second"
+msgid_plural "seconds"
+msgstr[0] "segon"
+msgstr[1] "segons"
+
+#: ../../include/datetime.php:514
+#, php-format
+msgid "%1$s's birthday"
+msgstr "Aniversari de %1$s"
+
+#: ../../include/datetime.php:515
+#, php-format
+msgid "Happy Birthday %1$s"
+msgstr "Feliç Aniversari %1$s"
+
+#: ../../include/nav.php:96
+msgid "Remote authentication"
+msgstr "Autenticació remota"
+
+#: ../../include/nav.php:96
+msgid "Click to authenticate to your home hub"
+msgstr "Clica per autentificar-te en el teu node"
+
+#: ../../include/nav.php:102 ../../include/nav.php:190
+msgid "Manage Your Channels"
+msgstr "Gestiona els Teus Canals"
+
+#: ../../include/nav.php:105 ../../include/nav.php:192
+msgid "Account/Channel Settings"
+msgstr "Ajustos de Compte/Canal"
+
+#: ../../include/nav.php:111 ../../include/nav.php:140
+msgid "End this session"
+msgstr "Finalitza aquesta sessió"
+
+#: ../../include/nav.php:114
+msgid "Your profile page"
+msgstr "La teva pàgina de perfil"
+
+#: ../../include/nav.php:117
+msgid "Manage/Edit profiles"
+msgstr "Gestiona/Edita perfils"
+
+#: ../../include/nav.php:126 ../../include/nav.php:130
+msgid "Sign in"
+msgstr "Signatura"
+
+#: ../../include/nav.php:157
+msgid "Take me home"
+msgstr "Porta'm a casa"
+
+#: ../../include/nav.php:159
+msgid "Log me out of this site"
+msgstr "Tanca'm la sessió en aquest lloc web"
+
+#: ../../include/nav.php:164
+msgid "Create an account"
+msgstr "Crear un compte"
+
+#: ../../include/nav.php:176
+msgid "Help and documentation"
+msgstr "Ajuda i documentació"
+
+#: ../../include/nav.php:179
+msgid "Search site @name, #tag, ?docs, content"
+msgstr "Cerca pel lloc @name, #tag, ?docs, contingut"
+
+#: ../../include/nav.php:199
+msgid "Site Setup and Configuration"
+msgstr "Ajustos i Configuració del Lloc"
+
+#: ../../include/nav.php:290
+msgid "@name, #tag, ?doc, content"
+msgstr "@nom, #etiqueta, ?doc, contingut"
+
+#: ../../include/nav.php:291
+msgid "Please wait..."
+msgstr "Si us plau, espera......."
+
+#: ../../include/nav.php:297
+msgid "Add Apps"
+msgstr "Afegeix aplicacions"
+
+#: ../../include/nav.php:298
+msgid "Arrange Apps"
+msgstr "Endreça les aplicacions"
+
+#: ../../include/nav.php:299
+msgid "Toggle System Apps"
+msgstr "Commuta l'estat de les aplicacions de sistema"
+
+#: ../../include/photos.php:150
+#, php-format
+msgid "Image exceeds website size limit of %lu bytes"
+msgstr "La imatge excedeix la mida limit pel lloc web en %lu bytes"
+
+#: ../../include/photos.php:161
+msgid "Image file is empty."
+msgstr "El fitxer d'imatge esta buit."
+
+#: ../../include/photos.php:322
+msgid "Photo storage failed."
+msgstr "Fracassà l'emmagatzematge de la Foto"
+
+#: ../../include/photos.php:364
+msgid "a new photo"
+msgstr "Una foto nova"
+
+#: ../../include/photos.php:368
+#, php-format
+msgctxt "photo_upload"
+msgid "%1$s posted %2$s to %3$s"
+msgstr "%1$s enviat %2$s a %3$s"
+
+#: ../../include/photos.php:660
+msgid "Upload New Photos"
+msgstr "Puja Noves Fotos"
+
+#: ../../include/zot.php:767
+msgid "Invalid data packet"
+msgstr "paquet de dades invàlid"
+
+#: ../../include/zot.php:794
+msgid "Unable to verify channel signature"
+msgstr "No es pot verificar la signatura del canal"
+
+#: ../../include/zot.php:2529
+#, php-format
+msgid "Unable to verify site signature for %s"
+msgstr "No es pot verificar la signatura del lloc per %s"
+
+#: ../../include/zot.php:4180
+msgid "invalid target signature"
+msgstr "Signatura objectiu invàlida"
+
+#: ../../include/group.php:22
+msgid ""
+"A deleted group with this name was revived. Existing item permissions "
+"<strong>may</strong> apply to this group and any future members. If this is "
+"not what you intended, please create another group with a different name."
+msgstr "Un grup esborrat amb aquest nom fou reviscolat. Els permisos dels items existents <strong>poden</strong> aplicar-se a aquest grup i qualsevol membre futur. Si no es això el que vols, si et plau, crea un altre grup amb un nom diferent."
+
+#: ../../include/group.php:264
+msgid "Add new connections to this privacy group"
+msgstr "Afegir noves connexions a aquest grup privat"
+
+#: ../../include/group.php:306
+msgid "edit"
+msgstr "edita"
+
+#: ../../include/group.php:329
+msgid "Edit group"
+msgstr "Editar grup"
+
+#: ../../include/group.php:330
+msgid "Add privacy group"
+msgstr "Afegir grup privat"
+
+#: ../../include/group.php:331
+msgid "Channels not in any privacy group"
+msgstr "Sense canals en grups privats"
+
+#: ../../include/connections.php:128
+msgid "New window"
+msgstr "Nova finestra"
+
+#: ../../include/connections.php:129
+msgid "Open the selected location in a different window or browser tab"
+msgstr "Obrir la localització seleccionada en un altre finestra o pestanya del navegador"
+
+#: ../../include/auth.php:148
+msgid "Logged out."
+msgstr "Sortir."
+
+#: ../../include/auth.php:263
+msgid "Email validation is incomplete. Please check your email."
+msgstr "Encara no s'ha validat el teu correu. Comprova la safata d'entrada i la paperera."
+
+#: ../../include/auth.php:279
+msgid "Failed authentication"
+msgstr "Autenticació fallida"
+
+#: ../../include/help.php:34
+msgid "Help:"
+msgstr "Ajuda:"
+
+#: ../../include/help.php:78
+msgid "Not Found"
+msgstr "No s'ha pogut trobar la pàgina"

--- a/view/ca/lostpass_eml.tpl
+++ b/view/ca/lostpass_eml.tpl
@@ -1,35 +1,32 @@
 
 Apreciat/da {{$username}},
-	
-	S'ha rebut una sol·licitud en {{$sitename}} recentment per restablir
-la teva contrasenya. Per confirmar aquesta sol·licitud, per favor seleccioni l'enllaç de
-verificació sota o copia-ho i pega-ho en la barra d'adreces del teu navegador.
+	Recentment hem rebut una petició en {{$sitename}} per canviar la contrasenya  
+del teu compte. Per tal de confirmar aquesta petició, si us plau sel·lecciona l'enllaç de verificació
+de sota o enganxa'l a la barra de direccions del teu navegador. 
 
-Si NO has sol·licitat aquest canvi, per favor NO segueixis l'enllaç indicat i ignora
-i/o elimina aquest missatge.
+Si NO has fet cap petició de canvi, si us plau, NO segueixis l'enllaç
+i ignora i/o esborra aquest missatge. 
 
-La teva contrasenya no es canviarà tret que puguem verificar que ets la teva qui
-va emetre aquesta sol·licitud.
+La teva contrasenya no es modificara mentres no verifiquis que has
+enviat aquesta petició. 
 
 Segueix aquest enllaç per verificar la teva identitat:
 
 {{$reset_link}}
 
-A continuació rebràs un missatge amb la nova contrasenya.
+Rebràs un missatge amb la nova contrasenya.
 
-Després de accedir, podràs canviar la contrasenya del teu compte a la pàgina de
-configuració.
+pots canviar aquesta contrasenya en el teu compte desprès de que hagis accedit.
 
-Les dades d'accés són els següents:
+Les dades d'identificació son les següents:
 
-
-Lloc:	{{$siteurl}}
-Nom:	{{$email}}
+Localització del Lloc Web:	{{$siteurl}}
+Nom Identificatiu:⇥{{$email}}
 
 
 
 
-Salutacions,
-	L'administració de {{$sitename}}
+Atentament,
+	{{$sitename}} Administrador
 
  

--- a/view/ca/messages.po
+++ b/view/ca/messages.po
@@ -3,7 +3,7 @@
 # This file is distributed under the same license as the Red package.
 # 
 # Translators:
-# Espart <ranker72@gmail.com>, 2015
+# fadelkon <fadelkon@posteo.net>, 2015
 # Rafael Garau, 2016
 # Rafael Garau, 2013-2015
 # Rafael Garau, 2015
@@ -12,8 +12,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Redmatrix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-20 00:01-0700\n"
-"PO-Revision-Date: 2016-02-19 11:17+0000\n"
+"POT-Creation-Date: 2016-07-08 00:01-0700\n"
+"PO-Revision-Date: 2017-09-23 19:03+0000\n"
 "Last-Translator: Rafael Garau\n"
 "Language-Team: Catalan (Spain) (http://www.transifex.com/Friendica/red-matrix/language/ca_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -199,7 +199,7 @@ msgstr "Editar Perfils"
 msgid "Manage/Edit profiles"
 msgstr "Gestiona/Edita perfils"
 
-#: ../../include/nav.php:95 ../../include/identity.php:979
+#: ../../include/nav.php:95 ../../include/identity.php:987
 msgid "Edit Profile"
 msgstr "Edita Perfil"
 
@@ -844,7 +844,7 @@ msgstr "Editar Personal App"
 
 #: ../../include/widgets.php:136 ../../include/widgets.php:175
 #: ../../include/Contact.php:107 ../../include/conversation.php:956
-#: ../../include/identity.php:956 ../../mod/match.php:64
+#: ../../include/identity.php:964 ../../mod/match.php:64
 #: ../../mod/directory.php:316 ../../mod/suggest.php:52
 msgid "Connect"
 msgstr "Connecta "
@@ -1110,7 +1110,7 @@ msgid "View all"
 msgstr "Mostra-ho tot"
 
 #: ../../include/ItemObject.php:179 ../../include/conversation.php:1712
-#: ../../include/identity.php:1266 ../../include/taxonomy.php:396
+#: ../../include/identity.php:1274 ../../include/taxonomy.php:396
 #: ../../mod/photos.php:1019
 msgctxt "noun"
 msgid "Like"
@@ -1470,7 +1470,7 @@ msgstr "Visita %1$s de %2$s"
 msgid "%1$s has an updated %2$s, changing %3$s."
 msgstr "%1$s Ha actualitzat %2$s, canviant %3$s."
 
-#: ../../include/api.php:1178
+#: ../../include/api.php:1203
 msgid "Public Timeline"
 msgstr "Cronologia pública"
 
@@ -1482,8 +1482,8 @@ msgstr "Administració"
 msgid "Address Book"
 msgstr "Adreçes"
 
-#: ../../include/apps.php:138 ../../include/identity.php:1240
-#: ../../include/identity.php:1357 ../../mod/profperm.php:112
+#: ../../include/apps.php:138 ../../include/identity.php:1248
+#: ../../include/identity.php:1365 ../../mod/profperm.php:112
 msgid "Profile"
 msgstr "Perfil"
 
@@ -1659,7 +1659,7 @@ msgstr "Adjuntat:"
 
 #: ../../include/bb2diaspora.php:459 ../../include/event.php:22
 msgid "l F d, Y \\@ g:i A"
-msgstr "l F d, Y \\@ g:i A"
+msgstr "l d \\d\\e/\\d' F de Y \\@ H:i T"
 
 #: ../../include/bb2diaspora.php:461
 msgid "$Projectname event notification:"
@@ -1674,7 +1674,7 @@ msgid "Finishes:"
 msgstr "Acaba:"
 
 #: ../../include/bb2diaspora.php:481 ../../include/event.php:50
-#: ../../include/identity.php:1007 ../../mod/directory.php:302
+#: ../../include/identity.php:1015 ../../mod/directory.php:302
 #: ../../mod/events.php:684
 msgid "Location:"
 msgstr "Lloc:"
@@ -3061,11 +3061,11 @@ msgstr "No es pot recuperar la identitat creada"
 msgid "Default Profile"
 msgstr "Perfil per Defecte"
 
-#: ../../include/identity.php:759
+#: ../../include/identity.php:767
 msgid "Requested channel is not available."
 msgstr "El canal demanat no està disponible."
 
-#: ../../include/identity.php:806 ../../mod/achievements.php:11
+#: ../../include/identity.php:814 ../../mod/achievements.php:11
 #: ../../mod/blocks.php:29 ../../mod/profile.php:16 ../../mod/connect.php:13
 #: ../../mod/editblock.php:29 ../../mod/editlayout.php:27
 #: ../../mod/editwebpage.php:28 ../../mod/filestorage.php:54
@@ -3073,188 +3073,188 @@ msgstr "El canal demanat no està disponible."
 msgid "Requested profile is not available."
 msgstr "El perfil demanat no està disponible."
 
-#: ../../include/identity.php:969 ../../mod/profiles.php:774
+#: ../../include/identity.php:977 ../../mod/profiles.php:774
 msgid "Change profile photo"
 msgstr "Canviar la foto del perfil"
 
-#: ../../include/identity.php:975
+#: ../../include/identity.php:983
 msgid "Profiles"
 msgstr "Perfils"
 
-#: ../../include/identity.php:975
+#: ../../include/identity.php:983
 msgid "Manage/edit profiles"
 msgstr "Gestiona/edita perfils"
 
-#: ../../include/identity.php:976 ../../mod/profiles.php:775
+#: ../../include/identity.php:984 ../../mod/profiles.php:775
 msgid "Create New Profile"
 msgstr "Crear un Perfil Nou"
 
-#: ../../include/identity.php:991 ../../mod/profiles.php:786
+#: ../../include/identity.php:999 ../../mod/profiles.php:786
 msgid "Profile Image"
 msgstr "Imatge del Perfil"
 
-#: ../../include/identity.php:994
+#: ../../include/identity.php:1002
 msgid "visible to everybody"
 msgstr "visible per tothom"
 
-#: ../../include/identity.php:995 ../../mod/profiles.php:669
+#: ../../include/identity.php:1003 ../../mod/profiles.php:669
 #: ../../mod/profiles.php:790
 msgid "Edit visibility"
 msgstr "Editar visibilitat"
 
-#: ../../include/identity.php:1011 ../../include/identity.php:1250
+#: ../../include/identity.php:1019 ../../include/identity.php:1258
 msgid "Gender:"
 msgstr "Gènere:"
 
-#: ../../include/identity.php:1012 ../../include/identity.php:1294
+#: ../../include/identity.php:1020 ../../include/identity.php:1302
 msgid "Status:"
 msgstr "Estatus:"
 
-#: ../../include/identity.php:1013 ../../include/identity.php:1305
+#: ../../include/identity.php:1021 ../../include/identity.php:1313
 msgid "Homepage:"
 msgstr "Pàgina Personal:"
 
-#: ../../include/identity.php:1014
+#: ../../include/identity.php:1022
 msgid "Online Now"
 msgstr "Ara en Linia"
 
-#: ../../include/identity.php:1097 ../../include/identity.php:1175
+#: ../../include/identity.php:1105 ../../include/identity.php:1183
 #: ../../mod/ping.php:324
 msgid "g A l F d"
 msgstr "g A l F d"
 
-#: ../../include/identity.php:1098 ../../include/identity.php:1176
+#: ../../include/identity.php:1106 ../../include/identity.php:1184
 msgid "F d"
 msgstr "F d"
 
-#: ../../include/identity.php:1143 ../../include/identity.php:1215
+#: ../../include/identity.php:1151 ../../include/identity.php:1223
 #: ../../mod/ping.php:346
 msgid "[today]"
 msgstr "[avui]"
 
-#: ../../include/identity.php:1154
+#: ../../include/identity.php:1162
 msgid "Birthday Reminders"
 msgstr "Recordatori d'Aniversaris"
 
-#: ../../include/identity.php:1155
+#: ../../include/identity.php:1163
 msgid "Birthdays this week:"
 msgstr "Aniversari aquesta setmana:"
 
-#: ../../include/identity.php:1208
+#: ../../include/identity.php:1216
 msgid "[No description]"
 msgstr "[Sense descripció]"
 
-#: ../../include/identity.php:1226
+#: ../../include/identity.php:1234
 msgid "Event Reminders"
 msgstr "Recordatori d'Events"
 
-#: ../../include/identity.php:1227
+#: ../../include/identity.php:1235
 msgid "Events this week:"
 msgstr "Event aquesta setmana:"
 
-#: ../../include/identity.php:1248 ../../mod/settings.php:1056
+#: ../../include/identity.php:1256 ../../mod/settings.php:1056
 msgid "Full Name:"
 msgstr "Nom Complet:"
 
-#: ../../include/identity.php:1255
+#: ../../include/identity.php:1263
 msgid "Like this channel"
 msgstr "M'agrada aquest canal"
 
-#: ../../include/identity.php:1279
+#: ../../include/identity.php:1287
 msgid "j F, Y"
 msgstr "j F, Y"
 
-#: ../../include/identity.php:1280
+#: ../../include/identity.php:1288
 msgid "j F"
 msgstr "j F"
 
-#: ../../include/identity.php:1287
+#: ../../include/identity.php:1295
 msgid "Birthday:"
 msgstr "Aniversari:"
 
-#: ../../include/identity.php:1291 ../../mod/directory.php:297
+#: ../../include/identity.php:1299 ../../mod/directory.php:297
 msgid "Age:"
 msgstr "Edat:"
 
-#: ../../include/identity.php:1300
+#: ../../include/identity.php:1308
 #, php-format
 msgid "for %1$d %2$s"
 msgstr "per %1$d %2$s"
 
-#: ../../include/identity.php:1303 ../../mod/profiles.php:691
+#: ../../include/identity.php:1311 ../../mod/profiles.php:691
 msgid "Sexual Preference:"
 msgstr "Preferència Sexual:"
 
-#: ../../include/identity.php:1307 ../../mod/profiles.php:693
+#: ../../include/identity.php:1315 ../../mod/profiles.php:693
 #: ../../mod/directory.php:313
 msgid "Hometown:"
 msgstr "Ciutat Natal:"
 
-#: ../../include/identity.php:1309
+#: ../../include/identity.php:1317
 msgid "Tags:"
 msgstr "Etiquetes:"
 
-#: ../../include/identity.php:1311 ../../mod/profiles.php:694
+#: ../../include/identity.php:1319 ../../mod/profiles.php:694
 msgid "Political Views:"
 msgstr "Idees Polítiques:"
 
-#: ../../include/identity.php:1313
+#: ../../include/identity.php:1321
 msgid "Religion:"
 msgstr "Religió:"
 
-#: ../../include/identity.php:1315 ../../mod/directory.php:315
+#: ../../include/identity.php:1323 ../../mod/directory.php:315
 msgid "About:"
 msgstr "Sobre mi:"
 
-#: ../../include/identity.php:1317
+#: ../../include/identity.php:1325
 msgid "Hobbies/Interests:"
 msgstr "Aficions/Interessos:"
 
-#: ../../include/identity.php:1319 ../../mod/profiles.php:697
+#: ../../include/identity.php:1327 ../../mod/profiles.php:697
 msgid "Likes:"
 msgstr "M'agrada:"
 
-#: ../../include/identity.php:1321 ../../mod/profiles.php:698
+#: ../../include/identity.php:1329 ../../mod/profiles.php:698
 msgid "Dislikes:"
 msgstr "No li agrada:"
 
-#: ../../include/identity.php:1323
+#: ../../include/identity.php:1331
 msgid "Contact information and Social Networks:"
 msgstr "Informació de contacte i Xarxes Socials:"
 
-#: ../../include/identity.php:1325
+#: ../../include/identity.php:1333
 msgid "My other channels:"
 msgstr "Els meus altres canals:"
 
-#: ../../include/identity.php:1327
+#: ../../include/identity.php:1335
 msgid "Musical interests:"
 msgstr "Interessos Musicals:"
 
-#: ../../include/identity.php:1329
+#: ../../include/identity.php:1337
 msgid "Books, literature:"
 msgstr "Llibres, literatura:"
 
-#: ../../include/identity.php:1331
+#: ../../include/identity.php:1339
 msgid "Television:"
 msgstr "Televisió:"
 
-#: ../../include/identity.php:1333
+#: ../../include/identity.php:1341
 msgid "Film/dance/culture/entertainment:"
 msgstr "Películes/Dança/Cultura/Entreteniment:"
 
-#: ../../include/identity.php:1335
+#: ../../include/identity.php:1343
 msgid "Love/Romance:"
 msgstr "Amor/Romace:"
 
-#: ../../include/identity.php:1337
+#: ../../include/identity.php:1345
 msgid "Work/employment:"
 msgstr "Treball/feina:"
 
-#: ../../include/identity.php:1339
+#: ../../include/identity.php:1347
 msgid "School/education:"
 msgstr "Escola/educació:"
 
-#: ../../include/identity.php:1359
+#: ../../include/identity.php:1367
 msgid "Like this thing"
 msgstr "M'agrada això"
 
@@ -8845,7 +8845,7 @@ msgstr "Cerca a xchan"
 msgid "Lookup xchan beginning with (or webbie): "
 msgstr "Cerca a xchan començant per (o webbie)"
 
-#: ../../mod/zfinger.php:23
+#: ../../mod/zfinger.php:24
 msgid "invalid target signature"
 msgstr "Signatura objectiu invàlida"
 

--- a/view/ca/passchanged_eml.tpl
+++ b/view/ca/passchanged_eml.tpl
@@ -1,19 +1,20 @@
 
 Apreciat/da {{$username}},
+	La teva contrasenya ha estat canviada com has demanat. Si et plau, recorda 
+aquesta informació per a tu (o canvia-la immediatament a 
+quelcom que puguis recordar).
 
-    La teva contrasenya ha estat modificada com has sol·licitat. Pren nota d'aquesta informació
-(o canvía immediatament la contrasenya amb quelcom que recordis).
 
+Les dades d'identificació son les següents:
 
-Les teves dades d'accés son les següents:
-
-Lloc:	{{$siteurl}}
-Nom:	{{$email}}
+Localització del lloc Web:⇥{{$siteurl}}
+Nom Identificatiu:⇥{{$email}}
 Contrasenya:	{{$new_password}}
 
-Després d'accedir pots canviar la contrasenya des de la pàgina de configuració del teu perfil.
+Pots canviar aquesta contrasenya en el teu compte desprès que hagis accedit.
 
 
-	{{$sitename}}
+Atentament,
+	{{$sitename}} Administrador
 
  

--- a/view/ca/register_open_eml.tpl
+++ b/view/ca/register_open_eml.tpl
@@ -1,22 +1,19 @@
 
-Apreciat/da {{$username}},
+S'ha creat un compte en {{$sitename}} per a aquesta adreça de correu. 
+Les dades d'identificació son les següents:
 
-	Gràcies per registrar-te en {{$sitename}}. El teu compte ha estat creat.
+Localització del Lloc Web:⇥{{$siteurl}}
+Identificació:⇥{{$email}}
+Contrasenya: (la que has emprat durant el procés de registre)
 
+Si aquest compte s'ha creat sense el seu coneixement i no el desitja, pot 
+visitar aquest lloc web i canviar la contrasenya. Això li permetrà esborrar el 
+compte en els Ajustos de la pàgina, li demanem disculpes 
+per qualsevol inconvenient causat. 
 
-Les dades d'accés són les següents:
+Gràcies i benvingut a {{$sitename}}.
 
-
-Lloc:	{{$siteurl}}
-Nom:	{{$email}}
-Contrasenya:	{{$password}}
-
-
-Després d'accedir pots canviar la teva contrasenya a la pàgina de "Configuració".
-
-Pren un moment per revisar les altres configuracions del compte en aquesta pàgina.
-
-
-Gràcies i benvingut/da {{$sitename}}.
+Atentament,
+	{{$sitename}} Administrador
 
  

--- a/view/ca/register_verify_eml.tpl
+++ b/view/ca/register_verify_eml.tpl
@@ -1,23 +1,24 @@
 
-S'ha rebut la sol·licitud de registre d'un nou usuari en
-{{$sitename}} que requereix la teva aprovació.
-
-Les dades d'accés són els següents:
-
-Nom Complet: {{$username}}
-Lloc: {{$siteurl}}
-Nom: {{$email}}
+S'ha rebut una nova petició de registre en {{$sitename}} la qual cosa requereix 
+la seva aprovació. 
 
 
-Per aprovar aquesta sol·licitud, visita el següent enllaç:
+Les dades d'identificació son les següents:
 
-{{$siteurl}}/regmod/allow/{{$hash}}
+Localització del Lloc Web:	{{$siteurl}}
+Nom Identificatiu:⇥{{$email}}
+Adreça IP: {{$details}}
 
-Per denegar la sol·licitud i eliminar el compte, per favor visita:
+Per tal d'aprovar aquesta petició, si us plau, visita el següent enllaç:
+
+
+{{$siteurl}}/regmod/allow/{{$hash}} 
+
+
+Per rebutjar la petició i esborrar el compte, si us plau visita:
+
 
 {{$siteurl}}/regmod/deny/{{$hash}}
 
 
 Gràcies.
-
-


### PR DESCRIPTION
I'm afraid it's been a long time since there wasn't a merge. There are some translations from 2015 that appear new to the repo, according to git.

The same commit also includes a 100% translation of hmessages.po for strings up to March 1st.

Cheers!