### PR TITLE
Install imagemagick. Instructions to avoid DNS check if it fails.

### DIFF
--- a/.homeinstall/README.md
+++ b/.homeinstall/README.md
@@ -134,7 +134,7 @@ There are two ways to get a domain...
 
 The cost are around 10,- € once and 1,50 € per month (2017).
 
-### Method 2: Register a free domain
+### Method 2: Register a free subdomain
 
 ...for example register at freedns.afraid.org
 

--- a/.homeinstall/README.md
+++ b/.homeinstall/README.md
@@ -39,7 +39,7 @@ Software
   - mkdir -p /var/www
   - cd /var/www
   - git clone https://github.com/redmatrix/hubzilla.git html
-  - cd /html/.homeinstall
+  - cd html/.homeinstall
   - cp hubzilla-config.txt.template hubzilla-config.txt
   - nano hubzilla-config.txt
     - Read the comments carefully
@@ -49,6 +49,20 @@ Software
     - ... wait, wait, wait until the script is finised
   - reboot
 + Open your domain with a browser and step throught the initial configuration of hubzilla.
+
+## Troubleshooting
+
+If the check of the mail address fails when you try to register the very first user in the browser. Do...
+
+    cd /var/www/html
+    util/config system.do_not_check_dns 1
+
+## Optional - Set path to imagemagick
+
+In Admin settings of hubzilla or via terminal
+
+    cd /var/www/html
+    util/config system.imagick_convert_path /usr/bin/convert
 
 # Step-by-Step in Detail
 
@@ -120,7 +134,7 @@ There are two ways to get a domain...
 
 The cost are around 10,- € once and 1,50 € per month (2017).
 
-### Method 2 Register a (free) Subdomain
+The cost are around 10,- € once and 1,50 € per month (2017).
 
 ...for example register at freedns.afraid.org
 
@@ -189,9 +203,16 @@ Leave db type "MySQL" untouched.
 
 Follow the instructions in the next pages.
 
+Recommended: Set path to imagemagick
+
+- in admin settings of hubzilla or 
+- via terminal
+
+    util/config system.imagick_convert_path /usr/bin/convert
+
 After the daily script was executed at 05:30 (am)
 
-- look at var/www/html/hubzilla-daily.log
+- look at /var/www/html/hubzilla-daily.log
 - check your backup on the external drive
 - optionally view the daily log under yourdomain.org/admin/logs/
   - set the logfile to var/www/html/hubzilla-daily.log
@@ -212,5 +233,13 @@ It is recommended to run the Raspi without graphical frontend (X-Server). Use...
 to boot the Rapsi to the client console.
 
 DO NOT FORGET TO CHANGE THE DEFAULT PASSWORD FOR USER PI!
+
+On a Raspian Stretch (Debian 9) the validation of the mail address fails for the very first user.
+This used to happen on some *bsd distros but there was some work to fix that a year ago (2017).
+
+So if your system isn't registered in DNS or DNS isn't active do
+
+    cd /var/www/html
+    util/config system.do_not_check_dns 1
 
 

--- a/.homeinstall/README.md
+++ b/.homeinstall/README.md
@@ -134,7 +134,7 @@ There are two ways to get a domain...
 
 The cost are around 10,- € once and 1,50 € per month (2017).
 
-The cost are around 10,- € once and 1,50 € per month (2017).
+### Method 2: Register a free domain
 
 ...for example register at freedns.afraid.org
 

--- a/.homeinstall/hubzilla-setup.sh
+++ b/.homeinstall/hubzilla-setup.sh
@@ -136,17 +136,17 @@ function check_config {
     # backup is important and should be checked
 	if [ -n "$backup_device_name" ]
 	then
-        device_mounted=0
+            if [ ! -d "$backup_mount_point" ]
+            then
+                mkdir "$backup_mount_point"
+	    fi
+            device_mounted=0
 		if fdisk -l | grep -i "$backup_device_name.*linux"
 		then
 		    print_info "ok - filesystem of external device is linux"
 	        if [ -n "$backup_device_pass" ]
 	        then
 	            echo "$backup_device_pass" | cryptsetup luksOpen $backup_device_name cryptobackup
-	            if [ ! -d /media/hubzilla_backup ]
-	            then
-	                mkdir /media/hubzilla_backup
-	            fi
 	            if mount /dev/mapper/cryptobackup /media/hubzilla_backup
 	            then
                     device_mounted=1
@@ -244,6 +244,11 @@ function stop_hubzilla {
 function install_apache {
     print_info "installing apache..."
     nocheck_install "apache2 apache2-utils"
+}
+
+function install_imagemagick {
+    print_info "installing imagemagick..."
+    nocheck_install "imagemagick"
 }
 
 function install_curl {
@@ -801,6 +806,7 @@ update_upgrade
 install_curl
 install_sendmail
 install_apache
+install_imagemagick
 install_php
 install_mysql
 install_phpmyadmin


### PR DESCRIPTION
Some changes for the homeinstall script basically

- include imagemagick in the installation
- instruction to set the path to imagemagick
- instructions to avoid the failed DNS check for mail addresses (happens an a current Raspian)
- make the mount dir for backups automatically (to avoid installation errors)