### PR TITLE
Update sample-nginx.conf - fix .well-known location block

### DIFF
--- a/install/sample-nginx.conf
+++ b/install/sample-nginx.conf
@@ -83,7 +83,7 @@ server {
 
   # make sure webfinger and other well known services aren't blocked
   # by denying dot files and rewrite request to the front controller
-  location ^~ /.well-known/ {
+ location ~ (\/\.well-known\/) {
     allow all;
     rewrite ^/(.*) /index.php?q=$uri&$args last;
   }


### PR DESCRIPTION
Fixes "access forbidden by rule" errors for "POST /channel/xxx/.well-known/zot-info" by changing the location block of the config to use a regex for /.well-known/ rather than simply looking for the non-regex URI prefix /.well-known/