### PR TITLE
add basic structure for additional features documentation

### DIFF
--- a/doc/feature/additional/access.md
+++ b/doc/feature/additional/access.md
@@ -1,0 +1,41 @@
+## Access Control and Permissions
+
+
+### Privacy Groups
+
+Enable management and selection of privacy groups.
+<!-- TODO: full description for Privacy Groups -->
+
+Minimum required technical skill level to see this feature: 0
+
+
+### Multiple Profiles
+
+Ability to create multiple profiles.
+<!-- TODO: full description for Multiple Profiles -->
+
+Minimum required technical skill level to see this feature: 3
+
+
+### Permission Groups
+
+Provide alternate connection permission roles.
+<!-- TODO: full description for Permission Groups -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### OAuth Clients
+
+Manage authenticatication tokens for mobile and remote apps.
+<!-- TODO: full description for OAuth Clients -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Access Tokens
+
+Create access tokens so that non-members can access private content.
+<!-- TODO: full description for Access Tokens -->
+
+Minimum required technical skill level to see this feature: 2

--- a/doc/feature/additional/composition.md
+++ b/doc/feature/additional/composition.md
@@ -1,0 +1,67 @@
+## Post Composition Features
+
+
+### Large Photos
+
+Include large (1024px) photo thumbnails in posts.
+If not enabled, use small (640px) photo thumbnails
+<!-- TODO: full description for Large Photos -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Channel Sources
+
+Automatically import channel content from other channels or feeds
+<!-- TODO: full description for Channel Sources -->
+
+Minimum required technical skill level to see this feature: 3
+
+
+### Even More Encryption
+
+Allow optional encryption of content end-to-end with a shared secret key
+<!-- TODO: full description for Even More Encryption -->
+
+Minimum required technical skill level to see this feature: 3
+
+
+### Enable Voting Tools
+
+Provide a class of post which others can vote on
+<!-- TODO: full description for Enable Voting Tools -->
+
+Minimum required technical skill level to see this feature: 3
+
+
+### Disable Comments
+
+Provide the option to disable comments for a post
+<!-- TODO: full description for Disable Comments -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Delayed Posting
+
+Allow posts to be published at a later date
+<!-- TODO: full description for Delayed Posting -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Content Expiration
+
+Remove posts/comments and/or private messages at a future time
+<!-- TODO: full description for Content Expiration -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Suppress Duplicate Posts/Comments
+
+Prevent posts with identical content to be published
+with less than two minutes in between submissions.
+<!-- TODO: full description for Suppress Duplicate Posts/Comments -->
+
+Minimum required technical skill level to see this feature: 1

--- a/doc/feature/additional/filtering.md
+++ b/doc/feature/additional/filtering.md
@@ -1,0 +1,57 @@
+## Network and Stream Filtering
+
+
+### Search by Date
+
+Ability to select posts by date ranges
+<!-- TODO: full description for Search by Date -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Saved Searches
+
+Save search terms for re-use
+<!-- TODO: full description for Saved Searches -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Network Personal Tab
+
+Enable tab to display only Network posts that you've interacted on
+<!-- TODO: full description for Network Personal Tab -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Network New Tab
+
+Enable tab to display all new Network activity
+<!-- TODO: full description for Network New Tab -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Affinity Tool
+
+Filter stream activity by depth of relationships
+<!-- TODO: full description for Affinity Tool -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Suggest Channels
+
+Show friend and connection suggestions
+<!-- TODO: full description for Suggest Channels -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Connection Filtering
+
+Filter incoming posts from connections based on keywords/content
+<!-- TODO: full description for Connection Filtering -->
+
+Minimum required technical skill level to see this feature: 3

--- a/doc/feature/additional/general.md
+++ b/doc/feature/additional/general.md
@@ -1,0 +1,130 @@
+## General Features
+
+
+### New Member Links
+
+Display new member quick links menu.
+<!-- TODO: full description for New Member Links -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Advanced Profiles
+
+Additional profile sections and selections
+<!-- TODO: full description for Advanced Profiles -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Profile Import/Export
+
+Save and load profile details across sites/channels
+<!-- TODO: full description for Profile Import/Export -->
+
+Minimum required technical skill level to see this feature: 3
+
+
+### Web Pages
+
+Provide managed web pages on your channel
+<!-- TODO: full description for Web Pages -->
+
+Minimum required technical skill level to see this feature: 3
+
+
+### Wiki
+
+Provide a wiki for your channel
+<!-- TODO: full description for Wiki -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Private Notes
+
+Enables a tool to store notes and reminders (note: not encrypted)
+<!-- TODO: full description for Private Notes -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Cards
+
+Create personal planning cards
+<!-- TODO: full description for Cards -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Articles
+
+Create interactive articles
+<!-- TODO: full description for Articles -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Navigation Channel Select
+
+Change channels directly from within the navigation dropdown menu
+<!-- TODO: full description for Navigation Channel Select -->
+
+Minimum required technical skill level to see this feature: 3
+
+
+### Photo Location
+
+If location data is available on uploaded photos, link this to a map.
+<!-- TODO: full description for Photo Location -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Access Controlled Chatrooms
+
+Provide chatrooms and chat services with access control.
+<!-- TODO: full description for Access Controlled Chatrooms -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Smart Birthdays
+
+Make birthday events timezone aware in case your friends are scattered across the planet.
+<!-- TODO: full description for Smart Birthdays -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Event Timezone Selection
+
+Allow event creation in timezones other than your own.
+<!-- TODO: full description for Event Timezone Selection -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Premium Channel
+
+Allows you to set restrictions and terms
+on those that connect with your channel
+<!-- TODO: full description for Premium Channel -->
+
+Minimum required technical skill level to see this feature: 4
+
+
+### Advanced Directory Search
+
+Allows creation of complex directory search queries
+<!-- TODO: full description for Advanced Directory Search -->
+
+Minimum required technical skill level to see this feature: 4
+
+
+### Advanced Theme and Layout Settings
+
+Allows fine tuning of themes and page layouts
+<!-- TODO: full description for Advanced Theme and Layout Settings -->
+
+Minimum required technical skill level to see this feature: 4

--- a/doc/feature/additional/overview.md
+++ b/doc/feature/additional/overview.md
@@ -1,0 +1,33 @@
+[chset]: /settings "Channel Settings"
+[ftset]: /settings/features "Additional Features Settings"
+[ftgen]: /help/feature/additional/general "General Features"
+[ftacc]: /help/feature/additional/access "Access Control and Permissions"
+[ftcom]: /help/feature/additional/composition "Post Composition Features"
+[ftfil]: /help/feature/additional/filtering "Network and Stream Filtering"
+[ftpos]: /help/feature/additional/posts "Post/Comment Tools"
+
+
+# Additional Features
+
+<!-- TODO: Introduction to additional features -->
+
+<!-- TODO: Short info and crosslink on techlevels -->
+
+You can switch the features on and off from the
+[Additional Features][ftset] link in the [Channel Settings][chset].
+
+<!-- TODO: Infos about feature visibility and causes/dependencies -->
+
+The following pages decribe all the available features
+grouped in the same way as they are with the accordion tabs on the
+[Additional Features][ftset] settings page:
+
+[General Features][ftgen]
+
+[Access Control and Permissions][ftacc]
+
+[Post Composition Features][ftcom]
+
+[Network and Stream Filtering][ftfil]
+
+[Post/Comment Tools][ftpos]

--- a/doc/feature/additional/posts.md
+++ b/doc/feature/additional/posts.md
@@ -1,0 +1,57 @@
+## Post/Comment Tools
+
+
+### Community Tagging
+
+Ability to tag existing posts
+<!-- TODO: full description for Community Tagging -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Post Categories
+
+Add categories to your posts
+<!-- TODO: full description for Post Categories -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Emoji Reactions
+
+Add emoji reaction ability to posts
+<!-- TODO: full description for Emoji Reactions -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Saved Folders
+
+Ability to file posts under folders
+<!-- TODO: full description for Saved Folders -->
+
+Minimum required technical skill level to see this feature: 2
+
+
+### Dislike Posts
+
+Ability to dislike posts/comments
+<!-- TODO: full description for Dislike Posts -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Star Posts
+
+Ability to mark special posts with a star indicator
+<!-- TODO: full description for Star Posts -->
+
+Minimum required technical skill level to see this feature: 1
+
+
+### Tag Cloud
+
+Provide a personal tag cloud on your channel page
+<!-- TODO: full description for Tag Cloud -->
+
+Minimum required technical skill level to see this feature: 2

--- a/doc/toc.html
+++ b/doc/toc.html
@@ -21,7 +21,8 @@
             <div class="flex-column">
                <a class="nav-link" href="/help/member/member_guide">Guide</a>
                <a class="nav-link" href="/help/member/bbcode">BBcode Reference</a>
-               <a class="nav-link" href="/help/bugs">Reporting Bugs</a>	
+               <a class="nav-link" href="/help/feature/additional/overview">Additional Features</a>
+               <a class="nav-link" href="/help/bugs">Reporting Bugs</a>
                <a class="nav-link" href="/help/member/member_faq">FAQ</a>
             </div>
         </div>


### PR DESCRIPTION
Setting the raw frame with overview, short descriptions like in code
and already revealing skill levels.

Based on the current (recently modified) structure of the feature settings.

Detailed descriptions in work and coming with later commits as well as
a dedicated admin section for that topic. Better menu integration
may be possible with Andrew's new doco structure work in progress later.